### PR TITLE
[WIP] move logic embedded in cli classes to ansible_galaxy.actions

### DIFF
--- a/ansible_galaxy/actions/info.py
+++ b/ansible_galaxy/actions/info.py
@@ -72,7 +72,6 @@ def _repr_role_info(role_info):
 def info_content_specs(galaxy_context,
                        api,
                        content_specs,
-#                       base_content_path,
                        display_callback=None,
                        offline=None):
 

--- a/ansible_galaxy/actions/info.py
+++ b/ansible_galaxy/actions/info.py
@@ -1,0 +1,102 @@
+
+import logging
+
+from ansible_galaxy import display
+from ansible_galaxy.utils.content_name import parse_content_name
+from ansible_galaxy.utils.text import to_text
+
+from ansible_galaxy.flat_rest_api.content import GalaxyContent
+
+log = logging.getLogger(__name__)
+
+SKIP_INFO_KEYS = ("name", "description", "readme_html", "related", "summary_fields", "average_aw_composite", "average_aw_score", "url")
+
+
+# FIXME: format?
+def _repr_content_info(content_info):
+    log.debug('content_info: %s', content_info)
+    print(content_info)
+    return content_info
+
+
+# TODO: move to a repr for Role?
+def _repr_role_info(role_info):
+
+    text = [u"", u"Role: %s" % to_text(role_info['name'])]
+    text.append(u"\tdescription: %s" % role_info.get('description', ''))
+
+    for k in sorted(role_info.keys()):
+
+        if k in SKIP_INFO_KEYS:
+            continue
+
+        if isinstance(role_info[k], dict):
+            text.append(u"\t%s:" % (k))
+            for key in sorted(role_info[k].keys()):
+                if key in SKIP_INFO_KEYS:
+                    continue
+                text.append(u"\t\t%s: %s" % (key, role_info[k][key]))
+        else:
+            text.append(u"\t%s: %s" % (k, role_info[k]))
+
+    return u'\n'.join(text)
+
+
+def info_content_specs(galaxy_context,
+                       api,
+                       content_specs,
+                       content_path,
+                       display_callback=None,
+                       offline=None):
+
+    data = ''
+    display_callback = display_callback or display.display_callback
+
+    offline = offline or False
+    for content_spec in content_specs:
+
+        content_username, repo_name, content_name = parse_content_name(content_spec)
+
+        log.debug('content_spec=%s', content_spec)
+        log.debug('content_username=%s', content_username)
+        log.debug('repo_name=%s', repo_name)
+        log.debug('content_name=%s', content_name)
+
+        repo_name = repo_name or content_name
+        log.debug('repo_name2=%s', repo_name)
+
+        content_info = {'path': content_path}
+        gr = GalaxyContent(galaxy_context, content_spec)
+
+        install_info = gr.install_info
+        if install_info:
+            if 'version' in install_info:
+                install_info['intalled_version'] = install_info['version']
+                del install_info['version']
+            content_info.update(install_info)
+
+        remote_data = False
+        if not offline:
+            remote_data = api.lookup_content_by_name(content_username, repo_name, content_name)
+
+        if remote_data:
+            content_info.update(remote_data)
+
+        if gr.metadata:
+            content_info.update(gr.metadata)
+
+        # role_spec = yaml_parse({'role': role})
+        # if role_spec:
+        #     role_info.update(role_spec)
+
+        data = _repr_content_info(content_info)
+        display_callback(data)
+        # data = self._display_role_info(content_info)
+        # FIXME: This is broken in both 1.9 and 2.0 as
+        # _display_role_info() always returns something
+        if not data:
+            data = u"\n- the content %s was not found" % content_spec
+
+    display_callback(data)
+    return data
+    # self.display(data)

--- a/ansible_galaxy/actions/info.py
+++ b/ansible_galaxy/actions/info.py
@@ -1,5 +1,8 @@
 
 import logging
+import os
+import pprint
+
 
 from ansible_galaxy import display
 from ansible_galaxy.utils.content_name import parse_content_name
@@ -11,11 +14,35 @@ log = logging.getLogger(__name__)
 
 SKIP_INFO_KEYS = ("name", "description", "readme_html", "related", "summary_fields", "average_aw_composite", "average_aw_score", "url")
 
+CONTENT_TEMPLATE = """
+content_type: {content_type}
+namespace: {namespace}
+repo_name: {repo_name}
+name: {content_name}
+description: {description}
+scm: {repo_clone_url}
+"""
+
 
 # FIXME: format?
+def _repr_remote_data(remote_data):
+    log.debug('remote_data: %s', remote_data)
+    # print(remote_data)
+
+    # flatten some info for format simplicity
+    remote_data['namespace'] = remote_data['summary_fields']['namespace']['name']
+    remote_data['content_type'] = remote_data['summary_fields']['content_type']['description']
+    remote_data['content_type'] = remote_data['summary_fields']['content_type']['name']
+    # remote_data['description'] = remote_data['summary_fields']['content_type']['description']
+    remote_data['repo_clone_url'] = remote_data['summary_fields']['repository']['clone_url']
+    remote_data['repo_name'] = remote_data['summary_fields']['repository']['original_name']
+    remote_data['content_name'] = remote_data['name']
+    log.debug(pprint.pformat(remote_data))
+    return CONTENT_TEMPLATE.format(**remote_data)
+    # return pprint.pformat(content_info)
+
+
 def _repr_content_info(content_info):
-    log.debug('content_info: %s', content_info)
-    print(content_info)
     return content_info
 
 
@@ -45,12 +72,16 @@ def _repr_role_info(role_info):
 def info_content_specs(galaxy_context,
                        api,
                        content_specs,
-                       content_path,
+#                       base_content_path,
                        display_callback=None,
                        offline=None):
 
     data = ''
+    output = ''
     display_callback = display_callback or display.display_callback
+
+    # log.debug('base_content_path: %s', base_content_path)
+    content_path = galaxy_context.content_path
 
     offline = offline or False
     for content_spec in content_specs:
