### PR TITLE
Fix 'init' for default skel path

### DIFF
--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -247,7 +247,7 @@ class GalaxyCLI(cli.CLI):
             this_dir, this_filename = os.path.split(__file__)
 
             type_path = getattr(self.options, 'role_type', "default")
-            role_skeleton_path = os.path.join(this_dir, '../', 'data/role_skelton', type_path)
+            role_skeleton_path = os.path.join(this_dir, '../', 'data/role_skeleton', type_path)
 
             self.log.debug('role_skeleton_path: %s', role_skeleton_path)
 

--- a/tests/ansible_galaxy_cli/cli/test_galaxy_upstream.py
+++ b/tests/ansible_galaxy_cli/cli/test_galaxy_upstream.py
@@ -319,7 +319,9 @@ class ValidRoleTests(object):
 
         log.debug('skeleton_path arg: %s', skeleton_path)
 
-        # FIXME: mo
+        # TODO: mock out role_skeleton path instead of always testing
+        #       with --role-skeleton path to avoid issues like
+        #       https://github.com/ansible/galaxy-cli/issues/20
         cls.role_skeleton_path = skeleton_path
         if '--role-skeleton' not in galaxy_args:
             galaxy_args += ['--role-skeleton', skeleton_path]


### PR DESCRIPTION
The default role skeleton data is in data/role_skeleton
not data/role_skelton

Fixes #20

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
 - Bugfix Pull Request



##### GALAXY CLI VERSION
<!--- Paste verbatim output from "ansible-galaxy --version" between quotes below -->
```
cce2c2409a93524e99adb09f6883f43f09fb788f
```
