### PR TITLE
Add 'yamlloader' to setup.py requires for 'setup.py develop'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ with open('HISTORY.rst') as history_file:
 requirements = ['six',
                 'PyYaml',
                 'jinja2',
+                'yamlloader',
                 ]
 
 setup_requirements = ['pytest-runner', ]


### PR DESCRIPTION
##### SUMMARY
dd 'yamlloader' to setup.py requires for 'setup.py develop'
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request



##### GALAXY CLI VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
Ansible Galaxy CLI, version 0.1.0
Linux, newswoop, 4.16.6-202.fc27.x86_64, #1 SMP Wed May 2 00:09:32 UTC 2018, x86_64
3.6.5 (default, Apr  4 2018, 15:01:18) 
[GCC 7.3.1 20180303 (Red Hat 7.3.1-5)] /home/adrian/venvs/galaxy-py36-demo/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

