### PR TITLE
Fix fetch 404 handling

### DIFF
--- a/ansible_galaxy/download.py
+++ b/ansible_galaxy/download.py
@@ -33,6 +33,6 @@ def fetch_url(archive_url, validate_certs=True):
     except Exception as e:
         # FIXME: there is a ton of reasons a download and save could fail so could likely provided better errors here
         log.exception(e)
-        raise exceptions.GalaxyDownloadError("failed to download the file: %s" % str(e))
+        raise exceptions.GalaxyDownloadError(e, url=archive_url)
 
     return False

--- a/ansible_galaxy/exceptions/__init__.py
+++ b/ansible_galaxy/exceptions/__init__.py
@@ -20,8 +20,22 @@ class ParserError(GalaxyError):
 
 # TODO: attrs for http code, url, msg or just reuse http exception from elsewhere
 class GalaxyDownloadError(GalaxyError):
-    '''Raise when there is an error downloading galaxy content'''
-    pass
+    '''Raise when there is an error downloading galaxy content
+
+    raise GalaxyDownloadError('some message', url='http://error.example.com')'''
+    def __init__(self, *args, **kwargs):
+        url = kwargs.pop('url', None)
+        super(GalaxyDownloadError, self).__init__(*args, **kwargs)
+        self.url = url
+
+    def __str__(self):
+        url_blurb = ': '
+        if self.url:
+            url_blurb = ' (%s): ' % self.url
+        return 'Error downloading%s%s' % (url_blurb, super(GalaxyDownloadError, self).__str__())
+
+    def __repr__(self):
+        return '%s(url=%s, %s)' % (self.__class__.__name__, self.url, self.args)
 
 
 class GalaxyClientAPIConnectionError(GalaxyClientError):

--- a/ansible_galaxy/fetch/galaxy_url.py
+++ b/ansible_galaxy/fetch/galaxy_url.py
@@ -36,8 +36,6 @@ class GalaxyUrlFetch(base.BaseFetch):
 
         log.debug('Validate TLS certificates: %s', self.validate_certs)
 
-        self.remote_resource = content_spec
-
     def fetch(self):
         api = GalaxyAPI(self.galaxy_context)
 
@@ -108,13 +106,12 @@ class GalaxyUrlFetch(base.BaseFetch):
         log.debug('content_spec=%s', self.content_spec)
         log.debug('download_url=%s', download_url)
 
-        try:
-            content_archive_path = download.fetch_url(download_url,
-                                                      validate_certs=self.validate_certs)
-        except exceptions.GalaxyDownloadError as e:
-            log.exception(e)
-            self.display_callback("failed to download the file: %s" % str(e))
-            return None
+        # for including in any error messages or logging for this fetch
+        self.remote_resource = download_url
+
+        # can raise GalaxyDownloadError
+        content_archive_path = download.fetch_url(download_url,
+                                                  validate_certs=self.validate_certs)
 
         self.local_path = content_archive_path
 

--- a/ansible_galaxy/flat_rest_api/content.py
+++ b/ansible_galaxy/flat_rest_api/content.py
@@ -452,7 +452,18 @@ class GalaxyContent(object):
         log.debug('fetch_method: %s', fetch_method)
 
         if fetcher:
-            content_archive = fetcher.fetch()
+            try:
+                content_archive = fetcher.fetch()
+            except exceptions.GalaxyDownloadError as e:
+                log.exception(e)
+
+                blurb = 'Failed to fetch the content archive "%s": %s'
+                log.error(blurb, fetcher.remote_resource, e)
+
+                # reraise, currently handled in main
+                # TODO: if we support more than one archive per invocation, will need to accumulate errors
+                #       if we want to skip some of them
+                raise
 
             log.debug('content_archive=%s', content_archive)
 

--- a/tests/ansible_galaxy/exceptions/test_exceptions.py
+++ b/tests/ansible_galaxy/exceptions/test_exceptions.py
@@ -1,3 +1,5 @@
+
+# -*- coding: utf-8 -*-
 import logging
 
 from ansible_galaxy import exceptions
@@ -20,10 +22,6 @@ def test_galaxy_download_error_no_args():
 VALID_STRINGS = (
     (b'abcde', u'abcde', 'ascii'),
     (b'caf\xc3\xa9', u'caf\xe9', 'utf-8'),
-    (b'caf\xe9', u'caf\xe9', 'latin-1'),
-    # u'くらとみ'
-    (b'\xe3\x81\x8f\xe3\x82\x89\xe3\x81\xa8\xe3\x81\xbf', u'\u304f\u3089\u3068\u307f', 'utf-8'),
-    (b'\x82\xad\x82\xe7\x82\xc6\x82\xdd', u'\u304f\u3089\u3068\u307f', 'shift-jis'),
 )
 
 

