### PR TITLE
update default log config flat_rest_api.api -> rest_api

### DIFF
--- a/ansible_galaxy_cli/logger/default-mazer-logging.yml
+++ b/ansible_galaxy_cli/logger/default-mazer-logging.yml
@@ -47,7 +47,7 @@ loggers:
     propagate: false
   ansible_galaxy.archive.extract:
     level: INFO
-  ansible_galaxy.flat_rest_api.api.(http):
+  ansible_galaxy.rest_api.(http):
     level: INFO
     propagate: false
     # to log verbose debug level logging to http_file handler:

--- a/config/mazer-logging.yml
+++ b/config/mazer-logging.yml
@@ -47,7 +47,7 @@ loggers:
     propagate: false
   ansible_galaxy.archive.extract:
     level: INFO
-  ansible_galaxy.flat_rest_api.api.(http):
+  ansible_galaxy.rest_api.(http):
     level: INFO
     propagate: false
     # to log verbose debug level logging to http_file handler:


### PR DESCRIPTION
##### SUMMARY
The rest_api class changed names, but the default logging config didnt get updated. This updates it.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### GALAXY CLI VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

