### PR TITLE
Add role_skeleton files to MANIFEST.in so its gets installed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ include LICENSE
 include README.rst
 
 recursive-include tests *
+recursive-include ansible_galaxy_cli/data *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 


### PR DESCRIPTION
##### SUMMARY
On a 'python setup.py install' the files in ansible_galaxy_cli/data/role_skeleton weren't being installed, so
'mazer init blip' would create an empty 'blip' dir. 



##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request



##### GALAXY CLI VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
Ansible Galaxy CLI, version0.1.0
Linux, newswoop, 4.16.6-202.fc27.x86_64, #1 SMP Wed May 2 00:09:32 UTC 2018, x86_64
3.6.5 (default, Apr  4 2018, 15:01:18) 
[GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]/home/adrian/venvs/galaxy-cli-py3/bin/python
Using /home/adrian/.ansible/mazer.yml as config file

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

