### PR TITLE
Adds 'version' commmand

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
 """The setup script."""
 
 from setuptools import setup, find_packages
+import ansible_galaxy_cli
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()
@@ -52,6 +53,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/ansible/ansible_galaxy_cli',
-    version='0.1.0',
+    version=ansible_galaxy_cli.__version__,
     zip_safe=False,
 )


### PR DESCRIPTION
##### SUMMARY
Add version command

Fixes #30 

##### ISSUE TYPE

 - Feature Pull Request


##### GALAXY CLI VERSION
<!--- Paste verbatim output from "ansible-galaxy --version" between quotes below -->

(meta!)

```
Ansible Galaxy CLI, version 0.1.0
Linux, newswoop, 4.16.6-202.fc27.x86_64, #1 SMP Wed May 2 00:09:32 UTC 2018, x86_64
3.6.5 (default, Apr  4 2018, 15:01:18) 
[GCC 7.3.1 20180303 (Red Hat 7.3.1-5)] /home/adrian/venvs/galaxy-cli-py3/bin/python
No config file found; using defaults


```




```

