### PR TITLE
split archive.py, more tests

### DIFF
--- a/ansible_galaxy/archive.py
+++ b/ansible_galaxy/archive.py
@@ -6,8 +6,6 @@
 import fnmatch
 import logging
 import os
-import yaml
-
 
 from ansible_galaxy import display
 from ansible_galaxy import exceptions
@@ -26,21 +24,6 @@ log = logging.getLogger(__name__)
 # extract_content_by_role_name(role_name)
 
 # def content_type_match(content_type, member_path):
-
-
-# FIXME: mv to AnsibleGalaxyMetadata
-def load_archive_role_metadata(tar_file_obj, meta_file_path):
-    metadata = None
-    if not meta_file_path:
-        return None
-
-    try:
-        metadata = yaml.safe_load(tar_file_obj.extractfile(meta_file_path))
-    except Exception:
-        log.debug('unable to extract and yaml load role meta_file=%s tar_file_obj=%s',
-                  meta_file_path, tar_file_obj)
-
-    return metadata
 
 
 def tar_info_content_name_match(tar_info, content_name, content_path=None, match_pattern=None):
@@ -93,16 +76,6 @@ def filter_members_by_content_type(tar_file_members,
     # log.debug('member_matches=%s', pprint.pformat([x.name for x in member_matches]))
 
     return member_matches
-
-
-def filter_members_by_content_meta(tar_file_members, content_archive_type, content_meta):
-    if not content_meta:
-        log.debug('no content_meta info')
-        return []
-
-    content_type = content_meta.content_type
-
-    return filter_members_by_content_type(tar_file_members, content_archive_type, content_type)
 
 
 def extract_file(tar_file, file_to_extract):

--- a/ansible_galaxy/archive.py
+++ b/ansible_galaxy/archive.py
@@ -9,21 +9,16 @@ import os
 import yaml
 
 
+from ansible_galaxy import display
 from ansible_galaxy import exceptions
-from ansible_galaxy.models.content import CONTENT_TYPE_DIR_MAP, CONTENT_TYPES
+from ansible_galaxy.models import content
 from ansible_galaxy.models import content_repository
 
 log = logging.getLogger(__name__)
 
 # pass in list of tarinfo of paths to extract
 # pass in a map of tar member paths -> dest paths, built separately?
-#  (based on content_type and CONTENT_TYPE_DIR_MAP etc)
-
-
-def default_display_callback(*args, **kwargs):
-    # log.debug('args=%s, kwargs=%s', args, kwargs)
-
-    print(''.join(args))
+#  (based on content_type and content.CONTENT_TYPE_DIR_MAP etc)
 
 # for plugins and everything except roles
 # extract_content_by_content_type(content_type, base_path=None)
@@ -32,120 +27,6 @@ def default_display_callback(*args, **kwargs):
 # extract_content_by_role_name(role_name)
 
 # def content_type_match(content_type, member_path):
-
-
-# TODO:
-
-# TODO: better place to define?
-META_MAIN = os.path.join('meta', 'main.yml')
-GALAXY_FILE = 'ansible-galaxy.yml'
-APB_YAML = 'apb.yml'
-
-
-class ContentArchiveMetadataFiles(object):
-    def __init__(self):
-        self.meta_main_yml = None
-        self.meta_main_parent_dir = None
-
-        self.galaxy_file = None
-        self.apb_yaml = None
-
-        # FIXME: doesnt belong here
-        self.archive_parent_dir = None
-
-
-# TODO/FIXME: try to make sense of this and find_archive_parent_dir
-def find_archive_metadata(archive_members):
-    '''Try to find the paths to the archives meta data files
-
-    Aka, meta/main.yml or ansible-galaxy.yml.
-
-    Also, while we are at it, try to find the archive parent
-    dir.'''
-
-    meta_file = None
-    galaxy_file = None
-
-    meta_parent_dir = None
-    archive_parent_dir = None
-
-    apb_yaml_file = None
-
-    for member in archive_members:
-        if fnmatch.fnmatch(member.name, '*/%s' % APB_YAML):
-            log.debug('apb.yml member: %s', member)
-            apb_yaml_file = member.name
-
-        if META_MAIN in member.name or GALAXY_FILE in member.name:
-            # Look for parent of meta/main.yml
-            # Due to possibility of sub roles each containing meta/main.yml
-            # look for shortest length parent
-            meta_parent_dir = os.path.dirname(os.path.dirname(member.name))
-            if not meta_file:
-                archive_parent_dir = meta_parent_dir
-                if GALAXY_FILE in member.name:
-                    galaxy_file = member
-                else:
-                    meta_file = member
-            else:
-                # self.log.debug('meta_parent_dir: %s archive_parent_dir: %s len(m): %s len(a): %s member.name: %s',
-                #               meta_parent_dir, archive_parent_dir,
-                #               len(meta_parent_dir),
-                #               len(archive_parent_dir),
-                #               member.name)
-                if len(meta_parent_dir) < len(archive_parent_dir):
-                    archive_parent_dir = meta_parent_dir
-                    meta_file = member
-                    if GALAXY_FILE in member.name:
-                        galaxy_file = member
-                    else:
-                        meta_file = member
-
-    log.debug('apb_yaml_file: %s', apb_yaml_file)
-    # FIXME: return a real type/object for archive metadata
-    return (meta_file,
-            meta_parent_dir,
-            galaxy_file,
-            apb_yaml_file)
-
-
-def find_archive_parent_dir(archive_members, content_type, content_dir):
-    # archive_parent_dir wasn't found when checking for metadata files
-    archive_parent_dir = None
-
-    shortest_dir = None
-    for member in archive_members:
-        # This is either a new-type Galaxy Content that doesn't have an
-        # ansible-galaxy.yml file and the type desired is specified and
-        # we check parent dir based on the correct subdir existing or
-        # we need to just scan the subdirs heuristically and figure out
-        # what to do
-        member_dir = os.path.dirname(os.path.dirname(member.name))
-        shortest_dir = shortest_dir or member_dir
-
-        if len(member_dir) < len(shortest_dir):
-            shortest_dir = member_dir
-
-        if content_type != "all":
-            if content_dir and content_dir in member.name:
-                archive_parent_dir = os.path.dirname(member.name)
-                return archive_parent_dir
-        else:
-            for plugin_dir in CONTENT_TYPE_DIR_MAP.values():
-                if plugin_dir in member.name:
-                    archive_parent_dir = os.path.dirname(member.name)
-                    return archive_parent_dir
-
-    if content_type not in CONTENT_TYPES:
-        log.debug('did not find a content_dir or plugin_dir, so using shortest_dir %s for archive_parent_dir', shortest_dir)
-        return shortest_dir
-
-    # TODO: archive format exception?
-    msg = "No content metadata provided, nor content directories found for content_type: %s" % \
-        content_type
-    log.debug('content_type: %s', content_type)
-    log.debug('content_dir: %s', content_dir)
-    raise exceptions.GalaxyClientError(msg)
 
 
 # FIXME: mv to AnsibleGalaxyMetadata
@@ -201,7 +82,7 @@ def find_content_type_subdirs(tar_file_members):
     parent dir, which will be self.content_meta.name (we don't want it as it's
     not needed for plugin types. First make sure the length of
     that split and drop of parent dir is length > 1 and verify
-    that the subdir is infact in CONTENT_TYPE_DIR_MAP.values()
+    that the subdir is infact in content.CONTENT_TYPE_DIR_MAP.values()
 
     This should give us a list of valid content type subdirs
     found heuristically within this Galaxy Content repo'''
@@ -209,7 +90,7 @@ def find_content_type_subdirs(tar_file_members):
         os.path.join(m.name.split(os.sep)[1:])[0]
         for m in tar_file_members
         if len(os.path.join(m.name.split(os.sep)[1:])) > 1
-        and os.path.join(m.name.split(os.sep)[1:])[0] in CONTENT_TYPE_DIR_MAP.values()
+        and os.path.join(m.name.split(os.sep)[1:])[0] in content.CONTENT_TYPE_DIR_MAP.values()
     ]
 
     # uniq and order
@@ -261,7 +142,7 @@ def filter_members_by_content_type(tar_file_obj,
                       if tar_info_content_name_match(tar_file_member,
                                                      "",
                                                      # self.content_meta.name,
-                                                     content_path=CONTENT_TYPE_DIR_MAP.get(content_type))]
+                                                     content_path=content.CONTENT_TYPE_DIR_MAP.get(content_type))]
 
     # everything for roles
     if content_archive_type == 'role':
@@ -371,7 +252,7 @@ def extract_by_content_type(tar_file_obj,
     elog.debug('extract_to_path=%s', extract_to_path)
     elog.debug('content_meta=%s', content_meta)
 
-    display_callback = display_callback or default_display_callback
+    display_callback = display_callback or display.display_callback
     files_to_extract = files_to_extract or []
 
     # if content_type != "role" and content_type not in self.NO_META:
@@ -386,7 +267,7 @@ def extract_by_content_type(tar_file_obj,
 
     # append the content_dir if we have one
     content_path = os.path.join(extract_to_path,
-                                CONTENT_TYPE_DIR_MAP.get('install_content_type', content_meta.content_dir or ''))
+                                content.CONTENT_TYPE_DIR_MAP.get('install_content_type', content_meta.content_dir or ''))
     if content_meta.content_sub_dir:
         log.debug('content_sub_path=%s', content_meta.content_sub_dir)
         content_path = os.path.join(content_path, content_meta.content_sub_dir or '')
@@ -426,8 +307,8 @@ def extract_by_content_type(tar_file_obj,
                     plugin_found = parent_dir.lstrip(content_meta.name)
 
             # secondary dir (roles/, callback_plugins/) is a match for the content_type
-            elif len(parts_list) > 1 and parts_list[1] == CONTENT_TYPE_DIR_MAP.get(content_meta.content_type):
-                plugin_found = CONTENT_TYPE_DIR_MAP.get(content_meta.content_type)
+            elif len(parts_list) > 1 and parts_list[1] == content.CONTENT_TYPE_DIR_MAP.get(content_meta.content_type):
+                plugin_found = content.CONTENT_TYPE_DIR_MAP.get(content_meta.content_type)
 
             # log.debug('plugin_found1: %s', plugin_found)
             # if not plugin_found:

--- a/ansible_galaxy/archive.py
+++ b/ansible_galaxy/archive.py
@@ -12,7 +12,6 @@ import yaml
 from ansible_galaxy import display
 from ansible_galaxy import exceptions
 from ansible_galaxy.models import content
-from ansible_galaxy.models import content_repository
 
 log = logging.getLogger(__name__)
 
@@ -42,20 +41,6 @@ def load_archive_role_metadata(tar_file_obj, meta_file_path):
                   meta_file_path, tar_file_obj)
 
     return metadata
-
-
-def load_archive_galaxyfile(tar_file_obj, galaxy_file_path):
-    galaxy_metadata = None
-    if not galaxy_file_path:
-        return None
-
-    try:
-        galaxy_metadata = content_repository.load(tar_file_obj.extractfile(galaxy_file_path))
-    except Exception:
-        log.warn('unable to extract and yaml load galaxy_file=%s tar_file_obj=%s',
-                 galaxy_file_path, tar_file_obj)
-
-    return galaxy_metadata
 
 
 def load_archive_apb_yaml(tar_file_obj, apb_yaml_path):

--- a/ansible_galaxy/content_archive.py
+++ b/ansible_galaxy/content_archive.py
@@ -169,24 +169,12 @@ def load_archive(archive_path):
     #                                                         content_dir=content_meta.content_dir)
 
     log.debug('meta_file: %s', meta_file)
-    log.debug('galaxy_file: %s', galaxy_file)
     log.debug('archive_type: %s', archive_type)
     log.debug("archive_parent_dir: %s", archive_parent_dir)
     log.debug("meta_parent_dir: %s", meta_parent_dir)
 
-    # if not meta_file and not galaxy_file and self.content_type == "role":
-    #    raise exceptions.GalaxyClientError("this role does not appear to have a meta/main.yml file or ansible-galaxy.yml.")
-
     # metadata_ = archive.load_archive_role_metadata(content_tar_file,
     #                                               meta_file)
-
-    # galaxy_metadata = archive.load_archive_galaxyfile(content_tar_file,
-    #                                                  galaxy_file)
-
-    # apb_data = archive.load_archive_apb_yaml(content_tar_file,
-    #                                          apb_yaml_file)
-
-    # log.debug('apb_data: %s', pprint.pformat(apb_data))
 
     # looks like we are a role, update the default content_type from all -> role
     if archive_type == 'role':
@@ -205,17 +193,3 @@ def load_archive(archive_path):
 
     return content_tar_file, content_archive.ContentArchiveMeta(archive_type=archive_type,
                                                                 top_dir=archive_parent_dir)
-
-# TODO: add back galaxy, apb meta data load
-#    if apb_data:
-#        log.debug('Find APB metadata in the archive, so installing it as APB content_type')
-#
-#        data = self.content_meta.data
-#        data['apb_data'] = apb_data
-#
-#        content_meta = content.APBContentArchiveMeta.from_data(data)
-#
-#        log.debug('APB content_meta: %s', content_meta)
-#        content_archive_type = 'apb'
-#
-#    log.debug('content_archive_type=%s', content_archive_type)

--- a/ansible_galaxy/content_archive.py
+++ b/ansible_galaxy/content_archive.py
@@ -1,13 +1,18 @@
+import fnmatch
 import logging
 import os
 import tarfile
 
-from ansible_galaxy import archive
 from ansible_galaxy import exceptions
 from ansible_galaxy.models import content
 from ansible_galaxy.models import content_archive
 
 log = logging.getLogger(__name__)
+
+# TODO: better place to define?
+META_MAIN = os.path.join('meta', 'main.yml')
+GALAXY_FILE = 'ansible-galaxy.yml'
+APB_YAML = 'apb.yml'
 
 
 def detect_content_archive_type(archive_path, archive_members):
@@ -41,6 +46,100 @@ def detect_content_archive_type(archive_path, archive_members):
     return None
 
 
+# TODO/FIXME: try to make sense of this and find_archive_parent_dir
+def find_archive_metadata(archive_members):
+    '''Try to find the paths to the archives meta data files
+
+    Aka, meta/main.yml or ansible-galaxy.yml.
+
+    Also, while we are at it, try to find the archive parent
+    dir.'''
+
+    meta_file = None
+    galaxy_file = None
+
+    meta_parent_dir = None
+    archive_parent_dir = None
+
+    apb_yaml_file = None
+
+    for member in archive_members:
+        if fnmatch.fnmatch(member.name, '*/%s' % APB_YAML):
+            log.debug('apb.yml member: %s', member)
+            apb_yaml_file = member.name
+
+        if META_MAIN in member.name or GALAXY_FILE in member.name:
+            # Look for parent of meta/main.yml
+            # Due to possibility of sub roles each containing meta/main.yml
+            # look for shortest length parent
+            meta_parent_dir = os.path.dirname(os.path.dirname(member.name))
+            if not meta_file:
+                archive_parent_dir = meta_parent_dir
+                if GALAXY_FILE in member.name:
+                    galaxy_file = member
+                else:
+                    meta_file = member
+            else:
+                # self.log.debug('meta_parent_dir: %s archive_parent_dir: %s len(m): %s len(a): %s member.name: %s',
+                #               meta_parent_dir, archive_parent_dir,
+                #               len(meta_parent_dir),
+                #               len(archive_parent_dir),
+                #               member.name)
+                if len(meta_parent_dir) < len(archive_parent_dir):
+                    archive_parent_dir = meta_parent_dir
+                    meta_file = member
+                    if GALAXY_FILE in member.name:
+                        galaxy_file = member
+                    else:
+                        meta_file = member
+
+    log.debug('apb_yaml_file: %s', apb_yaml_file)
+    # FIXME: return a real type/object for archive metadata
+    return (meta_file,
+            meta_parent_dir,
+            galaxy_file,
+            apb_yaml_file)
+
+
+def find_archive_parent_dir(archive_members, content_type, content_dir):
+    # archive_parent_dir wasn't found when checking for metadata files
+    archive_parent_dir = None
+
+    shortest_dir = None
+    for member in archive_members:
+        # This is either a new-type Galaxy Content that doesn't have an
+        # ansible-galaxy.yml file and the type desired is specified and
+        # we check parent dir based on the correct subdir existing or
+        # we need to just scan the subdirs heuristically and figure out
+        # what to do
+        member_dir = os.path.dirname(os.path.dirname(member.name))
+        shortest_dir = shortest_dir or member_dir
+
+        if len(member_dir) < len(shortest_dir):
+            shortest_dir = member_dir
+
+        if content_type != "all":
+            if content_dir and content_dir in member.name:
+                archive_parent_dir = os.path.dirname(member.name)
+                return archive_parent_dir
+        else:
+            for plugin_dir in content.CONTENT_TYPE_DIR_MAP.values():
+                if plugin_dir in member.name:
+                    archive_parent_dir = os.path.dirname(member.name)
+                    return archive_parent_dir
+
+    if content_type not in content.CONTENT_TYPES:
+        log.debug('did not find a content_dir or plugin_dir, so using shortest_dir %s for archive_parent_dir', shortest_dir)
+        return shortest_dir
+
+    # TODO: archive format exception?
+    msg = "No content metadata provided, nor content directories found for content_type: %s" % \
+        content_type
+    log.debug('content_type: %s', content_type)
+    log.debug('content_dir: %s', content_dir)
+    raise exceptions.GalaxyClientError(msg)
+
+
 def load_archive(archive_path):
     archive_parent_dir = None
 
@@ -58,7 +157,7 @@ def load_archive(archive_path):
 
     # next find the metadata file
     (meta_file, meta_parent_dir, galaxy_file, apb_yaml_file) = \
-        archive.find_archive_metadata(members)
+        find_archive_metadata(members)
 
     archive_type = detect_content_archive_type(archive_path, members)
     log.debug('archive_type: %s', archive_type)

--- a/ansible_galaxy/flat_rest_api/content.py
+++ b/ansible_galaxy/flat_rest_api/content.py
@@ -334,6 +334,9 @@ class GalaxyContent(object):
 
         all_installed_paths = []
         content_types_to_install = content_types_to_install or []
+
+        tar_file_members = content_tar_file.getmembers()
+
         for install_content_type in content_types_to_install:
             log.debug('INSTALLING %s type content from %s', install_content_type, content_tar_file)
 
@@ -342,7 +345,7 @@ class GalaxyContent(object):
             # TODO:  install_contents()  - iterator over all the contents of a content type (ie, 'roles')
             # TODO:   install_content()  - install a single content  (ie, a role)
             #         _install_content_role()  - role specific impl of install_content
-            content_type_member_matches = archive.filter_members_by_content_type(content_tar_file,
+            content_type_member_matches = archive.filter_members_by_content_type(tar_file_members,
                                                                                  content_archive_type,
                                                                                  content_type=install_content_type)
 
@@ -356,7 +359,7 @@ class GalaxyContent(object):
                 match_pattern = '*/%s/%s*' % (content_sub_dir, content_sub_name)
                 # log.debug('MATCH_PATTERNS: %s', match_pattern)
 
-                member_matches = archive.filter_members_by_fnmatch(content_tar_file,
+                member_matches = archive.filter_members_by_fnmatch(tar_file_members,
                                                                    match_pattern)
             log.debug('content_meta: %s', content_meta)
             log.info('about to extract %s to %s', content_meta.name, content_meta.path)
@@ -390,7 +393,7 @@ class GalaxyContent(object):
 
                 match_pattern = '%s/%s/%s*' % (parent_dir, content_sub_dir, content_name)
 
-                member_matches = archive.filter_members_by_fnmatch(content_tar_file,
+                member_matches = archive.filter_members_by_fnmatch(tar_file_members,
                                                                    match_pattern)
 
                 namespaced_content_path = '%s/%s/%s' % (namespace_repo_name,

--- a/ansible_galaxy/flat_rest_api/content.py
+++ b/ansible_galaxy/flat_rest_api/content.py
@@ -217,7 +217,7 @@ class GalaxyContent(object):
             return self._metadata
 
         meta_path = os.path.join(self.path,
-                                 archive.META_MAIN)
+                                 content_archive.META_MAIN)
 
         if os.path.isfile(meta_path):
             log.debug('loading content metadata from meta_path: %s', meta_path)

--- a/tests/ansible_galaxy/test_archive.py
+++ b/tests/ansible_galaxy/test_archive.py
@@ -83,7 +83,7 @@ def test_extract_file_foo():
     item = {'archive_member': member,
             'dest_dir': tmp_dir,
             'dest_filename': pathname,
-            'force_overwrite': True}
+            'force_overwrite': False}
 
     files_to_extract.append(item)
     import pprint
@@ -91,6 +91,55 @@ def test_extract_file_foo():
 
     read_tar_file = tarfile.TarFile.open(name=tmp_tar_fo.name, mode='r')
     res = archive.extract_file(read_tar_file, file_to_extract=item)
+    log.debug('res: %s', res)
+
+    log.debug('listdir: %s', os.listdir(tmp_dir))
+    assert pathname in os.listdir(tmp_dir)
+
+    os.unlink(tmp_tar_fo.name)
+    read_tar_file.close()
+    tmp_tar_fo.close()
+    tmp_member_fo.close()
+    os.unlink(tmp_member_fo.name)
+    shutil.rmtree(tmp_dir)
+
+
+def test_extract_files():
+    tmp_tar_fo = tempfile.NamedTemporaryFile(delete=False, prefix='dddddddddddddd')
+    tmp_member_fo = tempfile.NamedTemporaryFile(delete=False, prefix='cccccccccc')
+    # TODO: replace with tmpdir fixture
+    tmp_dir = tempfile.mkdtemp(prefix='fffffcccc')
+
+    tar_file = tarfile.TarFile.open(mode='w',
+                                    fileobj=tmp_tar_fo)
+    # fileobj=tmp_tar)
+
+    files_to_extract = []
+
+    # for pathname in tar_example1:
+    pathnames = ['foo_blip.yml',
+                 'bar_foo.yml']
+
+    for pathname in pathnames:
+        member = tarfile.TarInfo(pathname)
+        tar_file.addfile(member, tmp_member_fo)
+
+        item = {'archive_member': member,
+                'dest_dir': tmp_dir,
+                'dest_filename': pathname,
+                'force_overwrite': False}
+
+        files_to_extract.append(item)
+
+    log.debug('tar_file2 members: %s', tar_file.getmembers())
+    tar_file.close()
+
+    import pprint
+    log.debug('files_to_extract: %s', pprint.pformat(files_to_extract))
+
+    read_tar_file = tarfile.TarFile.open(name=tmp_tar_fo.name, mode='r')
+    res_gen = archive.extract_files(read_tar_file, files_to_extract=files_to_extract)
+    res = list(res_gen)
     log.debug('res: %s', res)
 
     log.debug('listdir: %s', os.listdir(tmp_dir))
@@ -139,7 +188,7 @@ def test_extract_file():
 
 
 @pytest.mark.skip(reason="Need to either add a test tar or build one on the fly")
-def test_extract_files():
+def test_extract_files_tmp():
     # FIXME: rm out of tests tar file example
     # FIXME: generate a test tarfile
     tar_file = tarfile.TarFile.open(name='/tmp/alikins.testing-content.tar.gz',
@@ -343,24 +392,53 @@ tar_example1 = [
     'ansible-testing-content-master/strategy_plugins/linear.py']
 
 
-def test_foo():
-
+def _tar_members(file_list):
     members = []
-    for file_name in tar_example1:
+    for file_name in file_list:
         members.append(tarfile.TarInfo(name=file_name))
+
+    return members
+
+
+def test_find_members_by_fnmatch():
+    members = _tar_members(tar_example1)
 
     len_members = len(members)
     match_pattern = '*'
     res = archive.filter_members_by_fnmatch(members, match_pattern)
-
-    import pprint
-    log.debug('res: %s', pprint.pformat(res))
 
     assert len(res) == len_members, 'filtering on "*" missed some archive members'
     assert isinstance(res, list)
 
     action_match_pattern = '*/action_plugins/*'
     res = archive.filter_members_by_fnmatch(members, action_match_pattern)
-    log.debug('res: %s', pprint.pformat(res))
 
     assert len(res) == 1, 'filtering on "%s" should find one action plugin' % action_match_pattern
+
+
+def test_find_members_by_content_type():
+    members = _tar_members(tar_example1)
+
+    res = archive.filter_members_by_content_type(members, 'multi-content', 'role')
+
+    import pprint
+    log.debug('res: %s', pprint.pformat(res))
+
+    filenames = [x.name for x in res]
+    assert 'ansible-testing-content-master/roles/test-role-d/vars/main.yml' in filenames
+    assert 'ansible-testing-content-master/strategy_plugins/free.py' not in filenames
+
+
+def test_find_members_by_content_type_role_archive():
+    members = _tar_members(tar_example1)
+    len_members = len(members)
+
+    res = archive.filter_members_by_content_type(members, 'role', 'role')
+
+    import pprint
+    log.debug('res: %s', pprint.pformat(res))
+
+    filenames = [x.name for x in res]
+    assert 'ansible-testing-content-master/roles/test-role-d/vars/main.yml' in filenames
+    # a role archive should not having anything filtered out
+    assert len_members == len(res)

--- a/tests/ansible_galaxy/test_archive.py
+++ b/tests/ansible_galaxy/test_archive.py
@@ -19,24 +19,6 @@ log = logging.getLogger(__name__)
 TMP_PREFIX = 'tmp_mazer_test_archive_'
 
 
-def test_find_content_type_subdirs_empty():
-    tmp_tar = tempfile.TemporaryFile(prefix=TMP_PREFIX)
-
-    tar_file = tarfile.TarFile(name='some-top-level',
-                               mode='w',
-                               fileobj=tmp_tar)
-
-    tar_file_members = tar_file.getmembers()
-
-    res = archive.find_content_type_subdirs(tar_file_members)
-    log.debug('res: %s', res)
-
-    assert isinstance(res, list)
-    assert res == []
-    assert not res
-    tmp_tar.close()
-
-
 def test_extract_file_empty():
     tmp_tar = tempfile.TemporaryFile(prefix=TMP_PREFIX)
     # TODO: replace with tmpdir fixture
@@ -361,18 +343,24 @@ tar_example1 = [
     'ansible-testing-content-master/strategy_plugins/linear.py']
 
 
-# def test_foo():
-#
-#    members = []
-#    for file_name in tar_example1:
-#        members.append(tarfile.TarInfo(name=file_name))
-#
-#    res = archive.find_content_type_subdirs(members)
-#    import pprint
-#    log.debug('res: %s', pprint.pformat(res))
+def test_foo():
 
-#    assert isinstance(res, list)
-#    assert 'roles' in res
-#    assert 'action_plugins' in res
-#    assert 'library' in res
-#    assert 'modules' not in res
+    members = []
+    for file_name in tar_example1:
+        members.append(tarfile.TarInfo(name=file_name))
+
+    len_members = len(members)
+    match_pattern = '*'
+    res = archive.filter_members_by_fnmatch(members, match_pattern)
+
+    import pprint
+    log.debug('res: %s', pprint.pformat(res))
+
+    assert len(res) == len_members, 'filtering on "*" missed some archive members'
+    assert isinstance(res, list)
+
+    action_match_pattern = '*/action_plugins/*'
+    res = archive.filter_members_by_fnmatch(members, action_match_pattern)
+    log.debug('res: %s', pprint.pformat(res))
+
+    assert len(res) == 1, 'filtering on "%s" should find one action plugin' % action_match_pattern

--- a/tox.ini
+++ b/tox.ini
@@ -42,3 +42,7 @@ log_date_format =
 [coverage:run]
 branch = True
 source = ansible_galaxy, ansible_galaxy_cli
+omit =
+    # stuff from ansible/ansible that we use but dont have our own tests for
+    ansible_galaxy/flat_rest_api/urls.py
+    ansible_galaxy/utils/text.py


### PR DESCRIPTION
##### SUMMARY
Some cleanup and fixes on archive.py.

Start splitting content/galaxy specify bits to content_archive.py
keep generic archive stuff in archive.py

Some api tweaks to make testing a little easier.
Add more unit tests and improve the test coverage.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request



##### GALAXY CLI VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
Ansible Galaxy CLI, version0.1.0
Linux, newswoop, 4.16.6-202.fc27.x86_64, #1 SMP Wed May 2 00:09:32 UTC 2018, x86_64
3.6.5 (default, Apr  4 2018, 15:01:18) 
[GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]/home/adrian/venvs/galaxy-cli-py3/bin/python
Using /home/adrian/.ansible/mazer.yml as config file

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