@@ -65,6 +96,9 @@ def info_content_specs(galaxy_context,
         repo_name = repo_name or content_name
         log.debug('repo_name2=%s', repo_name)
 
+        content_path = os.path.join(content_path, '%s.%s' % (content_username, repo_name))
+        # FIXME: this is not sufficient to load the right info, need to search for the namespace
+        #        in the content/* dir
         content_info = {'path': content_path}
         gr = GalaxyContent(galaxy_context, content_spec)
 
@@ -75,12 +109,15 @@ def info_content_specs(galaxy_context,
                 del install_info['version']
             content_info.update(install_info)
 
+        log.debug('content_info: %s', pprint.pformat(content_info))
         remote_data = False
         if not offline:
             remote_data = api.lookup_content_by_name(content_username, repo_name, content_name)
+            log.debug('remote_data: %s', pprint.pformat(remote_data))
+            display_callback(_repr_remote_data(remote_data))
 
-        if remote_data:
-            content_info.update(remote_data)
+        # if remote_data:
+        #    content_info.update(remote_data)
 
         if gr.metadata:
             content_info.update(gr.metadata)
@@ -95,8 +132,8 @@ def info_content_specs(galaxy_context,
         # FIXME: This is broken in both 1.9 and 2.0 as
         # _display_role_info() always returns something
         if not data:
-            data = u"\n- the content %s was not found" % content_spec
+            output = u"\n- the content %s was not found" % content_spec
 
-    display_callback(data)
-    return data
+    display_callback(output)
+    return 0
     # self.display(data)

--- a/ansible_galaxy/actions/init.py
+++ b/ansible_galaxy/actions/init.py
@@ -1,0 +1,74 @@
+import logging
+import os
+import re
+import shutil
+
+from jinja2 import Environment, FileSystemLoader
+
+log = logging.getLogger(__name__)
+
+
+def init(role_name,
+         init_path,
+         role_path,
+         force,
+         role_skeleton_path,
+         skeleton_ignore_expressions,
+         role_type,
+         display_callback=None):
+
+    # FIXME(akl): role_skeleton stuff should probably be a module or two and a few classes instead of inline here
+    # role_skeleton ends mostly being a list of file paths to copy
+    inject_data = dict(
+        role_name=role_name,
+        author='your name',
+        description='your description',
+        company='your company (optional)',
+        license='license (GPLv2, CC-BY, etc)',
+        issue_tracker_url='http://example.com/issue/tracker',
+        min_ansible_version='1.2',
+        role_type=role_type
+    )
+
+    import pprint
+    log.debug('inject_data: %s', pprint.pformat(inject_data))
+
+    # create role directory
+    if not os.path.exists(role_path):
+        os.makedirs(role_path)
+
+    role_skeleton = os.path.expanduser(role_skeleton_path)
+
+    log.debug('role_skeleton: %s', role_skeleton)
+    skeleton_ignore_re = [re.compile(x) for x in skeleton_ignore_expressions]
+
+    template_env = Environment(loader=FileSystemLoader(role_skeleton))
+
+    # TODO: mv elsewhere, this is main role install logic
+    for root, dirs, files in os.walk(role_skeleton, topdown=True):
+        rel_root = os.path.relpath(root, role_skeleton)
+        in_templates_dir = rel_root.split(os.sep, 1)[0] == 'templates'
+        dirs[:] = [d for d in dirs if not any(r.match(d) for r in skeleton_ignore_re)]
+
+        for f in files:
+            filename, ext = os.path.splitext(f)
+            if any(r.match(os.path.join(rel_root, f)) for r in skeleton_ignore_re):
+                continue
+            elif ext == ".j2" and not in_templates_dir:
+                src_template = os.path.join(rel_root, f)
+                dest_file = os.path.join(role_path, rel_root, filename)
+                template_env.get_template(src_template).stream(inject_data).dump(dest_file)
+            else:
+                f_rel_path = os.path.relpath(os.path.join(root, f), role_skeleton)
+                log.debug('copying %s to %s',
+                          os.path.join(root, f), os.path.join(role_path, f_rel_path))
+                shutil.copyfile(os.path.join(root, f), os.path.join(role_path, f_rel_path))
+
+        for d in dirs:
+            dir_path = os.path.join(role_path, rel_root, d)
+            if not os.path.exists(dir_path):
+                os.makedirs(dir_path)
+
+    display_callback("- %s was created successfully" % role_name)
+
+    # TODO: return?

--- a/ansible_galaxy/actions/install.py
+++ b/ansible_galaxy/actions/install.py
@@ -1,0 +1,192 @@
+import logging
+
+from ansible_galaxy import display
+from ansible_galaxy import exceptions
+from ansible_galaxy.utils.yaml_parse import yaml_parse
+
+# FIXME: get rid of flat_rest_api
+from ansible_galaxy.flat_rest_api.content import GalaxyContent
+
+log = logging.getLogger(__name__)
+
+
+def raise_without_ignore(ignore_errors, msg=None, rc=1):
+    """
+    Exits with the specified return code unless the
+    option --ignore-errors was specified
+    """
+    ignore_error_blurb = '- you can use --ignore-errors to skip failed roles and finish processing the list.'
+    if not ignore_errors:
+        message = ignore_error_blurb
+        if msg:
+            message = '%s:\n%s' % (msg, ignore_error_blurb)
+        # TODO: some sort of ignoreable exception
+        raise exceptions.GalaxyError(message)
+
+
+# FIXME: install_content_type is wrong, should be option to GalaxyContent.install()?
+# TODO: this will eventually be replaced by a content_spec 'resolver' that may
+#       hit galaxy api
+def _build_content_set(content_specs, install_content_type, galaxy_context):
+    # TODO: split this into methods that build GalaxyContent items from the content_specs
+    #       and another that installs a set of GalaxyContents
+    # roles were specified directly, so we'll just go out grab them
+    # (and their dependencies, unless the user doesn't want us to).
+
+    # FIXME: could be a generator...
+    content_left = []
+
+    for content_spec in content_specs:
+        galaxy_content = yaml_parse(content_spec.strip())
+
+        # FIXME: this is a InstallOption
+        galaxy_content["type"] = install_content_type
+
+        log.info('content install galaxy_content: %s', galaxy_content)
+
+        content_left.append(GalaxyContent(galaxy_context, **galaxy_content))
+
+    return content_left
+
+
+# pass a list of content_spec objects
+def install_content_specs(galaxy_context, content_specs, install_content_type,
+                          display_callback=None,
+                          # TODO: error handling callback ?
+                          ignore_errors=False,
+                          no_deps=False,
+                          force_overwrite=False):
+    log.debug('contents: %s', content_specs)
+    log.debug('install_content_type: %s', install_content_type)
+
+    requested_contents = _build_content_set(content_specs=content_specs,
+                                            install_content_type=install_content_type,
+                                            galaxy_context=galaxy_context)
+
+    return install_contents(galaxy_context, requested_contents, install_content_type,
+                            display_callback=display_callback,
+                            ignore_errors=ignore_errors,
+                            no_deps=no_deps,
+                            force_overwrite=force_overwrite)
+
+
+def install_contents(galaxy_context, requested_contents, install_content_type,
+                     display_callback=None,
+                     # TODO: error handling callback ?
+                     ignore_errors=False,
+                     no_deps=False,
+                     force_overwrite=False):
+
+    display_callback = display_callback or display.display_callback
+    log.debug('requested_contents: %s', requested_contents)
+    log.debug('install_content_type: %s', install_content_type)
+    log.debug('no_deps: %s', no_deps)
+    log.debug('force_overwrite: %s', force_overwrite)
+
+    # FIXME - Need to handle role files here for backwards compat
+
+    # TODO: this should be adding the content/self.args/content_left to
+    #       a list of needed deps
+
+    # FIXME: should be while? or some more func style processing
+    #        iterating until there is nothing left
+    for content in requested_contents:
+        # only process roles in roles files when names matches if given
+
+        # FIXME - not sure how to handle this scenario for ansible galaxy files
+        #         here or if we even want to handle that scenario because of
+        #         the galaxy content allowing blank repos to be inspected
+        #
+        #         maybe we want this but only for role types for backwards
+        #         compat
+        #
+        # if role_file and self.args and role.name not in self.args:
+        #    display.vvv('Skipping role %s' % role.name)
+        #    continue
+
+        log.debug('Processing %s as %s', content.name, content.content_type)
+
+        # FIXME - Unsure if we want to handle the install info for all galaxy
+        #         content. Skipping for non-role types for now.
+        # FIXME: this is just deciding if the content is installed or not, should check for it in
+        #        a 'installed_content_db' once we have one
+        if content.content_type == "role":
+            if content.install_info is not None:
+                # FIXME: seems like this should be up to the content type specific serializer/installer to figure out
+                # FIXME: this just checks for version difference, will need to enfore update/replace policy somewhre
+                if content.install_info['version'] != content.version or force_overwrite:
+                    if force_overwrite:
+                        display_callback('- changing role %s from %s to %s' %
+                                         (content.name, content.install_info['version'], content.version or "unspecified"))
+                        # FIXME: when we get to setting up a tranaction/update plan,
+                        #        this would add a remove step there and an install
+                        #        step (or an update maybe)
+                        content.remove()
+                    else:
+                        # eventually need to build a results object here
+                        log.warn('- %s (%s) is already installed - use --force to change version to %s',
+                                 content.name, content.install_info['version'], content.version or "unspecified")
+                        continue
+                else:
+                    if not force_overwrite:
+                        display_callback('- %s is already installed, skipping.' % str(content))
+                        continue
+
+        # FIXME: seems like we want to resolve deps before trying install
+        #        We need the role (or other content) deps from meta before installing
+        #        though, and sometimes (for galaxy case) we dont know that until we've downloaded
+        #        the file, which we dont do until somewhere in the begin of content.install (fetch).
+        #        We can get that from the galaxy API though.
+        #
+        try:
+            installed = content.install(force_overwrite=force_overwrite)
+        except exceptions.GalaxyError as e:
+            log.warning("- %s was NOT installed successfully: %s ", content.name, str(e))
+            raise_without_ignore(e)
+            continue
+
+        if not installed:
+            log.warning("- %s was NOT installed successfully.", content.name)
+            raise_without_ignore()
+
+        if no_deps:
+            log.warning('- %s was installed but any deps will not be installed because of no_deps',
+                        content.name)
+
+        # oh dear god, a dep solver...
+
+        # FIXME: should install all of init 'deps', then build a list of new deps, and repeat
+
+        # install dependencies, if we want them
+        # FIXME - Galaxy Content Types handle dependencies in the GalaxyContent type itself because
+        #         a content repo can contain many types and many of any single type and it's just
+        #         easier to have that introspection there. In the future this should be more
+        #         unified and have a clean API
+        if content.content_type == "role":
+            if not no_deps and installed:
+                if not content.metadata:
+                    log.warning("Meta file %s is empty. Skipping dependencies.", content.path)
+                else:
+                    role_dependencies = content.metadata.get('dependencies') or []
+                    for dep in role_dependencies:
+                        log.debug('Installing dep %s', dep)
+                        dep_info = yaml_parse(dep)
+                        dep_role = GalaxyContent(galaxy_context, **dep_info)
+                        if '.' not in dep_role.name and '.' not in dep_role.src and dep_role.scm is None:
+                            # we know we can skip this, as it's not going to
+                            # be found on galaxy.ansible.com
+                            continue
+                        if dep_role.install_info is None:
+                            if dep_role not in requested_contents:
+                                display_callback('- adding dependency: %s' % str(dep_role))
+                                requested_contents.append(dep_role)
+                            else:
+                                display_callback('- dependency %s already pending installation.' % dep_role.name)
+                        else:
+                            if dep_role.install_info['version'] != dep_role.version:
+                                log.warning('- dependency %s from role %s differs from already installed version (%s), skipping',
+                                            str(dep_role), content.name, dep_role.install_info['version'])
+                            else:
+                                display_callback('- dependency %s is already installed, skipping.' % dep_role.name)
+
+    return 0

--- a/ansible_galaxy/actions/install.py
+++ b/ansible_galaxy/actions/install.py
@@ -142,12 +142,12 @@ def install_contents(galaxy_context, requested_contents, install_content_type,
             installed = content.install(force_overwrite=force_overwrite)
         except exceptions.GalaxyError as e:
             log.warning("- %s was NOT installed successfully: %s ", content.name, str(e))
-            raise_without_ignore(e)
+            raise_without_ignore(ignore_errors, e)
             continue
 
         if not installed:
             log.warning("- %s was NOT installed successfully.", content.name)
-            raise_without_ignore()
+            raise_without_ignore(ignore_errors)
 
         if no_deps:
             log.warning('- %s was installed but any deps will not be installed because of no_deps',

--- a/ansible_galaxy/actions/install.py
+++ b/ansible_galaxy/actions/install.py
@@ -27,7 +27,8 @@ def raise_without_ignore(ignore_errors, msg=None, rc=1):
 # FIXME: install_content_type is wrong, should be option to GalaxyContent.install()?
 # TODO: this will eventually be replaced by a content_spec 'resolver' that may
 #       hit galaxy api
-def _build_content_set(content_specs, install_content_type, galaxy_context):
+def _build_content_set(content_specs, install_content_type, galaxy_context,
+                       namespace=None):
     # TODO: split this into methods that build GalaxyContent items from the content_specs
     #       and another that installs a set of GalaxyContents
     # roles were specified directly, so we'll just go out grab them
@@ -40,8 +41,8 @@ def _build_content_set(content_specs, install_content_type, galaxy_context):
         galaxy_content = yaml_parse(content_spec.strip())
 
         # FIXME: this is a InstallOption
-        galaxy_content["type"] = install_content_type
-
+        galaxy_content['type'] = install_content_type
+        galaxy_content['namespace'] = namespace
         log.info('content install galaxy_content: %s', galaxy_content)
 
         content_left.append(GalaxyContent(galaxy_context, **galaxy_content))
@@ -51,6 +52,7 @@ def _build_content_set(content_specs, install_content_type, galaxy_context):
 
 # pass a list of content_spec objects
 def install_content_specs(galaxy_context, content_specs, install_content_type,
+                          namespace=None,
                           display_callback=None,
                           # TODO: error handling callback ?
                           ignore_errors=False,
@@ -61,7 +63,8 @@ def install_content_specs(galaxy_context, content_specs, install_content_type,
 
     requested_contents = _build_content_set(content_specs=content_specs,
                                             install_content_type=install_content_type,
-                                            galaxy_context=galaxy_context)
+                                            galaxy_context=galaxy_context,
+                                            namespace=namespace)
 
     return install_contents(galaxy_context, requested_contents, install_content_type,
                             display_callback=display_callback,

--- a/ansible_galaxy/actions/list.py
+++ b/ansible_galaxy/actions/list.py
@@ -1,0 +1,62 @@
+
+import logging
+import os
+
+from ansible_galaxy import exceptions
+from ansible_galaxy.flat_rest_api.content import GalaxyContent
+
+log = logging.getLogger(__name__)
+
+
+def list(galaxy_context,
+         roles_path,
+         display_callback=None):
+
+    log.debug('locals: %s', locals())
+    full_role_paths = []
+    # show all valid roles in the roles_path directory
+    for path in roles_path:
+        role_path = os.path.expanduser(path)
+        if not os.path.exists(role_path):
+            raise exceptions.GalaxyError("- the path %s does not exist. Please specify a valid path with --roles-path" % role_path)
+        elif not os.path.isdir(role_path):
+            raise exceptions.GalaxyError("- %s exists, but it is not a directory. Please specify a valid path with --roles-path" % role_path)
+        full_role_paths.append(role_path)
+
+    log.debug('full_role_paths: %s', full_role_paths)
+
+    content_infos = []
+
+    for path in full_role_paths:
+        path_files = os.listdir(role_path)
+
+        for path_file in path_files:
+            role_full_path = os.path.join(role_path, path_file)
+
+            log.debug('role_full_path: %s', role_full_path)
+            log.debug('path_file: %s', path_file)
+
+            gr = GalaxyContent(galaxy_context, path_file, path=role_full_path)
+
+            log.debug('gr: %s', gr)
+            log.debug('gr.metadata: %s', gr.metadata)
+
+            version = None
+
+            if gr.metadata:
+                install_info = gr.install_info
+                if install_info:
+                    version = install_info.get("version", None)
+                if not version:
+                    version = "(unknown version)"
+                display_callback("- %s, %s" % (path_file, version))
+
+            content_infos.append({'path': path_file,
+                                  'content_data': gr,
+                                  'version': version})
+
+    log.debug('content_infos: %s', content_infos)
+    for content_info in content_infos:
+        display_callback("- {path}, {version}".format(**content_info))
+
+    return 0

--- a/ansible_galaxy/actions/list.py
+++ b/ansible_galaxy/actions/list.py
@@ -33,7 +33,10 @@ def list(galaxy_context,
     match_filter = match_filter or match_all
     log.debug('locals: %s', locals())
 
+    # TODO: make this into a Content iterator / database / name directory / index / etc
+
     full_role_paths = []
+
     # show all valid roles in the roles_path directory
     content_paths = roles_path
 

--- a/ansible_galaxy/actions/list.py
+++ b/ansible_galaxy/actions/list.py
@@ -74,16 +74,12 @@ def list(galaxy_context,
 
         gr = GalaxyContent(galaxy_context, path_file, path=role_full_path)
 
-
-
         # FIXME: not so much a kluge, but a sure sign that GalaxyContent.path
         #        (or its alias GalaxyContent.content_meta.path) have different meanings
         #        in diff parts of the code  (sometimes for the root dir where content lives
         #        (.ansible/content) sometimes for the path the dir to the content
         #        (.ansible/content/roles/test-role-a for ex)
         gr.content_meta.path = role_full_path
-
-
 
         log.debug('gr: %s', gr)
         log.debug('gr.metadata: %s', gr.metadata)

--- a/ansible_galaxy/actions/list.py
+++ b/ansible_galaxy/actions/list.py
@@ -8,11 +8,30 @@ from ansible_galaxy.flat_rest_api.content import GalaxyContent
 log = logging.getLogger(__name__)
 
 
+def match_all(galaxy_content):
+    return True
+
+
+class MatchNames(object):
+    def __init__(self, names):
+        self.names = names
+
+    def __call__(self, other):
+        return self.match(other)
+
+    def match(self, other):
+        log.debug('self.names: %s other.name: %s', self.names, other.name)
+        return other.name in self.names
+
+
 def list(galaxy_context,
          roles_path,
+         match_filter=None,
          display_callback=None):
 
+    match_filter = match_filter or match_all
     log.debug('locals: %s', locals())
+
     full_role_paths = []
     # show all valid roles in the roles_path directory
     for path in roles_path:
@@ -34,14 +53,27 @@ def list(galaxy_context,
             role_full_path = os.path.join(role_path, path_file)
 
             log.debug('role_full_path: %s', role_full_path)
-            log.debug('path_file: %s', path_file)
+            log.debug('path_file / name: %s', path_file)
 
             gr = GalaxyContent(galaxy_context, path_file, path=role_full_path)
+
+
+
+            # FIXME: not so much a kluge, but a sure sign that GalaxyContent.path
+            #        (or its alias GalaxyContent.content_meta.path) have different meanings
+            #        in diff parts of the code  (sometimes for the root dir where content lives
+            #        (.ansible/content) sometimes for the path the dir to the content
+            #        (.ansible/content/roles/test-role-a for ex)
+            gr.content_meta.path = role_full_path
+
+
 
             log.debug('gr: %s', gr)
             log.debug('gr.metadata: %s', gr.metadata)
 
             version = None
+
+            log.debug('gr.install_info: %s', gr.install_info)
 
             if gr.metadata:
                 install_info = gr.install_info
@@ -49,11 +81,12 @@ def list(galaxy_context,
                     version = install_info.get("version", None)
                 if not version:
                     version = "(unknown version)"
-                display_callback("- %s, %s" % (path_file, version))
+                # display_callback("- %s, %s" % (path_file, version))
 
-            content_infos.append({'path': path_file,
-                                  'content_data': gr,
-                                  'version': version})
+            if match_filter(gr):
+                content_infos.append({'path': path_file,
+                                      'content_data': gr,
+                                      'version': version})
 
     log.debug('content_infos: %s', content_infos)
     for content_info in content_infos:

--- a/ansible_galaxy/actions/list.py
+++ b/ansible_galaxy/actions/list.py
@@ -43,7 +43,14 @@ def list(galaxy_context,
     for content_path_ in content_paths:
         log.debug('content_path_: %s', content_path_)
         content_path = os.path.expanduser(content_path_)
-        namespace_paths = os.listdir(content_path)
+
+        namespace_paths = []
+        try:
+            namespace_paths = os.listdir(content_path)
+        except OSError as e:
+            log.exception(e)
+            raise exceptions.GalaxyError('The path %s did not exist', content_path)
+
         log.debug('namespace_paths: %s', namespace_paths)
 
         for namespace_path in namespace_paths:

--- a/ansible_galaxy/archive.py
+++ b/ansible_galaxy/archive.py
@@ -294,17 +294,16 @@ def extract_file(tar_file, file_to_extract):
         return None
 
     # TODO: raise from up a level in the stack?
-    # if os.path.exists(extract_to_path):
-    #    if not force_overwrite:
-    #        message = "The Galaxy content %s appears to already exist." % extract_to_path
-    #        raise exceptions.GalaxyClientError(message)
+    if os.path.exists(dest_dir):
+        if not force_overwrite:
+            message = "The Galaxy content %s appears to already exist." % dest_dir
+            raise exceptions.GalaxyClientError(message)
 
     # change the tar file member name in place to just the filename ('myfoo.py') so that extract places that file in
     # dest_dir directly instead of using adding the archive path as well
     # like '$dest_dir/archive-roles/library/myfoo.py'
     archive_member.name = dest_filename
-    tar_file.extract(archive_member, dest_dir) 
-
+    tar_file.extract(archive_member, dest_dir)
 
     installed_path = os.path.join(dest_dir, dest_filename)
 

--- a/ansible_galaxy/config/defaults.py
+++ b/ansible_galaxy/config/defaults.py
@@ -19,4 +19,4 @@ DEFAULTS = [
 
 # FIXME: replace with logging config
 VERBOSITY = 0
-CONFIG_FILE = '~/.ansible/galaxy.yml'
+CONFIG_FILE = '~/.ansible/mazer.yml'

--- a/ansible_galaxy/content_archive.py
+++ b/ansible_galaxy/content_archive.py
@@ -1,0 +1,123 @@
+import logging
+import os
+import tarfile
+
+from ansible_galaxy import archive
+from ansible_galaxy import exceptions
+from ansible_galaxy.models import content
+from ansible_galaxy.models import content_archive
+
+log = logging.getLogger(__name__)
+
+
+def detect_content_archive_type(archive_path, archive_members):
+    '''Try to determine if we are a role, multi-content, apb etc.
+
+    if there is a meta/main.yml ->  role
+
+    if there is any of the content types subdirs -> multi-content'''
+
+    # FIXME: just looking for the root dir...
+
+    top_dir = archive_members[0].name
+
+    log.debug('top_dir: %s', top_dir)
+
+    meta_main_target = os.path.join(top_dir, 'meta/main.yml')
+
+    type_dirs = content.CONTENT_TYPE_DIR_MAP.values()
+    log.debug('type_dirs: %s', type_dirs)
+
+    type_dir_targets = set([os.path.join(top_dir, x) for x in type_dirs])
+    log.debug('type_dir_targets: %s', type_dir_targets)
+
+    for member in archive_members:
+        if member.name == meta_main_target:
+            return 'role'
+        if member.name in type_dir_targets:
+            return 'multi-content'
+
+    # TODO: exception
+    return None
+
+
+def load_archive(archive_path):
+    archive_parent_dir = None
+
+    if not tarfile.is_tarfile(archive_path):
+        raise exceptions.GalaxyClientError("the file downloaded was not a tar.gz")
+
+    if archive_path.endswith('.gz'):
+        content_tar_file = tarfile.open(archive_path, "r:gz")
+    else:
+        content_tar_file = tarfile.open(archive_path, "r")
+
+    members = content_tar_file.getmembers()
+
+    archive_parent_dir = members[0].name
+
+    # next find the metadata file
+    (meta_file, meta_parent_dir, galaxy_file, apb_yaml_file) = \
+        archive.find_archive_metadata(members)
+
+    archive_type = detect_content_archive_type(archive_path, members)
+    log.debug('archive_type: %s', archive_type)
+
+    # log.debug('self.content_type: %s', self.content_type)
+    # if not archive_parent_dir:
+    #    archive_parent_dir = archive.find_archive_parent_dir(members,
+    #                                                         content_type=content_meta.content_type,
+    #                                                         content_dir=content_meta.content_dir)
+
+    log.debug('meta_file: %s', meta_file)
+    log.debug('galaxy_file: %s', galaxy_file)
+    log.debug('archive_type: %s', archive_type)
+    log.debug("archive_parent_dir: %s", archive_parent_dir)
+    log.debug("meta_parent_dir: %s", meta_parent_dir)
+
+    # if not meta_file and not galaxy_file and self.content_type == "role":
+    #    raise exceptions.GalaxyClientError("this role does not appear to have a meta/main.yml file or ansible-galaxy.yml.")
+
+
+    # metadata_ = archive.load_archive_role_metadata(content_tar_file,
+    #                                               meta_file)
+
+    # galaxy_metadata = archive.load_archive_galaxyfile(content_tar_file,
+    #                                                  galaxy_file)
+
+    # apb_data = archive.load_archive_apb_yaml(content_tar_file,
+    #                                          apb_yaml_file)
+
+    # log.debug('apb_data: %s', pprint.pformat(apb_data))
+
+    # looks like we are a role, update the default content_type from all -> role
+    if archive_type == 'role':
+        # Look for top level role metadata
+        # archive_role_metadata = \
+        #    archive.load_archive_role_metadata(content_tar_file,
+        #                                       os.path.join(archive_parent_dir, archive.META_MAIN))
+        log.debug('Find role metadata in the archive, so installing it as role content_type')
+
+        archive_meta = content_archive.RoleContentArchiveMeta(top_dir=archive_parent_dir)
+        # content_meta = content.RoleContentArchiveMeta.from_data(data)
+
+        log.debug('role archive_meta: %s', archive_meta)
+
+        return content_tar_file, archive_meta
+
+    return content_tar_file, content_archive.ContentArchiveMeta(archive_type=archive_type,
+                                                                top_dir=archive_parent_dir)
+
+# TODO: add back galaxy, apb meta data load
+#    if apb_data:
+#        log.debug('Find APB metadata in the archive, so installing it as APB content_type')
+#
+#        data = self.content_meta.data
+#        data['apb_data'] = apb_data
+#
+#        content_meta = content.APBContentArchiveMeta.from_data(data)
+#
+#        log.debug('APB content_meta: %s', content_meta)
+#        content_archive_type = 'apb'
+#
+#    log.debug('content_archive_type=%s', content_archive_type)

--- a/ansible_galaxy/content_archive.py
+++ b/ansible_galaxy/content_archive.py
@@ -78,7 +78,6 @@ def load_archive(archive_path):
     # if not meta_file and not galaxy_file and self.content_type == "role":
     #    raise exceptions.GalaxyClientError("this role does not appear to have a meta/main.yml file or ansible-galaxy.yml.")
 
-
     # metadata_ = archive.load_archive_role_metadata(content_tar_file,
     #                                               meta_file)
 

--- a/ansible_galaxy/display.py
+++ b/ansible_galaxy/display.py
@@ -32,7 +32,8 @@ def log_display_callback(*args, **kwargs):
     level_arg = kwargs.get('level', None)
     # find custom level, otherwise use INFO_LEVELs
     log_level = DISPLAY_LEVEL_MAP.get(level_arg, INFO_LEVEL)['log_level']
-    log.log(log_level, 'DISPLAY: %s', ''.join(args), extra={'display_args': args})
+    # log.log(log_level, 'DISPLAY: %s', ''.join(args), extra={'display_args': args})
+    log.log(log_level, 'DISPLAY: %s', *args, extra={'display_args': args})
 
 
 def display_callback(*args, **kwargs):

--- a/ansible_galaxy/display.py
+++ b/ansible_galaxy/display.py
@@ -32,7 +32,7 @@ def log_display_callback(*args, **kwargs):
     level_arg = kwargs.get('level', None)
     # find custom level, otherwise use INFO_LEVELs
     log_level = DISPLAY_LEVEL_MAP.get(level_arg, INFO_LEVEL)['log_level']
-    log.log(log_level, ''.join(args), extra={'display_args': args})
+#     log.log(log_level, ''.join(args), extra={'display_args': args})
 
 
 def display_callback(*args, **kwargs):

--- a/ansible_galaxy/display.py
+++ b/ansible_galaxy/display.py
@@ -24,7 +24,7 @@ def stdout_display_callback(*args, **kwargs):
     level_arg = kwargs.get('level', None)
     level_prefix = DISPLAY_LEVEL_MAP.get(level_arg, INFO_LEVEL)['prefix']
 
-    print('%s%s' % (level_prefix, *args))
+    print('%s%s' % (level_prefix, str(*args)))
 
 
 # will log whatever is display with display callback to the ansible_galaxy.display logger

--- a/ansible_galaxy/display.py
+++ b/ansible_galaxy/display.py
@@ -21,7 +21,7 @@ DISPLAY_LEVEL_MAP = {
 
 
 def stdout_display_callback(*args, **kwargs):
-    level_arg = kwargs.pop('level', None)
+    level_arg = kwargs.get('level', None)
     level_prefix = DISPLAY_LEVEL_MAP.get(level_arg, INFO_LEVEL)['prefix']
 
     print('%s' % level_prefix, args)
@@ -29,7 +29,8 @@ def stdout_display_callback(*args, **kwargs):
 
 # will log whatever is display with display callback to the ansible_galaxy.display logger
 def log_display_callback(*args, **kwargs):
-    level_arg = kwargs.pop('level', None)
+    level_arg = kwargs.get('level', None)
+    # find custom level, otherwise use INFO_LEVELs
     log_level = DISPLAY_LEVEL_MAP.get(level_arg, INFO_LEVEL)['log_level']
     log.log(log_level, ''.join(args), extra={'display_args': args})
 

--- a/ansible_galaxy/display.py
+++ b/ansible_galaxy/display.py
@@ -24,7 +24,7 @@ def stdout_display_callback(*args, **kwargs):
     level_arg = kwargs.get('level', None)
     level_prefix = DISPLAY_LEVEL_MAP.get(level_arg, INFO_LEVEL)['prefix']
 
-    print('%s' % level_prefix, args)
+    print('%s%s' % (level_prefix, *args))
 
 
 # will log whatever is display with display callback to the ansible_galaxy.display logger
@@ -32,12 +32,12 @@ def log_display_callback(*args, **kwargs):
     level_arg = kwargs.get('level', None)
     # find custom level, otherwise use INFO_LEVELs
     log_level = DISPLAY_LEVEL_MAP.get(level_arg, INFO_LEVEL)['log_level']
-#     log.log(log_level, ''.join(args), extra={'display_args': args})
+    log.log(log_level, 'DISPLAY: %s', ''.join(args), extra={'display_args': args})
 
 
 def display_callback(*args, **kwargs):
-    stdout_display_callback(args, kwargs)
-    log_display_callback(args, kwargs)
+    stdout_display_callback(*args, **kwargs)
+    log_display_callback(*args, **kwargs)
 
 
 def null_display_callback(*args, **kwargs):

--- a/ansible_galaxy/display.py
+++ b/ansible_galaxy/display.py
@@ -24,7 +24,7 @@ def stdout_display_callback(*args, **kwargs):
     level_arg = kwargs.get('level', None)
     level_prefix = DISPLAY_LEVEL_MAP.get(level_arg, INFO_LEVEL)['prefix']
 
-    print('%s%s' % (level_prefix, str(*args)))
+    print('%s%s' % (level_prefix, ''.join(args)))
 
 
 # will log whatever is display with display callback to the ansible_galaxy.display logger
@@ -33,7 +33,7 @@ def log_display_callback(*args, **kwargs):
     # find custom level, otherwise use INFO_LEVELs
     log_level = DISPLAY_LEVEL_MAP.get(level_arg, INFO_LEVEL)['log_level']
     # log.log(log_level, 'DISPLAY: %s', ''.join(args), extra={'display_args': args})
-    log.log(log_level, 'DISPLAY: %s', *args, extra={'display_args': args})
+    log.log(log_level, 'DISPLAY: %s', ''.join(args), extra={'display_args': args})
 
 
 def display_callback(*args, **kwargs):

--- a/ansible_galaxy/fetch/galaxy_url.py
+++ b/ansible_galaxy/fetch/galaxy_url.py
@@ -36,19 +36,19 @@ def get_download_url(repo_data=None, external_url=None, repoversion=None):
 
     # server response didn't suggest a download_url, take a guess and make one up
     if external_url and repoversion:
-        archive_url = '%s/archive/%s.tar.gz' % (external_url, repoversion['name'])
+        archive_url = '%s/archive/%s.tar.gz' % (external_url, repoversion['version'])
         return archive_url
 
 
 def select_repository_version(repoversions, version):
-    # repository_versions name is 'not null' so should always exist
+    # repository_versions 'version' is 'not null' so should always exist
 
     # we could build a map/dict first and search in it, but we only use this
     # once, so this linear search is ok, since building the map would be that
     # plus the getitem
-    results = [x for x in repoversions if x['name'] == version]
+    results = [x for x in repoversions if x['version'] == version]
 
-    # repository_versions is uniq on (name, repo.id) so for any given repo,
+    # repository_versions is uniq on (version, repo.id) so for any given repo,
     # there should only be one result here
     repoversion = results.pop()
     return repoversion
@@ -110,9 +110,6 @@ class GalaxyUrlFetch(base.BaseFetch):
         # FIXME: exception handling
         repoversions = api.fetch_content_related(repo_versions_url)
 
-        # repo_versions is uniq on (name, repository_id), so for a particular
-        # repository_id, we can build a map of repositoryversion.name -> repository.id
-
         # related_repo_url = related.get('repository', None)
         # log.debug('related_repo_url: %s', related_repo_url)
         # related_content_url = related.get('content', None)
@@ -121,7 +118,7 @@ class GalaxyUrlFetch(base.BaseFetch):
         # content_repo = None
         # if related_content_url:
         #     content_repo = api.fetch_content_related(related_content_url)
-        content_repo_versions = [a.get('name') for a in repoversions if a.get('name', None)]
+        content_repo_versions = [a.get('version') for a in repoversions if a.get('version', None)]
 
         # log.debug('content_repo: %s', content_repo)
         # FIXME: mv to it's own method

--- a/ansible_galaxy/fetch/galaxy_url.py
+++ b/ansible_galaxy/fetch/galaxy_url.py
@@ -181,5 +181,6 @@ class GalaxyUrlFetch(base.BaseFetch):
 
         results['content'] = {'fetched_version': _repoversion.get('version'),
                               'repo_name': repo_name,
-                              'content_name': content_name}
+                              'content_name': content_name,
+                              'content_namespace': content_username}
         return results

--- a/ansible_galaxy/fetch/galaxy_url.py
+++ b/ansible_galaxy/fetch/galaxy_url.py
@@ -41,7 +41,6 @@ def get_download_url(repo_data=None, external_url=None, repoversion=None):
 
 
 def select_repository_version(repoversions, version):
-    log.debug('repoversions: %s', pprint.pformat(repoversions))
     # repository_versions name is 'not null' so should always exist
 
     # we could build a map/dict first and search in it, but we only use this
@@ -111,8 +110,6 @@ class GalaxyUrlFetch(base.BaseFetch):
         # FIXME: exception handling
         repoversions = api.fetch_content_related(repo_versions_url)
 
-        log.debug('repoversions: %s', repoversions)
-
         # repo_versions is uniq on (name, repository_id), so for a particular
         # repository_id, we can build a map of repositoryversion.name -> repository.id
 
@@ -125,7 +122,6 @@ class GalaxyUrlFetch(base.BaseFetch):
         # if related_content_url:
         #     content_repo = api.fetch_content_related(related_content_url)
         content_repo_versions = [a.get('name') for a in repoversions if a.get('name', None)]
-        log.debug('content_repo_versions: %s', content_repo_versions)
 
         # log.debug('content_repo: %s', content_repo)
         # FIXME: mv to it's own method

--- a/ansible_galaxy/fetch/galaxy_url.py
+++ b/ansible_galaxy/fetch/galaxy_url.py
@@ -1,6 +1,5 @@
 
 import logging
-import pprint
 
 # mv details of this here
 from ansible_galaxy import exceptions

--- a/ansible_galaxy/fetch/galaxy_url.py
+++ b/ansible_galaxy/fetch/galaxy_url.py
@@ -179,7 +179,7 @@ class GalaxyUrlFetch(base.BaseFetch):
                              'specified_content_spec': self.content_spec,
                              'repository_data': repo_data}
 
-        results['content'] = {'fetched_version': _repoversion.get('name'),
+        results['content'] = {'fetched_version': _repoversion.get('version'),
                               'repo_name': repo_name,
                               'content_name': content_name}
         return results

--- a/ansible_galaxy/fetch/local_file.py
+++ b/ansible_galaxy/fetch/local_file.py
@@ -15,7 +15,12 @@ class LocalFileFetch(object):
 
         log.debug('content_archive_path=%s (inplace)', content_archive_path)
 
-        return content_archive_path
+        results = {'archive_path': content_archive_path,
+                   'fetch_method': self.fetch_method}
+
+        results['custom'] = {'local_path': self.local_path}
+
+        return results
 
     def cleanup(self):
         return None

--- a/ansible_galaxy/fetch/remote_url.py
+++ b/ansible_galaxy/fetch/remote_url.py
@@ -31,4 +31,8 @@ class RemoteUrlFetch(base.BaseFetch):
 
         log.debug('content_archive_path=%s', content_archive_path)
 
+        results = {'archive_path': content_archive_path,
+                   'fetch_method': self.fetch_method}
+        results['custom'] = {'remote_url': self.remote_url,
+                             'validate_certs': self.validate_certs}
         return content_archive_path

--- a/ansible_galaxy/fetch/scm_url.py
+++ b/ansible_galaxy/fetch/scm_url.py
@@ -25,4 +25,11 @@ class ScmUrlFetch(base.BaseFetch):
 
         log.debug('content_archive_path=%s', content_archive_path)
 
-        return content_archive_path
+        results = {'archive_path': content_archive_path,
+                   'fetch_method': self.fetch_method,
+                   'download_url': self.scm_url}
+        results['custom'] = {'scm_url': self.scm_url,
+                             'specified_content_spec': self.scm_spec}
+
+        # TODO: what the heck should the version be for a scm_url if one wasnt specified?
+        return results

--- a/ansible_galaxy/flat_rest_api/api.py
+++ b/ansible_galaxy/flat_rest_api/api.py
@@ -173,8 +173,8 @@ class GalaxyAPI(object):
         return None
 
     @g_connect
-    def lookup_content_by_name(self, user_name, repo_name, content_name, content_type=None, notify=True):
-        self.log.debug('user_name=%s', user_name)
+    def lookup_content_by_name(self, namespace, repo_name, content_name, content_type=None, notify=True):
+        self.log.debug('namespace=%s', namespace)
         self.log.debug('repo_name=%s', repo_name)
         self.log.debug('content_name=%s', content_name)
         self.log.debug('content_type=%s', content_type)
@@ -184,9 +184,9 @@ class GalaxyAPI(object):
         repo_name = urlquote(repo_name)
 
         if notify:
-            self.log.info("- downloading content '%s', type '%s',repo_name '%s'  owned by %s", content_name, content_type, repo_name, user_name)
+            self.log.info("- downloading content '%s', type '%s',repo_name '%s'  owned by %s", content_name, content_type, repo_name, namespace)
 
-        url = '%s/content/?owner__username=%s&name=%s' % (self.baseurl, user_name, content_name)
+        url = '%s/content/?name=%s&namespace__name=%s' % (self.baseurl, content_name, namespace)
         data = self.__call_galaxy(url)
         if len(data["results"]) != 0:
             return data["results"][0]

--- a/ansible_galaxy/flat_rest_api/content.py
+++ b/ansible_galaxy/flat_rest_api/content.py
@@ -400,6 +400,9 @@ class GalaxyContent(object):
             log.debug('content_names: %s', content_names)
 
             parent_dir_slash = '%s/' % parent_dir
+
+            namespace_repo_name = content_meta.src
+
             # extract each content individually
             for content_name in content_names:
                 files_to_extract = []
@@ -412,7 +415,11 @@ class GalaxyContent(object):
 
                 # log.debug('member_matches for content_name=%s: %s', content_name, pprint.pformat(member_matches))
 
+                namespaced_content_path = '%s/%s/%s' % (namespace_repo_name,
+                                                        content_sub_dir,
+                                                        content_name)
                 log.debug('namespace: %s', content_meta.namespace)
+                log.debug('namespaced_content_path: %s', namespaced_content_path)
 
                 for member_match in member_matches:
                     # archive_member, dest_dir, dest_filename, force_overwrite
@@ -422,12 +429,12 @@ class GalaxyContent(object):
 
                     # need to replace the role name in the archive with the role name
                     # that includes the galaxy namespace
-                    # roles/foobar/meta/main.yml, after_roles -> foobar/meta/main.yml
-                    after_roles = rel_path[len(content_sub_dir) + 1:]
 
-                    namespaced_role_rel_path = rel_path.replace('roles/%s' % content_name,
-                                                                'roles/%s.%s' % (content_meta.namespace, content_name),
+                    namespaced_role_rel_path = rel_path.replace('%s/%s' % (content_sub_dir,
+                                                                           content_name),
+                                                                namespaced_content_path,
                                                                 1)
+                    log.debug('namespaced_role_rel_path: %s', namespaced_role_rel_path)
                     extract_info = {'archive_member': member_match,
                                     'dest_dir': content_meta.path,
                                     # 'dest_dir': os.path.join(content_meta.path,
@@ -435,7 +442,8 @@ class GalaxyContent(object):
                                     #                         content_name),
                                     # 'dest_filename': os.path.join(content_sub_dir, content_name, member_match.name),
                                     # +1 to include the '/' at end of parent dir
-                                    'dest_filename': member_match.name[len(parent_dir) + 1:],
+                                    # 'dest_filename': member_match.name[len(parent_dir) + 1:],
+                                    'dest_filename': namespaced_role_rel_path,
                                     'force_overwrite': force_overwrite}
                     files_to_extract.append(extract_info)
 
@@ -457,8 +465,7 @@ class GalaxyContent(object):
 
                 if install_content_type in self.REQUIRES_META_MAIN:
                     info_path = os.path.join(content_meta.path,
-                                             content_sub_dir,
-                                             content_name,
+                                             namespaced_content_path,
                                              self.META_INSTALL)
                     self._write_galaxy_install_info(content_meta, info_path)
 

--- a/ansible_galaxy/flat_rest_api/content.py
+++ b/ansible_galaxy/flat_rest_api/content.py
@@ -428,6 +428,8 @@ class GalaxyContent(object):
 
         content_meta = content_meta or self.content_meta
 
+        # FIXME: really need to move the fetch step elsewhere and do it before,
+        #        install should get pass a content_archive (or something more abstract)
         # TODO: some useful exceptions for 'cant find', 'cant read', 'cant write'
         fetch_method = choose_content_fetch_method(scm_url=self.scm, src=self.src)
 

--- a/ansible_galaxy/flat_rest_api/content.py
+++ b/ansible_galaxy/flat_rest_api/content.py
@@ -468,9 +468,11 @@ class GalaxyContent(object):
         log.debug('fetch_method: %s', fetch_method)
 
         if fetcher:
-            content_archive = fetcher.fetch()
+            fetch_results = fetcher.fetch()
 
-            log.debug('content_archive=%s', content_archive)
+            content_archive = fetch_results['archive_path']
+            log.debug('fetch_results=%s', pprint.pformat(fetch_results))
+            # log.debug('content_archive=%s', fetch_results.archive_path)
 
         if not content_archive:
             raise exceptions.GalaxyClientError('No valid content data found for %s', self.src)
@@ -536,6 +538,8 @@ class GalaxyContent(object):
             log.debug('old content_meta: %s', old)
             data = self.content_meta.data
 
+            content_data = fetch_results.get('content', {})
+            data['version'] = content_data.get('fetched_version', data.get('version'))
             content_meta = content.RoleContentArchiveMeta.from_data(data)
 
             log.debug('role content_meta: %s', content_meta)

--- a/ansible_galaxy/flat_rest_api/content.py
+++ b/ansible_galaxy/flat_rest_api/content.py
@@ -125,7 +125,7 @@ class GalaxyContent(object):
 
         self.log = logging.getLogger(__name__ + '.' + self.__class__.__name__)
 
-        self.display_callback = display_callback or self._display_callback
+        self.display_callback = display_callback or display.display_callback
 
         # self.options = galaxy.options
         self.galaxy = galaxy
@@ -159,14 +159,6 @@ class GalaxyContent(object):
         # Set original path, needed to determine what action to take in order to
         # maintain backwards compat with legacy roles
         self._orig_path = path
-
-    def _display_callback(self, *args, **kwargs):
-        level_arg = kwargs.pop('level', None)
-        levels = {'warning': 'WARNING'}
-        level = levels.get(level_arg, None)
-        if level:
-            print('%s' % level, *args)
-        print(*args)
 
     def __repr__(self):
         """
@@ -249,7 +241,10 @@ class GalaxyContent(object):
         if self._install_info is None:
             log.debug('self.path: %s', self.path)
             log.debug('self.META_INSTALL: %s', self.META_INSTALL)
+
             info_path = os.path.join(self.path, self.META_INSTALL)
+
+            log.debug('info_path: %s', info_path)
             if os.path.isfile(info_path):
                 try:
                     f = open(info_path, 'r')

--- a/ansible_galaxy/flat_rest_api/content.py
+++ b/ansible_galaxy/flat_rest_api/content.py
@@ -380,8 +380,6 @@ class GalaxyContent(object):
                                                               # archive_parent_dir,
                                                               content_sub_dir,
                                                               content_meta,
-                                                              content_archive_type=content_archive_type,
-                                                              install_content_type=install_content_type,
                                                               files_to_extract=member_matches,
                                                               extract_to_path=content_meta.path,
                                                               force_overwrite=force_overwrite)

--- a/ansible_galaxy/flat_rest_api/content.py
+++ b/ansible_galaxy/flat_rest_api/content.py
@@ -340,11 +340,17 @@ class GalaxyContent(object):
                                    content_sub_name=None,
                                    force_overwrite=False):
 
+        import pprint; log.debug('locals():\n%s', pprint.pformat(locals()))
         all_installed_paths = []
         content_types_to_install = content_types_to_install or []
         for install_content_type in content_types_to_install:
             log.debug('INSTALLING %s type content from %s', install_content_type, content_tar_file)
 
+            # TODO: install_for_content_type()  - handle one content type
+            #       _install_for_content_type_role() - role specific impl
+            # TODO:  install_contents()  - iterator over all the contents of a content type (ie, 'roles')
+            # TODO:   install_content()  - install a single content  (ie, a role)
+            #         _install_content_role()  - role specific impl of install_content
             member_matches = archive.filter_members_by_content_type(content_tar_file,
                                                                     content_archive_type,
                                                                     content_type=install_content_type)
@@ -363,7 +369,13 @@ class GalaxyContent(object):
                                                                    match_pattern)
             log.debug('content_meta: %s', content_meta)
             log.info('about to extract %s to %s', content_meta.name, content_meta.path)
+            log.info('content_sub_dir: %s', content_sub_dir)
 
+            log.debug('member_matches: %s', pprint.pformat(member_matches))
+            # archive_extract_root = os.path.join(content_sub_dir, content_meta.content_sub_dir)
+            # log.debug('archive_extract_root: %s', archive_extract_root)
+
+            # TODO: extract_file_list_to_path(content_tar_file, files_to_extract, extract_to_path, force_overwrite)
             installed_paths = archive.extract_by_content_type(content_tar_file,
                                                               # archive_parent_dir,
                                                               content_sub_dir,
@@ -516,9 +528,9 @@ class GalaxyContent(object):
 
         log.info('Installing content from archive type: %s', archive_meta.archive_type)
 
-        content_types_to_install = [self.content_install_type]
-        if self.content_install_type == 'all':
-            content_types_to_install = CONTENT_TYPES
+        # content_types_to_install = [self.content_install_type]
+        # if self.content_install_type == 'all':
+        #    content_types_to_install = CONTENT_TYPES
 
         if archive_meta.archive_type == 'multi-content':
             # if content_meta.content_type == 'all':

--- a/ansible_galaxy/flat_rest_api/content.py
+++ b/ansible_galaxy/flat_rest_api/content.py
@@ -34,6 +34,7 @@ import yaml
 from ansible_galaxy import exceptions
 from ansible_galaxy import archive
 from ansible_galaxy.content_repo_galaxy_metadata import install_from_galaxy_metadata
+from ansible_galaxy import display
 from ansible_galaxy.fetch.scm_url import ScmUrlFetch
 from ansible_galaxy.fetch.local_file import LocalFileFetch
 from ansible_galaxy.fetch.remote_url import RemoteUrlFetch
@@ -218,7 +219,11 @@ class GalaxyContent(object):
             if self._metadata is None:
                 log.debug('content_meta.path: %s', self.content_meta.path)
                 log.debug('archive.META_MAIN: %s', archive.META_MAIN)
+
                 meta_path = os.path.join(self.content_meta.path, archive.META_MAIN)
+
+                log.debug('meta_path: %s', meta_path)
+
                 if os.path.isfile(meta_path):
                     try:
                         f = open(meta_path, 'r')

--- a/ansible_galaxy/flat_rest_api/content.py
+++ b/ansible_galaxy/flat_rest_api/content.py
@@ -270,6 +270,7 @@ class GalaxyContent(object):
         info = dict(
             version=content_meta.version,
             install_date=datetime.datetime.utcnow().strftime("%c"),
+            install_date_iso=datetime.datetime.now()
         )
 
         import pprint
@@ -288,7 +289,7 @@ class GalaxyContent(object):
             # FIXME: just return the install_info dict (or better, build it elsewhere and pass in)
             # FIXME: stop minging self state
             try:
-                self._install_info = yaml.safe_dump(info, f)
+                self._install_info = yaml.safe_dump(info, f, default_flow_style=False)
             except Exception as e:
                 log.warn('unable to serialize .galaxy_install_info to info_path=%s for data=%s', info_path, info)
                 log.exception(e)

--- a/ansible_galaxy/models/content.py
+++ b/ansible_galaxy/models/content.py
@@ -29,6 +29,7 @@ CONTENT_PLUGIN_TYPES = (
     'callback_plugin',
 )
 CONTENT_TYPES = CONTENT_PLUGIN_TYPES + ('role',)
+SUPPORTED_CONTENT_TYPES = ('role',)
 
 CONTENT_TYPE_DIR_MAP = dict([(k, '%ss' % k) for k in CONTENT_TYPES])
 CONTENT_TYPE_DIR_MAP['module'] = 'library'
@@ -88,26 +89,14 @@ class GalaxyContentMeta(object):
 
 
 # TODO: separate GalaxyContent, ContentMeta and ContentArchive classes
-class RoleContentArchiveMeta(GalaxyContentMeta):
+class RoleContentMeta(GalaxyContentMeta):
 
     def __init__(self, *args, **kwargs):
-        super(RoleContentArchiveMeta, self).__init__(*args, **kwargs)
+        super(RoleContentMeta, self).__init__(*args, **kwargs)
         self.content_type = 'role'
         self.content_dir = CONTENT_TYPE_DIR_MAP.get('role', None)
         self.content_sub_dir = self.name
-        self.requires_meta_main = True
-
-    @classmethod
-    def from_content_meta(cls, content_meta):
-        data = content_meta.data.copy()
-        data['content_type'] = 'role'
-        data['content_dir'] = CONTENT_TYPE_DIR_MAP.get('role', None)
-        # ie, for roles, the roles/$CONTENT_SUB_DIR/  name
-        data['content_sub_dir'] = data['name']
-        data['requires_meta_main'] = True
-        # data['path'] =
-        content_meta = cls.from_data(data)
-        return content_meta
+        # self.requires_meta_main = True
 
 
 class APBContentArchiveMeta(GalaxyContentMeta):

--- a/ansible_galaxy/models/content.py
+++ b/ansible_galaxy/models/content.py
@@ -76,9 +76,12 @@ class GalaxyContentMeta(object):
              other.content_type, other.content_dir, other.path)
 
     def __repr__(self):
-        return 'GalaxyContentMeta(name=%s, namespace=%s, version=%s, src=%s, scm=%s, content_type=%s, content_dir=%s, content_sub_dir=%s, path=%s, requires_meta_main=%s)' \
-            % (self.name, self.namespace, self.version, self.src, self.scm,
-               self.content_type, self.content_dir, self.content_sub_dir, self.path, self.requires_meta_main)
+        format_ = 'GalaxyContentMeta(name=%s, namespace=%s, version=%s, src=%s, scm=%s, ' + \
+            'content_type=%s, content_dir=%s, content_sub_dir=%s, path=%s, requires_meta_main=%s)'
+
+        return format_ % (self.name, self.namespace, self.version, self.src, self.scm,
+                          self.content_type, self.content_dir, self.content_sub_dir,
+                          self.path, self.requires_meta_main)
 
     def _as_dict(self):
         return {'name': self.name,

--- a/ansible_galaxy/models/content.py
+++ b/ansible_galaxy/models/content.py
@@ -87,6 +87,7 @@ class GalaxyContentMeta(object):
         return self._data
 
 
+# TODO: separate GalaxyContent, ContentMeta and ContentArchive classes
 class RoleContentArchiveMeta(GalaxyContentMeta):
 
     def __init__(self, *args, **kwargs):

--- a/ansible_galaxy/models/content.py
+++ b/ansible_galaxy/models/content.py
@@ -1,3 +1,7 @@
+import logging
+
+log = logging.getLogger(__name__)
+
 
 VALID_ROLE_SPEC_KEYS = [
     'src',
@@ -42,7 +46,8 @@ class GalaxyContentMeta(object):
                  src=None, scm=None,
                  content_type=None,
                  path=None, requires_meta_main=None,
-                 content_dir=None, content_sub_dir=None):
+                 content_dir=None, content_sub_dir=None,
+                 namespace=None):
 
         self.name = name
         self.version = version
@@ -53,7 +58,11 @@ class GalaxyContentMeta(object):
         self.requires_meta_main = requires_meta_main
         self.content_dir = content_dir
         self.content_sub_dir = content_sub_dir
+        self.namespace = namespace
         self._data = {}
+
+
+#         log.debug('%s locals: %s', self.__class__.__name__, locals())
 
     @classmethod
     def from_data(cls, data):
@@ -61,17 +70,19 @@ class GalaxyContentMeta(object):
         return inst
 
     def __eq__(self, other):
-        return (self.name, self.version, self.src, self.scm,
+        return (self.name, self.namespace, self.version, self.src, self.scm,
                 self.content_type, self.content_dir, self.path) == \
-            (other.name, other.version, other.src, other.scm,
+            (other.name, other.namespace, other.version, other.src, other.scm,
              other.content_type, other.content_dir, other.path)
 
     def __repr__(self):
-        return 'GalaxyContentMeta(name=%s, version=%s, src=%s, scm=%s, content_type=%s, content_dir=%s, content_sub_dir=%s, path=%s, requires_meta_main=%s)' \
-            % (self.name, self.version, self.src, self.scm, self.content_type, self.content_dir, self.content_sub_dir, self.path, self.requires_meta_main)
+        return 'GalaxyContentMeta(name=%s, namespace=%s, version=%s, src=%s, scm=%s, content_type=%s, content_dir=%s, content_sub_dir=%s, path=%s, requires_meta_main=%s)' \
+            % (self.name, self.namespace, self.version, self.src, self.scm,
+               self.content_type, self.content_dir, self.content_sub_dir, self.path, self.requires_meta_main)
 
     def _as_dict(self):
         return {'name': self.name,
+                'namespace': self.namespace,
                 'version': self.version,
                 'src': self.src,
                 'scm': self.scm,
@@ -96,7 +107,9 @@ class RoleContentMeta(GalaxyContentMeta):
         self.content_type = 'role'
         self.content_dir = CONTENT_TYPE_DIR_MAP.get('role', None)
         self.content_sub_dir = self.name
+
         # self.requires_meta_main = True
+        log.debug('%s self.__dict__: %s', self.__class__.__name__, self.__dict__)
 
 
 class APBContentArchiveMeta(GalaxyContentMeta):

--- a/ansible_galaxy/models/content_archive.py
+++ b/ansible_galaxy/models/content_archive.py
@@ -1,0 +1,20 @@
+
+
+class ContentArchiveMeta(object):
+    _archive_type = None
+    requires_meta_main = False
+
+    def __init__(self, archive_type=None, archive_path=None, top_dir=None):
+        self.archive_type = archive_type or self._archive_type
+        self.top_dir = top_dir
+        self.archive_path = archive_path
+
+    # download url?
+    # file path?
+    # checksum?
+    # signature?
+
+
+class RoleContentArchiveMeta(ContentArchiveMeta):
+    _archive_type = 'role'
+    requires_meta_main = True

--- a/ansible_galaxy/models/content_version.py
+++ b/ansible_galaxy/models/content_version.py
@@ -9,6 +9,7 @@ from ansible_galaxy.utils.version import normalize_version_string
 log = logging.getLogger(__name__)
 
 
+# FIXME: rename, really get_repo_version
 def get_content_version(content_data, version, content_versions, content_content_name):
     '''find and compare content version found in content_data dict
 
@@ -19,8 +20,8 @@ def get_content_version(content_data, version, content_versions, content_content
     '''
 
     log.debug('%s want ver: %s', content_content_name, version)
-    log.debug('%s vers avail: %s',
-              content_content_name, json.dumps(content_versions, indent=2))
+#    log.debug('%s vers avail: %s',
+#              content_content_name, json.dumps(content_versions, indent=2))
 
     # a list of tuples of (normalized_version, original_version) for building map of normalized version to original version
     normalized_versions = [(normalize_version_string(x), x) for x in content_versions]
@@ -32,8 +33,8 @@ def get_content_version(content_data, version, content_versions, content_content
 
     normalized_version = normalize_version_string(version)
 
-    log.debug('normalized_version: %s', normalized_version)
-    log.debug('avail_normalized_versions: %s', json.dumps(available_normalized_versions, indent=4))
+#    log.debug('normalized_version: %s', normalized_version)
+#    log.debug('avail_normalized_versions: %s', json.dumps(available_normalized_versions, indent=4))
 
     # we specified a particular version is required so look for it in available versions
     if version and version != 'master':

--- a/ansible_galaxy/models/content_version.py
+++ b/ansible_galaxy/models/content_version.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 from distutils.version import LooseVersion

--- a/ansible_galaxy_cli/cli/__init__.py
+++ b/ansible_galaxy_cli/cli/__init__.py
@@ -30,6 +30,7 @@ from abc import ABCMeta, abstractmethod
 
 from ansible_galaxy.config import defaults
 from ansible_galaxy.config import runtime
+from ansible_galaxy import display
 from ansible_galaxy.utils.text import to_text
 from ansible_galaxy_cli import exceptions as cli_exceptions
 
@@ -250,7 +251,7 @@ class CLI(six.with_metaclass(ABCMeta, object)):
     # FIXME: replace with output callback
     def display(self, *args, **kwargs):
         kwargs.pop('color', None)
-        print(*args, **kwargs)
+        display.display_callback(*args, **kwargs)
 
     @classmethod
     def tty_ify(cls, text):

--- a/ansible_galaxy_cli/cli/__init__.py
+++ b/ansible_galaxy_cli/cli/__init__.py
@@ -29,7 +29,6 @@ import six
 from abc import ABCMeta, abstractmethod
 
 from ansible_galaxy.config import defaults
-from ansible_galaxy.config import runtime
 from ansible_galaxy import display
 from ansible_galaxy.utils.text import to_text
 from ansible_galaxy_cli import exceptions as cli_exceptions
@@ -164,25 +163,6 @@ class CLI(six.with_metaclass(ABCMeta, object)):
             log.info(u"Using %s as config file", to_text(self.config_file_path))
         else:
             log.info(u"No config file found; using defaults")
-
-    # FIXME: doesn't make sense without real config yet
-    # NOTE: not used at the moment
-    def _validate_config(self):
-        # warn about deprecated config options
-        for deprecated in runtime.config.DEPRECATED:
-            name = deprecated[0]
-            why = deprecated[1]['why']
-            if 'alternatives' in deprecated[1]:
-                alt = ', use %s instead' % deprecated[1]['alternatives']
-            else:
-                alt = ''
-            ver = deprecated[1]['version']
-            # deprecation notice
-            log.warn("%s option, %s %s (version=%s)", name, why, alt, ver)
-
-        # warn about typing issues with configuration entries
-        for unable in runtime.config.UNABLE:
-            log.warn("Unable to set correct type for configuration entry: %s", unable)
 
     def validate_conflicts(self, vault_opts=False, runas_opts=False, fork_opts=False, vault_rekey_opts=False):
         ''' check for conflicting options '''

--- a/ansible_galaxy_cli/cli/__init__.py
+++ b/ansible_galaxy_cli/cli/__init__.py
@@ -111,6 +111,7 @@ class CLI(six.with_metaclass(ABCMeta, object)):
         self.action = None
         self.callback = callback
         self.log = logging.getLogger(__name__ + '.' + self.__class__.__name__)
+        self.config_file_path = None
 
     def set_action(self):
         """

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -104,7 +104,8 @@ class GalaxyCLI(cli.CLI):
             self.parser.add_option('-g', '--keep-scm-meta', dest='keep_scm_meta', action='store_true',
                                    default=False, help='Use tar instead of the scm archive option when packaging the role')
             self.parser.add_option('-t', '--type', dest='content_type', default="all", help='A type of Galaxy Content to install: role, module, etc')
-            # FIXME: rm when tests are updated
+            self.parser.add_option('--namespace', dest='namespace', default=None,
+                                   help='The namespace to use when installing content (required for installs from local scm repo or archives)')
         elif self.action == "remove":
             self.parser.set_usage("usage: %prog remove role1 role2 ...")
         elif self.action == "list":
@@ -313,6 +314,7 @@ class GalaxyCLI(cli.CLI):
             rc = install.install_content_specs(galaxy_context,
                                                content_specs=requested_content_specs,
                                                install_content_type=install_content_type,
+                                               namespace=self.options.namespace,
                                                display_callback=self.display,
                                                ignore_errors=self.options.ignore_errors,
                                                no_deps=self.options.no_deps,

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -33,6 +33,7 @@ from ansible_galaxy_cli import __version__ as galaxy_cli_version
 from ansible_galaxy.actions import install
 from ansible_galaxy.actions import info
 from ansible_galaxy.actions import init
+from ansible_galaxy.actions import list as list_action
 from ansible_galaxy.config import defaults
 from ansible_galaxy.config import config
 from ansible_galaxy_cli import exceptions as cli_exceptions
@@ -370,31 +371,15 @@ class GalaxyCLI(cli.CLI):
                 self.display("- %s, %s" % (name, version))
             else:
                 self.display("- the role %s was not found" % name)
-        else:
-            # show all valid roles in the roles_path directory
-            roles_path = self.options.roles_path
-            for path in roles_path:
-                role_path = os.path.expanduser(path)
-                if not os.path.exists(role_path):
-                    raise cli_exceptions.CliOptionsError("- the path %s does not exist. Please specify a valid path with --roles-path" % role_path)
-                elif not os.path.isdir(role_path):
-                    raise cli_exceptions.CliOptionsError("- %s exists, but it is not a directory. Please specify a valid path with --roles-path" % role_path)
-                path_files = os.listdir(role_path)
-                for path_file in path_files:
-                    role_full_path = os.path.join(role_path, path_file)
-                    log.debug('role_full_path: %s', role_full_path)
-                    gr = GalaxyContent(galaxy_context, path_file, path=role_full_path)
-                    log.debug('gr: %s', gr)
-                    log.debug('gr.metadata: %s', gr.metadata)
-                    if gr.metadata:
-                        install_info = gr.install_info
-                        version = None
-                        if install_info:
-                            version = install_info.get("version", None)
-                        if not version:
-                            version = "(unknown version)"
-                        self.display("- %s, %s" % (path_file, version))
-        return 0
+
+            return 0
+
+        log.debug('list')
+        roles_path = self.options.roles_path
+        # TODO: eventually, loop over content types
+        roles_path = [os.path.join(galaxy_context.content_path, 'roles')]
+
+        return list_action.list(galaxy_context, roles_path, display_callback=self.display)
 
     def execute_version(self):
         self.display('Ansible Galaxy CLI, version', galaxy_cli_version)

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -258,7 +258,8 @@ class GalaxyCLI(cli.CLI):
             # the user needs to specify a role
             raise cli_exceptions.CliOptionsError("- you must specify a user/role name")
 
-        content_path = self.options.roles_path
+        # content_path = self.options.roles_path
+        content_path = self.options.content_path
 
         log.debug('args=%s', self.args)
 
@@ -267,7 +268,8 @@ class GalaxyCLI(cli.CLI):
         content_specs = self.args
 
         # FIXME: rc?
-        return info.info_content_specs(galaxy_context, self.api, content_specs, content_path,
+        return info.info_content_specs(galaxy_context, self.api, content_specs,
+                                       #content_path,
                                        display_callback=self.display,
                                        offline=self.options.offline)
 

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -351,35 +351,20 @@ class GalaxyCLI(cli.CLI):
         lists the roles installed on the local system or matches a single role passed as an argument.
         """
 
-        if len(self.args) > 1:
-            raise cli_exceptions.CliOptionsError("- please specify only one role to list, or specify no roles to see a full list")
-
         galaxy_context = self._get_galaxy_context(self.options, self.config)
-
-        if len(self.args) == 1:
-            # show only the request role, if it exists
-            name = self.args.pop()
-            gr = GalaxyContent(galaxy_context, name)
-            if gr.metadata:
-                install_info = gr.install_info
-                version = None
-                if install_info:
-                    version = install_info.get("version", None)
-                if not version:
-                    version = "(unknown version)"
-                # show some more info about single roles here
-                self.display("- %s, %s" % (name, version))
-            else:
-                self.display("- the role %s was not found" % name)
-
-            return 0
-
-        log.debug('list')
-        roles_path = self.options.roles_path
-        # TODO: eventually, loop over content types
         roles_path = [os.path.join(galaxy_context.content_path, 'roles')]
 
-        return list_action.list(galaxy_context, roles_path, display_callback=self.display)
+        match_filter = list_action.match_all
+
+        # if len(self.args) == 1:
+        if self.args:
+            match_filter = list_action.MatchNames(self.args)
+
+        # TODO: eventually, loop over content types
+
+        return list_action.list(galaxy_context, roles_path,
+                                match_filter=match_filter,
+                                display_callback=self.display)
 
     def execute_version(self):
         self.display('Ansible Galaxy CLI, version', galaxy_cli_version)

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -26,7 +26,6 @@ import json
 import logging
 import os
 import sys
-import time
 
 from ansible_galaxy_cli import cli
 from ansible_galaxy_cli import __version__ as galaxy_cli_version
@@ -258,9 +257,6 @@ class GalaxyCLI(cli.CLI):
             # the user needs to specify a role
             raise cli_exceptions.CliOptionsError("- you must specify a user/role name")
 
-        # content_path = self.options.roles_path
-        content_path = self.options.content_path
-
         log.debug('args=%s', self.args)
 
         galaxy_context = self._get_galaxy_context(self.options, self.config)
@@ -269,7 +265,6 @@ class GalaxyCLI(cli.CLI):
 
         # FIXME: rc?
         return info.info_content_specs(galaxy_context, self.api, content_specs,
-                                       #content_path,
                                        display_callback=self.display,
                                        offline=self.options.offline)
 

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -35,12 +35,12 @@ from jinja2 import Environment, FileSystemLoader
 from ansible_galaxy_cli import cli
 from ansible_galaxy_cli import __version__ as galaxy_cli_version
 from ansible_galaxy.actions import install
+from ansible_galaxy.actions import info
 from ansible_galaxy.config import defaults
 from ansible_galaxy.config import config
 from ansible_galaxy_cli import exceptions as cli_exceptions
 from ansible_galaxy.models.context import GalaxyContext
 from ansible_galaxy.utils.text import to_text
-from ansible_galaxy.utils.content_name import parse_content_name
 
 # FIXME: importing class, fix name collision later or use this style
 # TODO: replace flat_rest_api with a OO interface
@@ -201,33 +201,6 @@ class GalaxyCLI(cli.CLI):
 
         self.execute()
 
-    def _display_content_info(self, content_info):
-        log.debug('content_info: %s', content_info)
-        print(content_info)
-        return content_info
-
-    # TODO: move to a repr for Role?
-    def _display_role_info(self, role_info):
-
-        text = [u"", u"Role: %s" % to_text(role_info['name'])]
-        text.append(u"\tdescription: %s" % role_info.get('description', ''))
-
-        for k in sorted(role_info.keys()):
-
-            if k in self.SKIP_INFO_KEYS:
-                continue
-
-            if isinstance(role_info[k], dict):
-                text.append(u"\t%s:" % (k))
-                for key in sorted(role_info[k].keys()):
-                    if key in self.SKIP_INFO_KEYS:
-                        continue
-                    text.append(u"\t\t%s: %s" % (key, role_info[k][key]))
-            else:
-                text.append(u"\t%s: %s" % (k, role_info[k]))
-
-        return u'\n'.join(text)
-
 ############################
 # execute actions
 ############################
@@ -330,56 +303,16 @@ class GalaxyCLI(cli.CLI):
 
         content_path = self.options.roles_path
 
-        data = ''
-
         log.debug('args=%s', self.args)
 
         galaxy_context = self._get_galaxy_context(self.options, self.config)
 
-        for content_spec in self.args:
+        content_specs = self.args
 
-            content_username, repo_name, content_name = parse_content_name(content_spec)
-
-            log.debug('content_spec=%s', content_spec)
-            log.debug('content_username=%s', content_username)
-            log.debug('repo_name=%s', repo_name)
-            log.debug('content_name=%s', content_name)
-
-            repo_name = repo_name or content_name
-            log.debug('repo_name2=%s', repo_name)
-
-            content_info = {'path': content_path}
-            gr = GalaxyContent(galaxy_context, content_spec)
-
-            install_info = gr.install_info
-            if install_info:
-                if 'version' in install_info:
-                    install_info['intalled_version'] = install_info['version']
-                    del install_info['version']
-                content_info.update(install_info)
-
-            remote_data = False
-            if not self.options.offline:
-                remote_data = self.api.lookup_content_repo_by_name(content_username, repo_name)
-
-            if remote_data:
-                content_info.update(remote_data)
-
-            if gr.metadata:
-                content_info.update(gr.metadata)
-
-            # role_spec = yaml_parse({'role': role})
-            # if role_spec:
-            #     role_info.update(role_spec)
-
-            data = self._display_content_info(content_info)
-            # data = self._display_role_info(content_info)
-            # FIXME: This is broken in both 1.9 and 2.0 as
-            # _display_role_info() always returns something
-            if not data:
-                data = u"\n- the content %s was not found" % content_spec
-
-        self.display(data)
+        # FIXME: rc?
+        return info.info_content_specs(galaxy_context, self.api, content_specs, content_path,
+                                       display_callback=self.display,
+                                       offline=self.options.offline)
 
     def execute_install(self):
         """

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -352,7 +352,7 @@ class GalaxyCLI(cli.CLI):
         """
 
         galaxy_context = self._get_galaxy_context(self.options, self.config)
-        roles_path = [os.path.join(galaxy_context.content_path, 'roles')]
+        # roles_path = [os.path.join(galaxy_context.content_path, 'roles')]
 
         match_filter = list_action.match_all
 
@@ -362,7 +362,7 @@ class GalaxyCLI(cli.CLI):
 
         # TODO: eventually, loop over content types
 
-        return list_action.list(galaxy_context, roles_path,
+        return list_action.list(galaxy_context, [galaxy_context.content_path],
                                 match_filter=match_filter,
                                 display_callback=self.display)
 

--- a/ansible_galaxy_cli/data/role_skeleton/apb/meta/main.yml.j2
+++ b/ansible_galaxy_cli/data/role_skeleton/apb/meta/main.yml.j2
@@ -1,4 +1,5 @@
 galaxy_info:
+  role_name: {{ role_name }}
   author: {{ author }}
   description: {{ description }}
   company: {{ company }}

--- a/ansible_galaxy_cli/data/role_skeleton/container/meta/main.yml.j2
+++ b/ansible_galaxy_cli/data/role_skeleton/container/meta/main.yml.j2
@@ -1,4 +1,5 @@
 galaxy_info:
+  role_name: {{ role_name }}
   author: {{ author }}
   description: {{ description }}
   company: {{ company }}

--- a/ansible_galaxy_cli/data/role_skeleton/default/meta/main.yml.j2
+++ b/ansible_galaxy_cli/data/role_skeleton/default/meta/main.yml.j2
@@ -1,4 +1,5 @@
 galaxy_info:
+  role_name: {{ role_name }}
   author: {{ author }}
   description: {{ description }}
   company: {{ company }}

--- a/ansible_galaxy_cli/data/role_skeleton/network/meta/main.yml.j2
+++ b/ansible_galaxy_cli/data/role_skeleton/network/meta/main.yml.j2
@@ -1,4 +1,5 @@
 galaxy_info:
+  role_name: {{ role_name }}
   author: {{ author }}
   description: {{ description }}
   company: {{ company }}

--- a/ansible_galaxy_cli/logger/setup.py
+++ b/ansible_galaxy_cli/logger/setup.py
@@ -77,6 +77,7 @@ DEFAULT_LOGGING_CONFIG = {
             'level': 'INFO',
             'handlers': DEFAULT_HANDLERS,
             # to log verbose debug level logging to http_file handler:
+            # 'propagate': False,
             # 'level': 'DEBUG',
             # 'handlers': ['http_file'],
         },

--- a/ansible_galaxy_cli/logger/setup.py
+++ b/ansible_galaxy_cli/logger/setup.py
@@ -74,11 +74,11 @@ DEFAULT_LOGGING_CONFIG = {
             'level': 'DEBUG'
         },
         'ansible_galaxy.flat_rest_api.api.(http)': {
-            # 'level': 'INFO',
-            # 'handlers': DEFAULT_HANDLERS,
+            'level': 'INFO',
+            'handlers': DEFAULT_HANDLERS,
             # to log verbose debug level logging to http_file handler:
-            'level': 'DEBUG',
-            'handlers': ['http_file'],
+            # 'level': 'DEBUG',
+            # 'handlers': ['http_file'],
         },
         'ansible_galaxy.archive.(extract)': {
             'level': 'INFO',

--- a/ansible_galaxy_cli/logger/setup.py
+++ b/ansible_galaxy_cli/logger/setup.py
@@ -74,11 +74,11 @@ DEFAULT_LOGGING_CONFIG = {
             'level': 'DEBUG'
         },
         'ansible_galaxy.flat_rest_api.api.(http)': {
-            'level': 'INFO',
-            'handlers': DEFAULT_HANDLERS,
+            # 'level': 'INFO',
+            # 'handlers': DEFAULT_HANDLERS,
             # to log verbose debug level logging to http_file handler:
-            # 'level': 'DEBUG',
-            # 'handlers': ['http_file'],
+            'level': 'DEBUG',
+            'handlers': ['http_file'],
         },
         'ansible_galaxy.archive.(extract)': {
             'level': 'INFO',

--- a/tests/ansible_galaxy/actions/conftest.py
+++ b/tests/ansible_galaxy/actions/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 
-from ansible_galaxy.models.context import GalaxyContext
 
 
 @pytest.fixture
@@ -10,4 +9,5 @@ def galaxy_context(tmpdir):
     server = {'url': 'http://localhost:8000',
               'ignore_certs': False}
     content = tmpdir.mkdir('content')
+    from ansible_galaxy.models.context import GalaxyContext
     return GalaxyContext(server=server, content_path=content.strpath)

--- a/tests/ansible_galaxy/actions/conftest.py
+++ b/tests/ansible_galaxy/actions/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+from ansible_galaxy.models.context import GalaxyContext
+
+
+@pytest.fixture
+def galaxy_context(tmpdir):
+    # tmp_content_path = tempfile.mkdtemp()
+    # FIXME: mock
+    server = {'url': 'http://localhost:8000',
+              'ignore_certs': False}
+    content = tmpdir.mkdir('content')
+    return GalaxyContext(server=server, content_path=content.strpath)

--- a/tests/ansible_galaxy/actions/test_info.py
+++ b/tests/ansible_galaxy/actions/test_info.py
@@ -13,16 +13,8 @@ def display_callback(msg, **kwargs):
     log.debug(msg)
 
 
-def _galaxy_context():
-    tmp_content_path = tempfile.mkdtemp()
-    # FIXME: mock
-    server = {'url': 'http://localhost:8000',
-              'ignore_certs': False}
-    return GalaxyContext(server=server, content_path=tmp_content_path)
-
-
-def test_info_empty():
-    ret = info.info_content_specs(_galaxy_context(),
+def test_info_empty(galaxy_context):
+    ret = info.info_content_specs(galaxy_context,
                                   # mock api
                                   mock.Mock(),
                                   [],
@@ -33,8 +25,8 @@ def test_info_empty():
     log.debug('ret: %s', ret)
 
 
-def test_info():
-    ret = info.info_content_specs(_galaxy_context(),
+def test_info(galaxy_context):
+    ret = info.info_content_specs(galaxy_context,
                                   # mock api
                                   mock.Mock(),
                                   ['namespace.repo.content'],

--- a/tests/ansible_galaxy/actions/test_info.py
+++ b/tests/ansible_galaxy/actions/test_info.py
@@ -1,0 +1,45 @@
+
+import logging
+import mock
+import tempfile
+
+from ansible_galaxy.actions import info
+from ansible_galaxy.models.context import GalaxyContext
+
+log = logging.getLogger(__name__)
+
+
+def display_callback(msg, **kwargs):
+    log.debug(msg)
+
+
+def _galaxy_context():
+    tmp_content_path = tempfile.mkdtemp()
+    # FIXME: mock
+    server = {'url': 'http://localhost:8000',
+              'ignore_certs': False}
+    return GalaxyContext(server=server, content_path=tmp_content_path)
+
+
+def test_info_empty():
+    ret = info.info_content_specs(_galaxy_context(),
+                                  # mock api
+                                  mock.Mock(),
+                                  [],
+                                  content_path=None,
+                                  display_callback=display_callback,
+                                  offline=True)
+
+    log.debug('ret: %s', ret)
+
+
+def test_info():
+    ret = info.info_content_specs(_galaxy_context(),
+                                  # mock api
+                                  mock.Mock(),
+                                  ['namespace.repo.content'],
+                                  content_path=None,
+                                  display_callback=display_callback,
+                                  offline=True)
+
+    log.debug('ret: %s', ret)

--- a/tests/ansible_galaxy/actions/test_info.py
+++ b/tests/ansible_galaxy/actions/test_info.py
@@ -18,7 +18,6 @@ def test_info_empty(galaxy_context):
                                   # mock api
                                   mock.Mock(),
                                   [],
-                                  content_path=None,
                                   display_callback=display_callback,
                                   offline=True)
 
@@ -30,7 +29,6 @@ def test_info(galaxy_context):
                                   # mock api
                                   mock.Mock(),
                                   ['namespace.repo.content'],
-                                  content_path=None,
                                   display_callback=display_callback,
                                   offline=True)
 

--- a/tests/ansible_galaxy/actions/test_init.py
+++ b/tests/ansible_galaxy/actions/test_init.py
@@ -1,0 +1,31 @@
+import logging
+import os
+import tempfile
+
+from ansible_galaxy.actions import init
+
+log = logging.getLogger(__name__)
+
+
+def display_callback(msg, **kwargs):
+    log.debug(msg)
+
+
+def test_init():
+    role_name = 'test-role'
+    # FIXME: needs lots of mocking
+    init_path = tempfile.mkdtemp()
+    role_path = os.path.join(init_path, role_name)
+    role_skeleton_path = tempfile.mkdtemp()
+    skeleton_ignore_expressions = []
+    role_type = 'default'
+    ret = init.init(role_name,
+                    init_path,
+                    role_path,
+                    False,  # force
+                    role_skeleton_path,
+                    skeleton_ignore_expressions,
+                    role_type,
+                    display_callback=display_callback)
+
+    log.debug('ret: %s', ret)

--- a/tests/ansible_galaxy/actions/test_init.py
+++ b/tests/ansible_galaxy/actions/test_init.py
@@ -11,12 +11,13 @@ def display_callback(msg, **kwargs):
     log.debug(msg)
 
 
-def test_init():
+def test_init(tmpdir):
     role_name = 'test-role'
     # FIXME: needs lots of mocking
-    init_path = tempfile.mkdtemp()
-    role_path = os.path.join(init_path, role_name)
-    role_skeleton_path = tempfile.mkdtemp()
+    init_path = tmpdir.mkdir('init_path')
+    role_path = init_path.join(role_name).strpath
+    # role_path = os.path.join(init_path, role_name)
+    role_skeleton_path = tmpdir.mkdir('role_skeleton').strpath
     skeleton_ignore_expressions = []
     role_type = 'default'
     ret = init.init(role_name,

--- a/tests/ansible_galaxy/actions/test_init.py
+++ b/tests/ansible_galaxy/actions/test_init.py
@@ -1,6 +1,7 @@
 import logging
 import os
-import tempfile
+
+import pytest
 
 from ansible_galaxy.actions import init
 
@@ -11,7 +12,22 @@ def display_callback(msg, **kwargs):
     log.debug(msg)
 
 
-def test_init(tmpdir):
+role_types = \
+    [
+        'default',
+        'container',
+        'apb',
+        'network',
+    ]
+
+
+@pytest.fixture(scope='module',
+                params=role_types)
+def role_type(request):
+    yield request.param
+
+
+def test_init(tmpdir, role_type):
     role_name = 'test-role'
     # FIXME: needs lots of mocking
     init_path = tmpdir.mkdir('init_path')
@@ -19,7 +35,6 @@ def test_init(tmpdir):
     # role_path = os.path.join(init_path, role_name)
     role_skeleton_path = tmpdir.mkdir('role_skeleton').strpath
     skeleton_ignore_expressions = []
-    role_type = 'default'
     ret = init.init(role_name,
                     init_path,
                     role_path,

--- a/tests/ansible_galaxy/actions/test_install.py
+++ b/tests/ansible_galaxy/actions/test_install.py
@@ -1,0 +1,82 @@
+
+import logging
+import mock
+import tempfile
+
+from ansible_galaxy.actions import install
+from ansible_galaxy.models.context import GalaxyContext
+from ansible_galaxy.flat_rest_api.content import GalaxyContent
+
+log = logging.getLogger(__name__)
+
+
+def display_callback(msg, **kwargs):
+    log.debug(msg)
+
+
+def _galaxy_context():
+    tmp_content_path = tempfile.mkdtemp()
+    # FIXME: mock
+    server = {'url': 'http://localhost:8000',
+              'ignore_certs': False}
+    return GalaxyContext(server=server, content_path=tmp_content_path)
+
+
+def test_install_contents_empty_contents():
+    contents = []
+
+    galaxy_context = _galaxy_context()
+    ret = install.install_contents(galaxy_context,
+                                   requested_contents=contents,
+                                   install_content_type='role',
+                                   display_callback=display_callback)
+
+    log.debug('ret: %s', ret)
+    assert ret == 0
+
+
+def test_install_contents():
+    contents = [mock.Mock(content_type='role',
+                          # FIXME: install bases update on install_info existing, so will fail for other content
+                          install_info=None,
+                          metadata={'content_type': 'role'})]
+
+    galaxy_context = _galaxy_context()
+    ret = install.install_contents(galaxy_context,
+                                   requested_contents=contents,
+                                   install_content_type='role',
+                                   display_callback=display_callback)
+
+    log.debug('ret: %s', ret)
+    assert ret == 0
+
+
+def test_install_contents_module():
+    contents = [mock.Mock(content_type='module',
+                          # FIXME: install bases update on install_info existing, so will fail for other content
+                          install_info=None,
+                          metadata={'content_type': 'module'})]
+
+    galaxy_context = _galaxy_context()
+    ret = install.install_contents(galaxy_context,
+                                   requested_contents=contents,
+                                   install_content_type='module',
+                                   display_callback=display_callback)
+
+    log.debug('ret: %s', ret)
+    # assert ret == 0
+
+
+def test_build_content_set_empty():
+    ret = install._build_content_set([], 'role', _galaxy_context())
+    log.debug('ret: %s', ret)
+    assert ret == []
+
+
+# even though 'blrp' isnt a valid spec, _build_content_set return something for now
+def test_build_content_set_malformed():
+    ret = install._build_content_set(['blrp'], 'role', _galaxy_context())
+    log.debug('ret: %s', ret)
+    # TODO: eventually this should fail, depending on where it looks it up
+    assert isinstance(ret[0], GalaxyContent)
+    assert ret[0].name == 'blrp'

--- a/tests/ansible_galaxy/actions/test_install.py
+++ b/tests/ansible_galaxy/actions/test_install.py
@@ -22,10 +22,9 @@ def _galaxy_context():
     return GalaxyContext(server=server, content_path=tmp_content_path)
 
 
-def test_install_contents_empty_contents():
+def test_install_contents_empty_contents(galaxy_context):
     contents = []
 
-    galaxy_context = _galaxy_context()
     ret = install.install_contents(galaxy_context,
                                    requested_contents=contents,
                                    install_content_type='role',
@@ -35,13 +34,12 @@ def test_install_contents_empty_contents():
     assert ret == 0
 
 
-def test_install_contents():
+def test_install_contents(galaxy_context):
     contents = [mock.Mock(content_type='role',
                           # FIXME: install bases update on install_info existing, so will fail for other content
                           install_info=None,
                           metadata={'content_type': 'role'})]
 
-    galaxy_context = _galaxy_context()
     ret = install.install_contents(galaxy_context,
                                    requested_contents=contents,
                                    install_content_type='role',
@@ -51,13 +49,12 @@ def test_install_contents():
     assert ret == 0
 
 
-def test_install_contents_module():
+def test_install_contents_module(galaxy_context):
     contents = [mock.Mock(content_type='module',
                           # FIXME: install bases update on install_info existing, so will fail for other content
                           install_info=None,
                           metadata={'content_type': 'module'})]
 
-    galaxy_context = _galaxy_context()
     ret = install.install_contents(galaxy_context,
                                    requested_contents=contents,
                                    install_content_type='module',
@@ -67,15 +64,15 @@ def test_install_contents_module():
     # assert ret == 0
 
 
-def test_build_content_set_empty():
-    ret = install._build_content_set([], 'role', _galaxy_context())
+def test_build_content_set_empty(galaxy_context):
+    ret = install._build_content_set([], 'role', galaxy_context)
     log.debug('ret: %s', ret)
     assert ret == []
 
 
 # even though 'blrp' isnt a valid spec, _build_content_set return something for now
-def test_build_content_set_malformed():
-    ret = install._build_content_set(['blrp'], 'role', _galaxy_context())
+def test_build_content_set_malformed(galaxy_context):
+    ret = install._build_content_set(['blrp'], 'role', galaxy_context)
     log.debug('ret: %s', ret)
     # TODO: eventually this should fail, depending on where it looks it up
     assert isinstance(ret[0], GalaxyContent)

--- a/tests/ansible_galaxy/actions/test_list.py
+++ b/tests/ansible_galaxy/actions/test_list.py
@@ -1,0 +1,52 @@
+import logging
+import os
+import tempfile
+
+from ansible_galaxy import exceptions
+from ansible_galaxy.actions import list as list_action
+from ansible_galaxy.models.context import GalaxyContext
+
+log = logging.getLogger(__name__)
+
+
+def display_callback(msg, **kwargs):
+    log.debug(msg)
+
+
+def _galaxy_context():
+    tmp_content_path = tempfile.mkdtemp()
+    # FIXME: mock
+    server = {'url': 'http://localhost:8000',
+              'ignore_certs': False}
+    return GalaxyContext(server=server, content_path=tmp_content_path)
+
+
+def test_list_empty_roles_paths():
+
+    galaxy_context = _galaxy_context()
+    role_paths = []
+    try:
+        list_action.list(galaxy_context,
+                         role_paths,
+                         display_callback=display_callback)
+    except exceptions.GalaxyError as e:
+        log.debug(e, exc_info=True)
+        raise
+        return
+
+
+def test_list_no_roles_dir():
+
+    galaxy_context = _galaxy_context()
+    role_paths = [os.path.join(galaxy_context.content_path, 'roles')]
+    try:
+        list_action.list(galaxy_context,
+                         role_paths,
+                         display_callback=display_callback)
+    except exceptions.GalaxyError as e:
+        log.debug(e, exc_info=True)
+        return
+
+    assert False, 'Expected a GalaxyError for no dir %s but didnt get one' % role_paths
+    # log.debug('ret: %s', ret)
+

--- a/tests/ansible_galaxy/actions/test_list.py
+++ b/tests/ansible_galaxy/actions/test_list.py
@@ -1,10 +1,8 @@
 import logging
 import os
-import tempfile
 
 from ansible_galaxy import exceptions
 from ansible_galaxy.actions import list as list_action
-from ansible_galaxy.models.context import GalaxyContext
 
 log = logging.getLogger(__name__)
 
@@ -13,17 +11,10 @@ def display_callback(msg, **kwargs):
     log.debug(msg)
 
 
-def _galaxy_context():
-    tmp_content_path = tempfile.mkdtemp()
-    # FIXME: mock
-    server = {'url': 'http://localhost:8000',
-              'ignore_certs': False}
-    return GalaxyContext(server=server, content_path=tmp_content_path)
+def test_list_empty_roles_paths(galaxy_context):
 
+    # galaxy_context = _galaxy_context(tmpdir)
 
-def test_list_empty_roles_paths():
-
-    galaxy_context = _galaxy_context()
     role_paths = []
     try:
         list_action.list(galaxy_context,
@@ -35,9 +26,7 @@ def test_list_empty_roles_paths():
         return
 
 
-def test_list_no_roles_dir():
-
-    galaxy_context = _galaxy_context()
+def test_list_no_roles_dir(galaxy_context):
     role_paths = [os.path.join(galaxy_context.content_path, 'roles')]
     try:
         list_action.list(galaxy_context,
@@ -49,4 +38,3 @@ def test_list_no_roles_dir():
 
     assert False, 'Expected a GalaxyError for no dir %s but didnt get one' % role_paths
     # log.debug('ret: %s', ret)
-

--- a/tests/ansible_galaxy/fetch/test_local_file.py
+++ b/tests/ansible_galaxy/fetch/test_local_file.py
@@ -12,8 +12,9 @@ def test_local_file_fetch():
     log.debug('tmp_file.name=%s tmp_file=%s', tmp_file.name, tmp_file)
 
     local_fetch = local_file.LocalFileFetch(tmp_file.name)
-    local_fetch.fetch()
+    results = local_fetch.fetch()
 
+    log.debug('results: %s', results)
     local_fetch.cleanup()
 
     # LocalFileFetch is acting directly on an existing file, so it's cleanup

--- a/tests/ansible_galaxy/test_archive.py
+++ b/tests/ansible_galaxy/test_archive.py
@@ -2,8 +2,10 @@
 import logging
 import tarfile
 import tempfile
+import mock
 
 from ansible_galaxy import archive
+from ansible_galaxy.models.content import GalaxyContentMeta
 
 log = logging.getLogger(__name__)
 
@@ -23,6 +25,46 @@ def test_find_content_type_subdirs_empty():
     assert isinstance(res, list)
     assert res == []
     assert not res
+
+
+foo = {'content_archive_type': 'multi-content',
+#       'content_meta': GalaxyContentMeta(name=alikins.ansible-testing-content, version=3.1.0, src=alikins.ansible-testing-content, scm=None, content_type=all, content_dir=None, content_sub_dir=None, path=/home/adrian/.ansible/content, requires_meta_main=None),
+       'content_type': None,
+       'content_type_requires_meta': True,
+       'display_callback': None,
+       'extract_to_path': '/home/adrian/.ansible/content',
+       'file_name': None,
+ #      'files_to_extract': [<TarInfo 'ansible-testing-content-3.1.0/library/elasticsearch_plugin.py' at 0x7f5b549c9c90>,
+ #                           <TarInfo 'ansible-testing-content-3.1.0/library/riak.py' at 0x7f5b549c9e50>],
+       'force_overwrite': True,
+       'install_all_content': False,
+       'install_content_type': 'module',
+       'parent_dir': None,
+ #      'tar_file_obj': <tarfile.TarFile object at 0x7f5b549c9950>
+       }
+
+
+def test_extract_by_content_type():
+    # tar_file_obj = tarfile.TarFile()
+    members = [tarfile.TarInfo(name='foo')]
+    mock_tar_file_obj = mock.Mock(members=members)
+    res = archive.extract_by_content_type(tar_file_obj=mock_tar_file_obj,
+                                          parent_dir=None,
+                                          content_meta=GalaxyContentMeta(name="alikins.ansible-testing-content",
+                                                                         version="3.1.0",
+                                                                         src="alikins.ansible-testing-content",
+                                                                         scm=None,
+                                                                         content_type="all",
+                                                                         content_dir=None,
+                                                                         content_sub_dir=None,
+                                                                         path="/home/adrian/.ansible/content",
+                                                                         requires_meta_main=None),
+                                          install_content_type="module",
+                                          install_all_content=False,
+                                          files_to_extract=members,
+                                          extract_to_path='/home/adrian/.ansible/content')
+
+    log.debug('res: %s', res)
 
 
 tar_example1 = [

--- a/tests/ansible_galaxy_cli/cli/data/role_skeleton/meta/main.yml.j2
+++ b/tests/ansible_galaxy_cli/cli/data/role_skeleton/meta/main.yml.j2
@@ -1,4 +1,5 @@
 galaxy_info:
+  role_name: {{ role_name }}
   author: {{ author }}
   description: {{ description }}
   company: {{ company }}

--- a/tests/ansible_galaxy_cli/cli/test_galaxy_upstream.py
+++ b/tests/ansible_galaxy_cli/cli/test_galaxy_upstream.py
@@ -134,21 +134,6 @@ class TestGalaxy(unittest.TestCase):
         galaxy_cli = GalaxyCLI(args=self.default_args)
         self.assertTrue(isinstance(galaxy_cli, GalaxyCLI))
 
-    def test_display_min(self):
-        gc = GalaxyCLI(args=self.default_args)
-        role_info = {'name': 'some_role_name'}
-        display_result = gc._display_role_info(role_info)
-        self.assertTrue(display_result.find('some_role_name') > -1)
-
-    def test_display_galaxy_info(self):
-        gc = GalaxyCLI(args=self.default_args)
-        galaxy_info = {}
-        role_info = {'name': 'some_role_name',
-                     'galaxy_info': galaxy_info}
-        display_result = gc._display_role_info(role_info)
-        if display_result.find('\n\tgalaxy_info:') == -1:
-            self.fail('Expected galaxy_info to be indented once')
-
     def test_run(self):
         ''' verifies that the GalaxyCLI object's api is created and that execute() is called. '''
         gc = GalaxyCLI(args=["ansible-galaxy", "install", "--ignore-errors", "imaginary_role"])

--- a/tests/ansible_galaxy_cli/cli/test_galaxy_upstream.py
+++ b/tests/ansible_galaxy_cli/cli/test_galaxy_upstream.py
@@ -149,7 +149,7 @@ class TestGalaxy(unittest.TestCase):
 
     def test_execute_remove(self):
         # installing role
-        gc = GalaxyCLI(args=["ansible-galaxy", "content-install", "-p", self.role_path, "-r", self.role_req, '--force'])
+        gc = GalaxyCLI(args=["ansible-galaxy", "install", "-p", self.role_path, "-r", self.role_req, '--force'])
         gc.parse()
         gc.run()
 

--- a/tests/use-cases.sh
+++ b/tests/use-cases.sh
@@ -52,16 +52,16 @@ tree ~/.ansible/content
 
 # install role
 rm -rf ~/.ansible/content
-mazer install alikins.ansible-role-awx
+mazer install alikins.role-awx
 tree ~/.ansible/content
 [ -d ~/.ansible/content/roles ]
-[ -d ~/.ansible/content/roles/alikins.ansible-role-awx ]
-[ -d ~/.ansible/content/roles/alikins.ansible-role-awx/meta ]
-[ -f ~/.ansible/content/roles/alikins.ansible-role-awx/meta/main.yml ]
-[ -d ~/.ansible/content/roles/alikins.ansible-role-awx/tasks ]
-[ -f ~/.ansible/content/roles/alikins.ansible-role-awx/tasks/main.yml ]
-[ -d ~/.ansible/content/roles/alikins.ansible-role-awx/vars ]
-[ -f ~/.ansible/content/roles/alikins.ansible-role-awx/vars/RedHat.yml ]
+[ -d ~/.ansible/content/roles/alikins.role-awx ]
+[ -d ~/.ansible/content/roles/alikins.role-awx/meta ]
+[ -f ~/.ansible/content/roles/alikins.role-awx/meta/main.yml ]
+[ -d ~/.ansible/content/roles/alikins.role-awx/tasks ]
+[ -f ~/.ansible/content/roles/alikins.role-awx/tasks/main.yml ]
+[ -d ~/.ansible/content/roles/alikins.role-awx/vars ]
+[ -f ~/.ansible/content/roles/alikins.role-awx/vars/RedHat.yml ]
 
 
 
@@ -128,7 +128,7 @@ tree ~/.ansible/content
 
 # install all from a scm url
 rm -rf ~/.ansible/content
-ansible-galaxy-cli install  git+https://github.com/atestuseraccount/ansible-testing-content.git
+mazer install  git+https://github.com/atestuseraccount/ansible-testing-content.git
 tree ~/.ansible/content
 
 # install from a scm url again without cleaning up (should fail)
@@ -259,17 +259,18 @@ mazer install -t module git+https://github.com/atestuseraccount/ansible-testing-
 
 # The following uses the Galaxy name to install the latest version of the role:
 
-mazer install alikins.ansible-role-awx
+# mazer install alikins.role-awx
+mazer install alikins.role-awx
 
 # Here we use the SCM+URL convention to install the latest version:
-mazer install git+https://github.com/geerlingguy/ansible-role-awx.git
+mazer install git+https://github.com/geerlingguy/role-awx.git
 
 # Install a specific version
 # Using the Galaxy name
 
 # Using the Galaxy name, the version can be passed using the following two methods:
 
-mazer install alikins.ansible-role-awx,1.0.0
+mazer install alikins.role-awx,1.0.0
 mazer install alikins.awx,version=1.0.0
 
 #Using the SCM+URL convention, the version can be passed using the following two methods:


### PR DESCRIPTION
##### SUMMARY
Start extracting the logic embedded in ansible_galaxy_cli/cli/galaxy.py into 
ansible_galaxy/actions/install.py etc

With the intention of eventually making ansible_galaxy_cli.cli.galaxy just cli parsing
and setup stuff, so that the ansible_galaxy api can have high level entry points.


(and a whole lot of other misc stuff, some related, some not)
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### GALAXY CLI VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
Ansible Galaxy CLI, version 0.1.0
Linux, newswoop, 4.16.6-202.fc27.x86_64, #1 SMP Wed May 2 00:09:32 UTC 2018, x86_64
3.6.5 (default, Apr  4 2018, 15:01:18) 
[GCC 7.3.1 20180303 (Red Hat 7.3.1-5)] /home/adrian/venvs/galaxy-cli-py3/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

