### PR TITLE
Handle rest api results for repos with no versions (fix #79)

### DIFF
--- a/ansible_galaxy/fetch/galaxy_url.py
+++ b/ansible_galaxy/fetch/galaxy_url.py
@@ -40,12 +40,23 @@ def get_download_url(repo_data=None, external_url=None, repoversion=None):
 
 
 def select_repository_version(repoversions, version):
-    # repository_versions 'version' is 'not null' so should always exist
+    # repository_version's 'version' is 'not null' so should always exist
+    # however, the list of repository_versions can be empty
+
+    # If the rest api returns a empty list for repo versions, return an
+    # empty dict for 'no version'
+    if not repoversions:
+        return {}
 
     # we could build a map/dict first and search in it, but we only use this
     # once, so this linear search is ok, since building the map would be that
     # plus the getitem
     results = [x for x in repoversions if x['version'] == version]
+
+    # no matching versions, return an empty dict
+    # TODO: raise VersionNotFoundError ? return some sort of NullRepositoryVersion instance?
+    if not results:
+        return {}
 
     # repository_versions is uniq on (version, repo.id) so for any given repo,
     # there should only be one result here

--- a/tests/ansible_galaxy/fetch/test_galaxy_url.py
+++ b/tests/ansible_galaxy/fetch/test_galaxy_url.py
@@ -1,0 +1,104 @@
+import logging
+import pytest
+
+from ansible_galaxy.fetch import galaxy_url
+
+log = logging.getLogger(__name__)
+
+EXAMPLE_REPO_VERSION_LATEST = \
+        {
+            "id": 55616,
+            "version": "1.1.0",
+            "tag": "1.1.0",
+            "commit_date": "2015-11-24T13:00:32-05:00",
+            "commit_sha": None,
+            "download_url": "https://github.com/atestuseraccount/ansible-role-logstash/archive/1.1.0.tar.gz",
+            "url": "",
+            "related": {},
+            "summary_fields": {},
+            "created": "2018-05-18T13:13:40.208012Z",
+            "modified": "2018-05-18T13:13:40.208037Z",
+            "active": None
+        }
+
+EXAMPLE_REPO_VERSIONS_LIST = \
+    [
+        {
+            "id": 55617,
+            "version": "1.0.6",
+            "tag": "1.0.6",
+            "commit_date": "2015-11-16T11:08:07-05:00",
+            "commit_sha": None,
+            "download_url": "https://github.com/atestuseraccount/ansible-role-logstash/archive/1.0.6.tar.gz",
+            "url": "",
+            "related": {},
+            "summary_fields": {},
+            "created": "2018-05-18T13:13:40.344064Z",
+            "modified": "2018-05-18T13:13:40.344088Z",
+            "active": None
+        },
+        EXAMPLE_REPO_VERSION_LATEST,
+    ]
+
+
+# Note that select_repository_version just gets the full version object
+# from repoversions. It does not sort or compare versions aside from equality
+@pytest.mark.parametrize("repoversions,version,expected", [
+    ([], None, {}),
+    ([{'version': '1.2.3'}],
+     '1.2.3',
+     {'version': '1.2.3'}),
+    # the version requested isnt in repoversions, exp a {} result
+    ([{'version': '1.2.4'}],
+     '1.2.3',
+     {}),
+    # repoversions has 1.2.3 so expect the full repoversion object returned
+    ([{'version': '1.2.2'},
+      {'version': '1.2.3'},
+      {'version': '1.2.4'},
+      ],
+     '1.2.3',
+     {'version': '1.2.3'}),
+    ([{'version': '1.2.2'},
+      {'version': '1.2.3'},
+      {'version': '1.2.4'},
+      ],
+     '1.2.4',
+     {'version': '1.2.4'}),
+    # an example with full repo_version objects
+    (EXAMPLE_REPO_VERSIONS_LIST,
+     '1.1.0',
+     EXAMPLE_REPO_VERSION_LATEST),
+    # if repoversions somehow ends up with two repo_version objects with same version
+    ([{'version': '1.2.2',
+       'url': 'http://thefirsturl.example.com'},
+      {'version': '1.2.2',
+       'url': 'http://thesecondurl.example.com'},
+      ],
+     '1.2.2',
+     {'version': '1.2.2',
+      'url': 'http://thesecondurl.example.com'}),
+])
+def test_select_repository_versions(repoversions, version, expected):
+    log.debug('repoversions: %s', repoversions)
+    log.debug('version: %s', version)
+    log.debug('expected: %s', expected)
+    res = galaxy_url.select_repository_version(repoversions, version)
+
+    assert isinstance(res, dict)
+
+    if res and expected:
+        assert res['version'] == expected['version']
+
+    assert res == expected
+
+
+# see https://github.com/ansible/mazer/issues/79
+def test_select_repository_version_empty_repoversions():
+    repoversions = []
+    version = '1.2.3'
+
+    res = galaxy_url.select_repository_version(repoversions, version)
+
+    assert isinstance(res, dict)
+    assert res == {}


### PR DESCRIPTION


##### SUMMARY
Handle rest api results for repos with no versions

Fixes #79
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request



##### GALAXY CLI VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
Ansible Galaxy CLI, version0.1.0
Linux, newswoop, 4.16.6-202.fc27.x86_64, #1 SMP Wed May 2 00:09:32 UTC 2018, x86_64
3.6.5 (default, Apr  4 2018, 15:01:18) 
[GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]/home/adrian/venvs/galaxy-cli-py3/bin/python
Using /home/adrian/.ansible/mazer.yml as config file


```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

