### PR TITLE
catch SSLError and socket.error (inc timeout) on call_galaxy

### DIFF
--- a/ansible_galaxy/exceptions/__init__.py
+++ b/ansible_galaxy/exceptions/__init__.py
@@ -22,3 +22,8 @@ class ParserError(GalaxyError):
 class GalaxyDownloadError(GalaxyError):
     '''Raise when there is an error downloading galaxy content'''
     pass
+
+
+class GalaxyClientAPIConnectionError(GalaxyClientError):
+    '''Raised if there were errors connecting to the Galaxy REST API'''
+    pass


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

catch and log SSLErrors and socket errors and raise
a GalaxyClientAPIConnectionError exception for
main to handle and display.

Note: the default connection timeout is 20 seconds. On py2
if the connection times out, a ssl.SSLError is raised from
urls.py. On py3, a socket.timeout (socket.error subclass)
error is raised.

##### ISSUE TYPE
 - Bugfix Pull Request


##### GALAXY CLI VERSION
```
b0050074a027bd8ee17cc2de7a9de478b28c3e98
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

BEFORE:
```

(galaxy-cli-py3) [newswoop:F27:galaxy-cli (master % u=)]$ ansible-galaxy search --author=ALIKINS_SEARCH_TIMEOUT_MELLOW_MUSKRAT_MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
Traceback (most recent call last):
  File "/home/adrian/venvs/galaxy-cli-py3/bin/ansible-galaxy", line 11, in <module>
    load_entry_point('ansible-galaxy-cli', 'console_scripts', 'ansible-galaxy')()
  File "/home/adrian/src/galaxy-cli/ansible_galaxy_cli/main.py", line 31, in main
    exit_code = cli.run()
  File "/home/adrian/src/galaxy-cli/ansible_galaxy_cli/cli/galaxy.py", line 171, in run
    self.execute()
  File "/home/adrian/src/galaxy-cli/ansible_galaxy_cli/cli/__init__.py", line 145, in execute
    fn()
  File "/home/adrian/src/galaxy-cli/ansible_galaxy_cli/cli/galaxy.py", line 704, in execute_search
    tags=self.options.galaxy_tags, author=self.options.author, page_size=page_size)
  File "/home/adrian/src/galaxy-cli/ansible_galaxy/flat_rest_api/api.py", line 55, in wrapped
    return method(self, *args, **kwargs)
  File "/home/adrian/src/galaxy-cli/ansible_galaxy/flat_rest_api/api.py", line 360, in search_content
    data = self.__call_galaxy(search_url, method='GET')
  File "/home/adrian/src/galaxy-cli/ansible_galaxy/flat_rest_api/api.py", line 55, in wrapped
    return method(self, *args, **kwargs)
  File "/home/adrian/src/galaxy-cli/ansible_galaxy/flat_rest_api/api.py", line 95, in __call_galaxy
    timeout=20)
  File "/home/adrian/src/galaxy-cli/ansible_galaxy/flat_rest_api/urls.py", line 923, in open_url
    r = urllib_request.urlopen(*urlopen_args)
  File "/usr/lib64/python3.6/urllib/request.py", line 223, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib64/python3.6/urllib/request.py", line 526, in open
    response = self._open(req, data)
  File "/usr/lib64/python3.6/urllib/request.py", line 544, in _open
    '_open', req)
  File "/usr/lib64/python3.6/urllib/request.py", line 504, in _call_chain
    result = func(*args)
  File "/home/adrian/src/galaxy-cli/ansible_galaxy/flat_rest_api/urls.py", line 338, in https_open
    return self.do_open(CustomHTTPSConnection, req)
  File "/usr/lib64/python3.6/urllib/request.py", line 1321, in do_open
    r = h.getresponse()
  File "/usr/lib64/python3.6/http/client.py", line 1331, in getresponse
    response.begin()
  File "/usr/lib64/python3.6/http/client.py", line 297, in begin
    version, status, reason = self._read_status()
  File "/usr/lib64/python3.6/http/client.py", line 258, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "/usr/lib64/python3.6/socket.py", line 586, in readinto
    return self._sock.recv_into(b)
  File "/usr/lib64/python3.6/ssl.py", line 965, in recv_into
    return self.read(nbytes, buffer)
  File "/usr/lib64/python3.6/ssl.py", line 827, in read
    return self._sslobj.read(len, buffer)
  File "/usr/lib64/python3.6/ssl.py", line 587, in read
    v = self._sslobj.read(len, buffer)
socket.timeout: The read operation timed out

```

AFTER 
```
(galaxy-cli-py3) [newswoop:F27:galaxy-cli (graceful_ssl_socket_error %)]$ ansible-galaxy search --author=ALIKINS_SEARCH_TIMEOUT_MELLOW_MUSKRAT_MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
Connection error to Galaxy API for request "GET https://galaxy-qa.ansible.com/api/v1/search/content/?&page_size=1000&username_autocomplete=ALIKINS_SEARCH_TIMEOUT_MELLOW_MUSKRAT_MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM": The read operation timed out
```