--- a/tests/ansible_galaxy/exceptions/test_exceptions.py
+++ b/tests/ansible_galaxy/exceptions/test_exceptions.py
@@ -1,0 +1,81 @@
+import logging
+
+from ansible_galaxy import exceptions
+from ansible_galaxy.utils.text import to_text
+
+log = logging.getLogger(__name__)
+
+
+def test_galaxy_error():
+    exc = exceptions.GalaxyError()
+    log.debug('exc: %s', exc)
+
+
+def test_galaxy_download_error_no_args():
+    exc = exceptions.GalaxyDownloadError()
+    log.debug('exc: %s', exc)
+
+
+# Format: byte representation, text representation, encoding of byte representation
+VALID_STRINGS = (
+    (b'abcde', u'abcde', 'ascii'),
+    (b'caf\xc3\xa9', u'caf\xe9', 'utf-8'),
+    (b'caf\xe9', u'caf\xe9', 'latin-1'),
+    # u'くらとみ'
+    (b'\xe3\x81\x8f\xe3\x82\x89\xe3\x81\xa8\xe3\x81\xbf', u'\u304f\u3089\u3068\u307f', 'utf-8'),
+    (b'\x82\xad\x82\xe7\x82\xc6\x82\xdd', u'\u304f\u3089\u3068\u307f', 'shift-jis'),
+)
+
+
+def _text_encoding():
+    for valid_string, txtrpr, encoding in VALID_STRINGS:
+        log.debug('valid_string: %s txtrpr: %s encoding: %s', valid_string, txtrpr, encoding)
+        exc = exceptions.GalaxyDownloadError(to_text(valid_string))
+        log.debug('exc: %s', exc)
+        log.debug(exc)
+        log.debug('exc(str): %s', str(exc))
+        log.debug('exc(repr): %s', repr(exc))
+        ttext = to_text(valid_string)
+        log.debug('%s in %s: %s', ttext, '%s' % exc, ttext in '%s' % exc)
+        assert ttext in '%s' % exc
+
+
+def log_text(exc):
+    log.debug('exc: %s', exc)
+    log.debug(exc)
+    log.debug('exc(str): %s', str(exc))
+    log.debug('exc(repr): %s', repr(exc))
+
+
+def _galaxy_download_error(msg, url):
+    # url kw but no message
+    exc = exceptions.GalaxyDownloadError(url=url)
+    log.debug('exc: %s', exc)
+    assert exc.url == url
+    assert url in str(exc)
+
+    # multiple args, but no url kwarg
+    exc = exceptions.GalaxyDownloadError(url, msg)
+    log.debug('exc: %s', exc)
+    assert exc.url is None
+
+    # a message arg and a url kwarg
+    exc = exceptions.GalaxyDownloadError(msg, url=url)
+    log.debug('exc: %s', exc)
+    assert exc.url == url
+    assert url in str(exc)
+    assert msg in str(exc)
+
+    # just a single message arg, no url
+    exc = exceptions.GalaxyDownloadError(msg)
+    log.debug('exc: %s', exc)
+    assert exc.url is None
+    assert msg in str(exc)
+
+
+def test_galaxy_download_error():
+    url = 'http://error.example.com'
+    msgs = ['some_message', u'caf\xe9']
+
+    for msg in msgs:
+        _galaxy_download_error(msg, url)


### PR DESCRIPTION
##### SUMMARY

Reopen of #54 after the master->devel branch rename

Based on error reported at https://github.com/ansible/galaxy-cli/pull/50#issuecomment-391658643

If the content_archive url we build up to fetch
from archive source (ie, github.com/$user/$project/archive')
results in a 404, handle the error better.

Extend GalaxyDownloadError to include the url of the request
that failed. Add unit tests.

Make fetch.galaxy_url.GalaxyUrl set it's remote_resource properly
for including in messages and errors.

Stop ignoring download exceptions in GalaxyUrl.fetch() and returning
None so it makes it back to flat_rest_api.content.GalaxyContent.install

GalaxyContent.install handles the GalaxyDownloadError, logs the exception
and re raise so it propagates to error handling in main.

<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### GALAXY CLI VERSION
<!--- Paste verbatim output from "ansible-galaxy --version" between quotes below -->
```
Ansible Galaxy CLI, version 0.1.0
Linux, newswoop, 4.16.6-202.fc27.x86_64, #1 SMP Wed May 2 00:09:32 UTC 2018, x86_64
3.6.5 (default, Apr  4 2018, 15:01:18) 
[GCC 7.3.1 20180303 (Red Hat 7.3.1-5)] /home/adrian/venvs/galaxy-cli-py3/bin/python
No config file found; using defaults


```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```



