### PR TITLE
Disable the console log handler by default.

### DIFF
--- a/ansible_galaxy_cli/logger/setup.py
+++ b/ansible_galaxy_cli/logger/setup.py
@@ -10,8 +10,8 @@ DEFAULT_CONSOLE_LEVEL = os.getenv('GALAXY_CLI_LOG_LEVEL', 'WARNING').upper()
 DEFAULT_LEVEL = 'DEBUG'
 
 DEFAULT_DEBUG_FORMAT = '[%(asctime)s,%(msecs)03d %(process)05d %(levelname)-0.1s] %(name)s %(funcName)s:%(lineno)d - %(message)s'
-DEFAULT_HANDLERS = ['console', 'file']
-# DEFAULT_HANDLERS = ['file']
+# DEFAULT_HANDLERS = ['console', 'file']
+DEFAULT_HANDLERS = ['file']
 
 DEFAULT_LOGGING_CONFIG = {
     'version': 1,


### PR DESCRIPTION


##### SUMMARY

Previously console log handler was setup at WARN
level, so WARN and ERROR level messages would be
shown to console in the logging format.

Since log.exception() logs at ERROR level, this
would show stack traces of caught and handled
exceptions to stderr (if the except clause includes
a log.exception()).

Related to #29

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request



##### GALAXY CLI VERSION
<!--- Paste verbatim output from "ansible-galaxy --version" between quotes below -->
```
b0050074a027bd8ee17cc2de7a9de478b28c3e98
```
