### PR TITLE
add ansible_galaxy_cli/__main__.py and entry_points

### DIFF
--- a/ansible_galaxy_cli/__main__.py
+++ b/ansible_galaxy_cli/__main__.py
@@ -1,0 +1,10 @@
+#!/usr/bin/python
+# main 'entrypoint' for ansible-galaxy-cli
+# NOTE: not an actual setuptools 'entrypoint' yet
+
+import sys
+
+from ansible_galaxy_cli.main import main
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/ansible_galaxy_cli/main.py
+++ b/ansible_galaxy_cli/main.py
@@ -1,8 +1,11 @@
 import logging
+import os
+import sys
 
 from ansible_galaxy import exceptions
 from ansible_galaxy_cli.logger.setup import setup_default
 from ansible_galaxy_cli.cli import galaxy
+from ansible_galaxy_cli import exceptions as cli_exceptions
 
 log = logging.getLogger(__name__)
 
@@ -10,13 +13,19 @@ log = logging.getLogger(__name__)
 def main(args=None):
     setup_default()
 
-    args = args or []
+    args = args or sys.argv[:]
 
     # import logging_tree
     # logging_tree.printout()
 
+    log.debug('args: %s', args)
     cli = galaxy.GalaxyCLI(args)
-    cli.parse()
+    try:
+        cli.parse()
+    except cli_exceptions.CliOptionsError as e:
+        cli.parser.print_help()
+        log.error(e)
+        return os.EX_USAGE
 
     try:
         res = cli.run()

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,15 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = [ ]
+requirements = []
 
 setup_requirements = ['pytest-runner', ]
 
 test_requirements = ['pytest', ]
+
+entry_points = {
+    'console_scripts': ['ansible-galaxy-cli = ansible_galaxy_cli.__main__:main']
+}
 
 setup(
     author="Red Hat, Inc.",
@@ -33,13 +37,15 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     description="Manage Ansible roles and contents from the command line.",
+    entry_points=entry_points,
     install_requires=requirements,
     license="Apache-2.0",
     long_description=readme + '\n\n' + history,
     include_package_data=True,
     keywords='ansible_galaxy_cli',
     name='ansible_galaxy_cli',
-    packages=find_packages(include=['ansible_galaxy', 'ansible_galaxy_cli']),
+    packages=find_packages(include=['ansible_galaxy', 'ansible_galaxy_cli',
+                                    'ansible_galaxy.*', 'ansible_galaxy_cli.*']),
     setup_requires=setup_requirements,
     test_suite='tests',
     tests_require=test_requirements,


### PR DESCRIPTION
use setuptools entrypoints for installing the main
ansible-galaxy-cli executable script. At least until it become too
annoying.

Add wildcards to setup.py's find_packages()'s includes list.

handle CliOptionsError in main, make entrypoint compat

default to sys.argv if no args are passed in since that
is what __main__ will do as used via entry_points