### PR TITLE
Fix the path used when checking if a content exists.

### DIFF
--- a/ansible_galaxy/archive.py
+++ b/ansible_galaxy/archive.py
@@ -294,9 +294,11 @@ def extract_file(tar_file, file_to_extract):
         return None
 
     # TODO: raise from up a level in the stack?
-    if os.path.exists(dest_dir):
+    log.debug('dest_path %s', os.path.join(dest_dir, dest_filename))
+    dest_path = os.path.join(dest_dir, dest_filename)
+    if os.path.exists(dest_path):
         if not force_overwrite:
-            message = "The Galaxy content %s appears to already exist." % dest_dir
+            message = "The Galaxy content %s appears to already exist." % dest_path
             raise exceptions.GalaxyClientError(message)
 
     # change the tar file member name in place to just the filename ('myfoo.py') so that extract places that file in


### PR DESCRIPTION
##### SUMMARY
The 'does this content exist already' test was not using the full path, so the second 
file in ~/.ansible/content/* would fail.

##### ISSUE TYPE

 - Bugfix Pull Request
 - Docs Pull Request


##### GALAXY CLI VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
Ansible Galaxy CLI, version0.1.0
Linux, newswoop, 4.16.6-202.fc27.x86_64, #1 SMP Wed May 2 00:09:32 UTC 2018, x86_64
3.6.5 (default, Apr  4 2018, 15:01:18) 
[GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]/home/adrian/venvs/galaxy-cli-py3/bin/python
Using /home/adrian/.ansible/mazer.yml as config file

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

