### PR TITLE
add a logger specifically for http logging

### DIFF
--- a/ansible_galaxy_cli/logger/setup.py
+++ b/ansible_galaxy_cli/logger/setup.py
@@ -43,6 +43,13 @@ DEFAULT_LOGGING_CONFIG = {
             'class': 'logging.handlers.WatchedFileHandler',
             'filename': os.path.expandvars(os.path.expanduser('~/.ansible/ansible-galaxy-cli.log')),
             'formatter': 'file_verbose',
+        },
+        'http_file': {
+            'level': DEFAULT_LEVEL,
+            'class': 'logging.handlers.WatchedFileHandler',
+            'filename': os.path.expandvars(os.path.expanduser('~/.ansible/ansible-galaxy-cli-http.log')),
+            'formatter': 'file_verbose',
+
         }
     },
 
@@ -56,6 +63,13 @@ DEFAULT_LOGGING_CONFIG = {
         },
         'ansible_galaxy.flat_rest_api.content': {
             'level': 'DEBUG'
+        },
+        'ansible_galaxy.flat_rest_api.api.(http)': {
+            'level': 'INFO',
+            'handlers': DEFAULT_HANDLERS,
+            # to log verbose debug level logging to http_file handler:
+            # 'level': 'DEBUG',
+            # 'handlers': ['http_file'],
         },
         'ansible_galaxy.archive.(extract)': {
             'level': 'INFO',


### PR DESCRIPTION

##### SUMMARY
Add a 'ansible_galaxy.flat_rest_api.api.(http)' logger
and use it for http logging (method and url of each request,
and http status of each response). Default to INFO

Add a 'ansible_galaxy.flat_rest_api.api.(http).(request)' logger
and use it for logging full content of http requests including
method, url, request headers, and the body of the request.

Add a 'ansible_galaxy.flat_rest_api.api.(http).(response)' logger
and use it for logging full content of http responses including
method, url, response headers, and the body of the response.

The '.(http)' logger naming convention is to make it clear
that the logger name doesnt map directly to a python object
path like getLogger(__name__) loggers do.

Add an example log config where debug level http logging
goes to ~/.ansible/ansible-galaxy-cli-http.log

<!--- Describe the change, including rationale and design decisions -->



##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

This may be mostly obsoleted once we switch to a different http module (ie, requests)
but I end up modifying code to see the http responses fairly frequently so figured
I would add some support for it. 

Combined with a pending branch to add support for yaml based logging config
should be useful for troubleshooting/debugging client/server interactions as
we add more features... 

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


