### PR TITLE
Make sure the http method for api request is logged

### DIFF
--- a/ansible_galaxy/archive.py
+++ b/ansible_galaxy/archive.py
@@ -294,7 +294,6 @@ def extract_file(tar_file, file_to_extract):
         return None
 
     # TODO: raise from up a level in the stack?
-    log.debug('dest_path %s', os.path.join(dest_dir, dest_filename))
     dest_path = os.path.join(dest_dir, dest_filename)
     if os.path.exists(dest_path):
         if not force_overwrite:

--- a/ansible_galaxy_cli/logger/setup.py
+++ b/ansible_galaxy_cli/logger/setup.py
@@ -9,7 +9,7 @@ LOG_FILE = os.path.expandvars(os.path.expanduser('~/.ansible/mazer.log')),
 DEFAULT_CONSOLE_LEVEL = os.getenv('MAZER_LOG_LEVEL', 'WARNING').upper()
 DEFAULT_LEVEL = 'DEBUG'
 
-DEFAULT_DEBUG_FORMAT = '[%(asctime)s,%(msecs)03d %(process)05d %(levelname)-0.1s] %(name)s %(funcName)s:%(lineno)d - %(message)s'
+DEFAULT_DEBUG_FORMAT = '[%(asctime)s,%(msecs)03d %(process)05d %(levelname)-0.1s] %(name)s %(funcName)s:%(lineno)-3d - %(message)s'
 # DEFAULT_HANDLERS = ['console', 'file']
 DEFAULT_HANDLERS = ['file']
 
@@ -29,7 +29,7 @@ DEFAULT_LOGGING_CONFIG = {
             'format': '%(message)s',
         },
         'file_verbose': {
-            'format': '[%(asctime)s %(process)05d %(levelname)-0.1s] %(name)s %(funcName)s:%(lineno)d - %(message)s',
+            'format': '[%(asctime)s %(process)05d %(levelname)-0.1s] %(name)s %(funcName)s:%(lineno)-3d - %(message)s',
         },
     },
 
@@ -77,7 +77,7 @@ DEFAULT_LOGGING_CONFIG = {
             'level': 'INFO',
             'handlers': DEFAULT_HANDLERS,
             # to log verbose debug level logging to http_file handler:
-            # 'propagate': False,
+            'propagate': False,
             # 'level': 'DEBUG',
             # 'handlers': ['http_file'],
         },


### PR DESCRIPTION
##### SUMMARY

Make sure the http method for api request is logged

Also double quote the method and url ("GET /foo/bar") in
the logs.

Update some uses of _call_galaxy to specify the http_method
they use instead of the implicit/default 'GET' or 'POST' if
args are passed

justified the lineno in log format to 3 wide

makes url logs a little easier to read

<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request



##### GALAXY CLI VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
Ansible Galaxy CLI, version 0.1.0
Linux, newswoop, 4.16.6-202.fc27.x86_64, #1 SMP Wed May 2 00:09:32 UTC 2018, x86_64
2.7.14 (default, Mar 14 2018, 13:36:31) 
[GCC 7.3.1 20180303 (Red Hat 7.3.1-5)] /home/adrian/venvs/galaxy-py27/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

