### PR TITLE
Set default http log levels back to INFO

### DIFF
--- a/ansible_galaxy_cli/logger/setup.py
+++ b/ansible_galaxy_cli/logger/setup.py
@@ -74,12 +74,12 @@ DEFAULT_LOGGING_CONFIG = {
             'level': 'DEBUG'
         },
         'ansible_galaxy.flat_rest_api.api.(http)': {
-            # 'level': 'INFO',
-            # 'handlers': DEFAULT_HANDLERS,
+            'level': 'INFO',
+            'handlers': DEFAULT_HANDLERS,
             # to log verbose debug level logging to http_file handler:
             'propagate': False,
-            'level': 'DEBUG',
-            'handlers': ['http_file'],
+            # 'level': 'DEBUG',
+            # 'handlers': ['http_file'],
         },
         'ansible_galaxy.archive.(extract)': {
             'level': 'INFO',


### PR DESCRIPTION
130e2db27c2253dad70ac26b4b82cd7edbb69dbd
unintentionally turned http logging up
to DEBUG and enabled the ~/.ansible/mazer-http.log
log file.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request



##### GALAXY CLI VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

