### PR TITLE
Raise GalaxyArchiveError on extract_file if missing

### DIFF
--- a/ansible_galaxy/archive.py
+++ b/ansible_galaxy/archive.py
@@ -299,10 +299,17 @@ def extract_file(tar_file, file_to_extract):
             message = "The Galaxy content %s appears to already exist." % dest_dir
             raise exceptions.GalaxyClientError(message)
 
+    try:
+        tar_file.getmember(archive_member.name)
+    except KeyError:
+        raise exceptions.GalaxyArchiveError('The archive "%s" has no file "%s"' % (tar_file.name, archive_member.name),
+                                            archive_path=tar_file.name)
+
     # change the tar file member name in place to just the filename ('myfoo.py') so that extract places that file in
     # dest_dir directly instead of using adding the archive path as well
     # like '$dest_dir/archive-roles/library/myfoo.py'
     archive_member.name = dest_filename
+
     tar_file.extract(archive_member, dest_dir)
 
     installed_path = os.path.join(dest_dir, dest_filename)

--- a/ansible_galaxy/exceptions/__init__.py
+++ b/ansible_galaxy/exceptions/__init__.py
@@ -39,3 +39,12 @@ class GalaxyConfigFileError(GalaxyClientError):
         config_file_path = kwargs.pop('config_file_path', None)
         super(GalaxyConfigFileError, self).__init__(*args, **kwargs)
         self.config_file_path = config_file_path
+
+
+class GalaxyArchiveError(GalaxyClientError):
+    '''Raised for errors related to content archive (tar) files'''
+
+    def __init__(self, *args, **kwargs):
+        archive_path = kwargs.pop('archive_path', None)
+        super(GalaxyArchiveError, self).__init__(*args, **kwargs)
+        self.archive_path = archive_path


### PR DESCRIPTION
update test_archive to use it, and other fixes to
test cases.

flake8 fixups

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request



##### GALAXY CLI VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
Ansible Galaxy CLI, version0.1.0
Linux, newswoop, 4.16.6-202.fc27.x86_64, #1 SMP Wed May 2 00:09:32 UTC 2018, x86_64
3.6.5 (default, Apr  4 2018, 15:01:18) 
[GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]/home/adrian/venvs/galaxy-cli-py3/bin/python
Using /home/adrian/.ansible/mazer.yml as config file

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

