### PR TITLE
Update urls py

### DIFF
--- a/ansible_galaxy/flat_rest_api/urls.py
+++ b/ansible_galaxy/flat_rest_api/urls.py
@@ -48,13 +48,14 @@ except ImportError:
     # Python 3
     import http.client as httplib
 
-import six.moves.http_cookiejar as cookiejar
-import six.moves.urllib.request as urllib_request
-import six.moves.urllib.error as urllib_error
+import ansible.module_utils.six.moves.http_cookiejar as cookiejar
+import ansible.module_utils.six.moves.urllib.request as urllib_request
+import ansible.module_utils.six.moves.urllib.error as urllib_error
 
-# FIXME:
-# from ansible.module_utils.basic import get_distribution
-from ansible_galaxy.utils.text import to_bytes, to_native, to_text
+from ansible.module_utils.six import PY3
+
+from ansible.module_utils.basic import get_distribution
+from ansible.module_utils._text import to_bytes, to_native, to_text
 
 try:
     # python3
@@ -65,8 +66,10 @@ except ImportError:
     import urllib2 as urllib_request
     from urllib2 import AbstractHTTPHandler
 
+urllib_request.HTTPRedirectHandler.http_error_308 = urllib_request.HTTPRedirectHandler.http_error_307
+
 try:
-    from six.moves.urllib.parse import urlparse, urlunparse
+    from ansible.module_utils.six.moves.urllib.parse import urlparse, urlunparse
     HAS_URLPARSE = True
 except:
     HAS_URLPARSE = False
@@ -245,8 +248,8 @@ if not HAS_MATCH_HOSTNAME:
     HAS_MATCH_HOSTNAME = True
 
 
-# This is a dummy cacert provided for Mac OS since you need at least 1
-# ca cert, regardless of validity, for Python on Mac OS to use the
+# This is a dummy cacert provided for macOS since you need at least 1
+# ca cert, regardless of validity, for Python on macOS to use the
 # keychain functionality in OpenSSL for validating SSL certificates.
 # See: http://mercurial.selenic.com/wiki/CACertificates#Mac_OS_X_10.6_and_higher
 b_DUMMY_CA_CERT = b"""-----BEGIN CERTIFICATE-----
@@ -291,7 +294,6 @@ class SSLValidationError(ConnectionError):
 class NoSSLError(SSLValidationError):
     """Needed to connect to an HTTPS url but no ssl library available to verify the certificate"""
     pass
-
 
 # Some environments (Google Compute Engine's CoreOS deploys) do not compile
 # against openssl and thus do not have any HTTPS support.
@@ -447,11 +449,11 @@ class RequestWithMethod(urllib_request.Request):
     Originally contained in library/net_infrastructure/dnsmadeeasy
     '''
 
-    def __init__(self, url, method, data=None, headers=None):
+    def __init__(self, url, method, data=None, headers=None, origin_req_host=None, unverifiable=True):
         if headers is None:
             headers = {}
         self._method = method.upper()
-        urllib_request.Request.__init__(self, url, data, headers)
+        urllib_request.Request.__init__(self, url, data, headers, origin_req_host, unverifiable)
 
     def get_method(self):
         if self._method:
@@ -479,36 +481,68 @@ def RedirectHandlerFactory(follow_redirects=None, validate_certs=True):
             if handler:
                 urllib_request._opener.add_handler(handler)
 
+            # Preserve urllib2 compatibility
             if follow_redirects == 'urllib2':
                 return urllib_request.HTTPRedirectHandler.redirect_request(self, req, fp, code, msg, hdrs, newurl)
+
+            # Handle disabled redirects
             elif follow_redirects in ['no', 'none', False]:
                 raise urllib_error.HTTPError(newurl, code, msg, hdrs, fp)
 
-            do_redirect = False
+            method = req.get_method()
+
+            # Handle non-redirect HTTP status or invalid follow_redirects
             if follow_redirects in ['all', 'yes', True]:
-                do_redirect = (code >= 300 and code < 400)
-
+                if code < 300 or code >= 400:
+                    raise urllib_error.HTTPError(req.get_full_url(), code, msg, hdrs, fp)
             elif follow_redirects == 'safe':
-                m = req.get_method()
-                do_redirect = (code >= 300 and code < 400 and m in ('GET', 'HEAD'))
-
-            if do_redirect:
-                # be conciliant with URIs containing a space
-                newurl = newurl.replace(' ', '%20')
-                newheaders = dict((k, v) for k, v in req.headers.items()
-                                  if k.lower() not in ("content-length", "content-type"))
-                try:
-                    # Python 2-3.3
-                    origin_req_host = req.get_origin_req_host()
-                except AttributeError:
-                    # Python 3.4+
-                    origin_req_host = req.origin_req_host
-                return urllib_request.Request(newurl,
-                                              headers=newheaders,
-                                              origin_req_host=origin_req_host,
-                                              unverifiable=True)
+                if code < 300 or code >= 400 or method not in ('GET', 'HEAD'):
+                    raise urllib_error.HTTPError(req.get_full_url(), code, msg, hdrs, fp)
             else:
                 raise urllib_error.HTTPError(req.get_full_url(), code, msg, hdrs, fp)
+
+            try:
+                # Python 2-3.3
+                data = req.get_data()
+                origin_req_host = req.get_origin_req_host()
+            except AttributeError:
+                # Python 3.4+
+                data = req.data
+                origin_req_host = req.origin_req_host
+
+            # Be conciliant with URIs containing a space
+            newurl = newurl.replace(' ', '%20')
+
+            # Suport redirect with payload and original headers
+            if code in (307, 308):
+                # Preserve payload and headers
+                headers = req.headers
+            else:
+                # Do not preserve payload and filter headers
+                data = None
+                headers = dict((k, v) for k, v in req.headers.items()
+                               if k.lower() not in ("content-length", "content-type", "transfer-encoding"))
+
+                # http://tools.ietf.org/html/rfc7231#section-6.4.4
+                if code == 303 and method != 'HEAD':
+                    method = 'GET'
+
+                # Do what the browsers do, despite standards...
+                # First, turn 302s into GETs.
+                if code == 302 and method != 'HEAD':
+                    method = 'GET'
+
+                # Second, if a POST is responded to with a 301, turn it into a GET.
+                if code == 301 and method == 'POST':
+                    method = 'GET'
+
+            return RequestWithMethod(newurl,
+                                     method=method,
+                                     headers=headers,
+                                     data=data,
+                                     origin_req_host=origin_req_host,
+                                     unverifiable=True,
+                                     )
 
     return RedirectHandler
 
@@ -591,7 +625,7 @@ class SSLValidationHandler(urllib_request.BaseHandler):
         to_add_fd, to_add_path = tempfile.mkstemp()
         to_add = False
 
-        # Write the dummy ca cert if we are running on Mac OS X
+        # Write the dummy ca cert if we are running on macOS
         if system == u'Darwin':
             os.write(tmp_fd, b_DUMMY_CA_CERT)
             # Default Homebrew path for OpenSSL certs
@@ -782,6 +816,311 @@ def maybe_add_ssl_handler(url, validate_certs):
         return SSLValidationHandler(hostname, port)
 
 
+class Request:
+    def __init__(self, headers=None, use_proxy=True, force=False, timeout=10, validate_certs=True,
+                 url_username=None, url_password=None, http_agent=None, force_basic_auth=False,
+                 follow_redirects='urllib2', client_cert=None, client_key=None, cookies=None):
+        """This class works somewhat similarly to the ``Session`` class of from requests
+        by defining a cookiejar that an be used across requests as well as cascaded defaults that
+        can apply to repeated requests
+
+        For documentation of params, see ``Request.open``
+
+        >>> from ansible.module_utils.urls import Request
+        >>> r = Request()
+        >>> r.open('GET', 'http://httpbin.org/cookies/set?k1=v1').read()
+        '{\n  "cookies": {\n    "k1": "v1"\n  }\n}\n'
+        >>> r = Request(url_username='user', url_password='passwd')
+        >>> r.open('GET', 'http://httpbin.org/basic-auth/user/passwd').read()
+        '{\n  "authenticated": true, \n  "user": "user"\n}\n'
+        >>> r = Request(headers=dict(foo='bar'))
+        >>> r.open('GET', 'http://httpbin.org/get', headers=dict(baz='qux')).read()
+
+        """
+
+        self.headers = headers or {}
+        if not isinstance(self.headers, dict):
+            raise ValueError("headers must be a dict")
+        self.use_proxy = use_proxy
+        self.force = force
+        self.timeout = timeout
+        self.validate_certs = validate_certs
+        self.url_username = url_username
+        self.url_password = url_password
+        self.http_agent = http_agent
+        self.force_basic_auth = force_basic_auth
+        self.follow_redirects = follow_redirects
+        self.client_cert = client_cert
+        self.client_key = client_key
+        if isinstance(cookies, cookiejar.CookieJar):
+            self.cookies = cookies
+        else:
+            self.cookies = cookiejar.CookieJar()
+
+    def _fallback(self, value, fallback):
+        if value is None:
+            return fallback
+        return value
+
+    def open(self, method, url, data=None, headers=None, use_proxy=None,
+             force=None, last_mod_time=None, timeout=None, validate_certs=None,
+             url_username=None, url_password=None, http_agent=None,
+             force_basic_auth=None, follow_redirects=None,
+             client_cert=None, client_key=None, cookies=None):
+        """
+        Sends a request via HTTP(S) or FTP using urllib2 (Python2) or urllib (Python3)
+
+        Does not require the module environment
+
+        Returns :class:`HTTPResponse` object.
+
+        :arg method: method for the request
+        :arg url: URL to request
+
+        :kwarg data: (optional) bytes, or file-like object to send
+            in the body of the request
+        :kwarg headers: (optional) Dictionary of HTTP Headers to send with the
+            request
+        :kwarg use_proxy: (optional) Boolean of whether or not to use proxy
+        :kwarg force: (optional) Boolean of whether or not to set `cache-control: no-cache` header
+        :kwarg last_mod_time: (optional) Datetime object to use when setting If-Modified-Since header
+        :kwarg timeout: (optional) How long to wait for the server to send
+            data before giving up, as a float
+        :kwarg validate_certs: (optional) Booleani that controls whether we verify
+            the server's TLS certificate
+        :kwarg url_username: (optional) String of the user to use when authenticating
+        :kwarg url_password: (optional) String of the password to use when authenticating
+        :kwarg http_agent: (optional) String of the User-Agent to use in the request
+        :kwarg force_basic_auth: (optional) Boolean determining if auth header should be sent in the initial request
+        :kwarg follow_redirects: (optional) String of urllib2, all/yes, safe, none to determine how redirects are
+            followed, see RedirectHandlerFactory for more information
+        :kwarg client_cert: (optional) PEM formatted certificate chain file to be used for SSL client authentication.
+            This file can also include the key as well, and if the key is included, client_key is not required
+        :kwarg client_key: (optional) PEM formatted file that contains your private key to be used for SSL client
+            authentication. If client_cert contains both the certificate and key, this option is not required
+        :kwarg cookies: (optional) CookieJar object to send with the
+            request
+        :returns: HTTPResponse
+        """
+
+        method = method.upper()
+
+        if headers is None:
+            headers = {}
+        elif not isinstance(headers, dict):
+            raise ValueError("headers must be a dict")
+        headers = dict(self.headers, **headers)
+
+        use_proxy = self._fallback(use_proxy, self.use_proxy)
+        force = self._fallback(force, self.force)
+        timeout = self._fallback(timeout, self.timeout)
+        validate_certs = self._fallback(validate_certs, self.validate_certs)
+        url_username = self._fallback(url_username, self.url_username)
+        url_password = self._fallback(url_password, self.url_password)
+        http_agent = self._fallback(http_agent, self.http_agent)
+        force_basic_auth = self._fallback(force_basic_auth, self.force_basic_auth)
+        follow_redirects = self._fallback(follow_redirects, self.follow_redirects)
+        client_cert = self._fallback(client_cert, self.client_cert)
+        client_key = self._fallback(client_key, self.client_key)
+        cookies = self._fallback(cookies, self.cookies)
+
+        handlers = []
+        ssl_handler = maybe_add_ssl_handler(url, validate_certs)
+        if ssl_handler:
+            handlers.append(ssl_handler)
+
+        parsed = generic_urlparse(urlparse(url))
+        if parsed.scheme != 'ftp':
+            username = url_username
+
+            if username:
+                password = url_password
+                netloc = parsed.netloc
+            elif '@' in parsed.netloc:
+                credentials, netloc = parsed.netloc.split('@', 1)
+                if ':' in credentials:
+                    username, password = credentials.split(':', 1)
+                else:
+                    username = credentials
+                    password = ''
+
+                parsed_list = parsed.as_list()
+                parsed_list[1] = netloc
+
+                # reconstruct url without credentials
+                url = urlunparse(parsed_list)
+
+            if username and not force_basic_auth:
+                passman = urllib_request.HTTPPasswordMgrWithDefaultRealm()
+
+                # this creates a password manager
+                passman.add_password(None, netloc, username, password)
+
+                # because we have put None at the start it will always
+                # use this username/password combination for  urls
+                # for which `theurl` is a super-url
+                authhandler = urllib_request.HTTPBasicAuthHandler(passman)
+                digest_authhandler = urllib_request.HTTPDigestAuthHandler(passman)
+
+                # create the AuthHandler
+                handlers.append(authhandler)
+                handlers.append(digest_authhandler)
+
+            elif username and force_basic_auth:
+                headers["Authorization"] = basic_auth_header(username, password)
+
+            else:
+                try:
+                    rc = netrc.netrc(os.environ.get('NETRC'))
+                    login = rc.authenticators(parsed.hostname)
+                except IOError:
+                    login = None
+
+                if login:
+                    username, _, password = login
+                    if username and password:
+                        headers["Authorization"] = basic_auth_header(username, password)
+
+        if not use_proxy:
+            proxyhandler = urllib_request.ProxyHandler({})
+            handlers.append(proxyhandler)
+
+        if HAS_SSLCONTEXT and not validate_certs:
+            # In 2.7.9, the default context validates certificates
+            context = SSLContext(ssl.PROTOCOL_SSLv23)
+            if ssl.OP_NO_SSLv2:
+                context.options |= ssl.OP_NO_SSLv2
+            context.options |= ssl.OP_NO_SSLv3
+            context.verify_mode = ssl.CERT_NONE
+            context.check_hostname = False
+            handlers.append(HTTPSClientAuthHandler(client_cert=client_cert,
+                                                   client_key=client_key,
+                                                   context=context))
+        elif client_cert:
+            handlers.append(HTTPSClientAuthHandler(client_cert=client_cert,
+                                                   client_key=client_key))
+
+        # pre-2.6 versions of python cannot use the custom https
+        # handler, since the socket class is lacking create_connection.
+        # Some python builds lack HTTPS support.
+        if hasattr(socket, 'create_connection') and CustomHTTPSHandler:
+            handlers.append(CustomHTTPSHandler)
+
+        handlers.append(RedirectHandlerFactory(follow_redirects, validate_certs))
+
+        # add some nicer cookie handling
+        if cookies is not None:
+            handlers.append(urllib_request.HTTPCookieProcessor(cookies))
+
+        opener = urllib_request.build_opener(*handlers)
+        urllib_request.install_opener(opener)
+
+        data = to_bytes(data, nonstring='passthru')
+        if method not in ('OPTIONS', 'GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'TRACE', 'CONNECT', 'PATCH'):
+            raise ConnectionError('invalid HTTP request method; %s' % method)
+        request = RequestWithMethod(url, method, data)
+
+        # add the custom agent header, to help prevent issues
+        # with sites that block the default urllib agent string
+        if http_agent:
+            request.add_header('User-agent', http_agent)
+
+        # Cache control
+        # Either we directly force a cache refresh
+        if force:
+            request.add_header('cache-control', 'no-cache')
+        # or we do it if the original is more recent than our copy
+        elif last_mod_time:
+            tstamp = last_mod_time.strftime('%a, %d %b %Y %H:%M:%S +0000')
+            request.add_header('If-Modified-Since', tstamp)
+
+        # user defined headers now, which may override things we've set above
+        for header in headers:
+            request.add_header(header, headers[header])
+
+        urlopen_args = [request, None]
+        if sys.version_info >= (2, 6, 0):
+            # urlopen in python prior to 2.6.0 did not
+            # have a timeout parameter
+            urlopen_args.append(timeout)
+
+        r = urllib_request.urlopen(*urlopen_args)
+        return r
+
+    def get(self, url, **kwargs):
+        r"""Sends a GET request. Returns :class:`HTTPResponse` object.
+
+        :arg url: URL to request
+        :kwarg \*\*kwargs: Optional arguments that ``open`` takes.
+        :returns: HTTPResponse
+        """
+
+        return self.open('GET', url, **kwargs)
+
+    def options(self, url, **kwargs):
+        r"""Sends a OPTIONS request. Returns :class:`HTTPResponse` object.
+
+        :arg url: URL to request
+        :kwarg \*\*kwargs: Optional arguments that ``open`` takes.
+        :returns: HTTPResponse
+        """
+
+        return self.open('OPTIONS', url, **kwargs)
+
+    def head(self, url, **kwargs):
+        r"""Sends a HEAD request. Returns :class:`HTTPResponse` object.
+
+        :arg url: URL to request
+        :kwarg \*\*kwargs: Optional arguments that ``open`` takes.
+        :returns: HTTPResponse
+        """
+
+        return self.open('HEAD', url, **kwargs)
+
+    def post(self, url, data=None, **kwargs):
+        r"""Sends a POST request. Returns :class:`HTTPResponse` object.
+
+        :arg url: URL to request.
+        :kwarg data: (optional) bytes, or file-like object to send in the body of the request.
+        :kwarg \*\*kwargs: Optional arguments that ``open`` takes.
+        :returns: HTTPResponse
+        """
+
+        return self.open('POST', url, data=data, **kwargs)
+
+    def put(self, url, data=None, **kwargs):
+        r"""Sends a PUT request. Returns :class:`HTTPResponse` object.
+
+        :arg url: URL to request.
+        :kwarg data: (optional) bytes, or file-like object to send in the body of the request.
+        :kwarg \*\*kwargs: Optional arguments that ``open`` takes.
+        :returns: HTTPResponse
+        """
+
+        return self.open('PUT', url, data=data, **kwargs)
+
+    def patch(self, url, data=None, **kwargs):
+        r"""Sends a PATCH request. Returns :class:`HTTPResponse` object.
+
+        :arg url: URL to request.
+        :kwarg data: (optional) bytes, or file-like object to send in the body of the request.
+        :kwarg \*\*kwargs: Optional arguments that ``open`` takes.
+        :returns: HTTPResponse
+        """
+
+        return self.open('PATCH', url, data=data, **kwargs)
+
+    def delete(self, url, **kwargs):
+        r"""Sends a DELETE request. Returns :class:`HTTPResponse` object.
+
+        :arg url: URL to request
+        :kwargs \*\*kwargs: Optional arguments that ``open`` takes.
+        :returns: HTTPResponse
+        """
+
+        return self.open('DELETE', url, **kwargs)
+
+
 def open_url(url, data=None, headers=None, method=None, use_proxy=True,
              force=False, last_mod_time=None, timeout=10, validate_certs=True,
              url_username=None, url_password=None, http_agent=None,
@@ -792,136 +1131,13 @@ def open_url(url, data=None, headers=None, method=None, use_proxy=True,
 
     Does not require the module environment
     '''
-    handlers = []
-    ssl_handler = maybe_add_ssl_handler(url, validate_certs)
-    if ssl_handler:
-        handlers.append(ssl_handler)
+    method = method or 'GET'
+    return Request().open(method, url, data=data, headers=headers, use_proxy=use_proxy,
+                          force=force, last_mod_time=last_mod_time, timeout=timeout, validate_certs=validate_certs,
+                          url_username=url_username, url_password=url_password, http_agent=http_agent,
+                          force_basic_auth=force_basic_auth, follow_redirects=follow_redirects,
+                          client_cert=client_cert, client_key=client_key, cookies=cookies)
 
-    parsed = generic_urlparse(urlparse(url))
-    if parsed.scheme != 'ftp':
-        username = url_username
-
-        if headers is None:
-            headers = {}
-
-        if username:
-            password = url_password
-            netloc = parsed.netloc
-        elif '@' in parsed.netloc:
-            credentials, netloc = parsed.netloc.split('@', 1)
-            if ':' in credentials:
-                username, password = credentials.split(':', 1)
-            else:
-                username = credentials
-                password = ''
-
-            parsed_list = parsed.as_list()
-            parsed_list[1] = netloc
-
-            # reconstruct url without credentials
-            url = urlunparse(parsed_list)
-
-        if username and not force_basic_auth:
-            passman = urllib_request.HTTPPasswordMgrWithDefaultRealm()
-
-            # this creates a password manager
-            passman.add_password(None, netloc, username, password)
-
-            # because we have put None at the start it will always
-            # use this username/password combination for  urls
-            # for which `theurl` is a super-url
-            authhandler = urllib_request.HTTPBasicAuthHandler(passman)
-            digest_authhandler = urllib_request.HTTPDigestAuthHandler(passman)
-
-            # create the AuthHandler
-            handlers.append(authhandler)
-            handlers.append(digest_authhandler)
-
-        elif username and force_basic_auth:
-            headers["Authorization"] = basic_auth_header(username, password)
-
-        else:
-            try:
-                rc = netrc.netrc(os.environ.get('NETRC'))
-                login = rc.authenticators(parsed.hostname)
-            except IOError:
-                login = None
-
-            if login:
-                username, _, password = login
-                if username and password:
-                    headers["Authorization"] = basic_auth_header(username, password)
-
-    if not use_proxy:
-        proxyhandler = urllib_request.ProxyHandler({})
-        handlers.append(proxyhandler)
-
-    if HAS_SSLCONTEXT and not validate_certs:
-        # In 2.7.9, the default context validates certificates
-        context = SSLContext(ssl.PROTOCOL_SSLv23)
-        context.options |= ssl.OP_NO_SSLv2
-        context.options |= ssl.OP_NO_SSLv3
-        context.verify_mode = ssl.CERT_NONE
-        context.check_hostname = False
-        handlers.append(HTTPSClientAuthHandler(client_cert=client_cert,
-                                               client_key=client_key,
-                                               context=context))
-    elif client_cert:
-        handlers.append(HTTPSClientAuthHandler(client_cert=client_cert,
-                                               client_key=client_key))
-
-    # pre-2.6 versions of python cannot use the custom https
-    # handler, since the socket class is lacking create_connection.
-    # Some python builds lack HTTPS support.
-    if hasattr(socket, 'create_connection') and CustomHTTPSHandler:
-        handlers.append(CustomHTTPSHandler)
-
-    handlers.append(RedirectHandlerFactory(follow_redirects, validate_certs))
-
-    # add some nicer cookie handling
-    if cookies is not None:
-        handlers.append(urllib_request.HTTPCookieProcessor(cookies))
-
-    opener = urllib_request.build_opener(*handlers)
-    urllib_request.install_opener(opener)
-
-    data = to_bytes(data, nonstring='passthru')
-    if method:
-        if method.upper() not in ('OPTIONS', 'GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'TRACE', 'CONNECT', 'PATCH'):
-            raise ConnectionError('invalid HTTP request method; %s' % method.upper())
-        request = RequestWithMethod(url, method.upper(), data)
-    else:
-        request = urllib_request.Request(url, data)
-
-    # add the custom agent header, to help prevent issues
-    # with sites that block the default urllib agent string
-    if http_agent:
-        request.add_header('User-agent', http_agent)
-
-    # Cache control
-    # Either we directly force a cache refresh
-    if force:
-        request.add_header('cache-control', 'no-cache')
-    # or we do it if the original is more recent than our copy
-    elif last_mod_time:
-        tstamp = last_mod_time.strftime('%a, %d %b %Y %H:%M:%S +0000')
-        request.add_header('If-Modified-Since', tstamp)
-
-    # user defined headers now, which may override things we've set above
-    if headers:
-        if not isinstance(headers, dict):
-            raise ValueError("headers provided to fetch_url() must be a dict")
-        for header in headers:
-            request.add_header(header, headers[header])
-
-    urlopen_args = [request, None]
-    if sys.version_info >= (2, 6, 0):
-        # urlopen in python prior to 2.6.0 did not
-        # have a timeout parameter
-        urlopen_args.append(timeout)
-
-    r = urllib_request.urlopen(*urlopen_args)
-    return r
 
 #
 # Module-related functions
@@ -978,8 +1194,8 @@ def fetch_url(module, url, data=None, headers=None, method=None,
         data={...}
         resp, info = fetch_url(module,
                                "http://example.com",
-                               data=module.jsonify(data)
-                               header={Content-type': 'application/json'},
+                               data=module.jsonify(data),
+                               headers={'Content-type': 'application/json'},
                                method="POST")
         status_code = info["status"]
         body = resp.read()
@@ -1018,21 +1234,42 @@ def fetch_url(module, url, data=None, headers=None, method=None,
                      url_password=password, http_agent=http_agent, force_basic_auth=force_basic_auth,
                      follow_redirects=follow_redirects, client_cert=client_cert,
                      client_key=client_key, cookies=cookies)
-        info.update(r.info())
+        # Lowercase keys, to conform to py2 behavior, so that py3 and py2 are predictable
+        info.update(dict((k.lower(), v) for k, v in r.info().items()))
+
+        # Don't be lossy, append header values for duplicate headers
+        # In Py2 there is nothing that needs done, py2 does this for us
+        if PY3:
+            temp_headers = {}
+            for name, value in r.headers.items():
+                # The same as above, lower case keys to match py2 behavior, and create more consistent results
+                name = name.lower()
+                if name in temp_headers:
+                    temp_headers[name] = ', '.join((temp_headers[name], value))
+                else:
+                    temp_headers[name] = value
+            info.update(temp_headers)
+
         # parse the cookies into a nice dictionary
+        cookie_list = []
         cookie_dict = dict()
+        # Python sorts cookies in order of most specific (ie. longest) path first. See ``CookieJar._cookie_attrs``
+        # Cookies with the same path are reversed from response order.
+        # This code makes no assumptions about that, and accepts the order given by python
         for cookie in cookies:
             cookie_dict[cookie.name] = cookie.value
+            cookie_list.append((cookie.name, cookie.value))
+        info['cookies_string'] = '; '.join('%s=%s' % c for c in cookie_list)
+
         info['cookies'] = cookie_dict
         # finally update the result with a message about the fetch
         info.update(dict(msg="OK (%s bytes)" % r.headers.get('Content-Length', 'unknown'), url=r.geturl(), status=r.code))
     except NoSSLError as e:
-        # FIXME: can probably use python platform.py for this
-        # distribution = get_distribution()
-        # if distribution is not None and distribution.lower() == 'redhat':
-        #     module.fail_json(msg='%s. You can also install python-ssl from EPEL' % to_native(e))
-        # else:
-        module.fail_json(msg='%s' % to_native(e))
+        distribution = get_distribution()
+        if distribution is not None and distribution.lower() == 'redhat':
+            module.fail_json(msg='%s. You can also install python-ssl from EPEL' % to_native(e))
+        else:
+            module.fail_json(msg='%s' % to_native(e))
     except (ConnectionError, ValueError) as e:
         module.fail_json(msg=to_native(e))
     except urllib_error.HTTPError as e:

--- a/ansible_galaxy/flat_rest_api/urls.py
+++ b/ansible_galaxy/flat_rest_api/urls.py
@@ -48,14 +48,15 @@ except ImportError:
     # Python 3
     import http.client as httplib
 
-import ansible.module_utils.six.moves.http_cookiejar as cookiejar
-import ansible.module_utils.six.moves.urllib.request as urllib_request
-import ansible.module_utils.six.moves.urllib.error as urllib_error
+import six.moves.http_cookiejar as cookiejar
+import six.moves.urllib.request as urllib_request
+import six.moves.urllib.error as urllib_error
+from six import PY3
 
-from ansible.module_utils.six import PY3
+# FIXME:
+# from ansible.module_utils.basic import get_distribution
 
-from ansible.module_utils.basic import get_distribution
-from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible_galaxy.utils.text import to_bytes, to_native, to_text
 
 try:
     # python3
@@ -69,7 +70,7 @@ except ImportError:
 urllib_request.HTTPRedirectHandler.http_error_308 = urllib_request.HTTPRedirectHandler.http_error_307
 
 try:
-    from ansible.module_utils.six.moves.urllib.parse import urlparse, urlunparse
+    from six.moves.urllib.parse import urlparse, urlunparse
     HAS_URLPARSE = True
 except:
     HAS_URLPARSE = False
@@ -1265,11 +1266,11 @@ def fetch_url(module, url, data=None, headers=None, method=None,
         # finally update the result with a message about the fetch
         info.update(dict(msg="OK (%s bytes)" % r.headers.get('Content-Length', 'unknown'), url=r.geturl(), status=r.code))
     except NoSSLError as e:
-        distribution = get_distribution()
-        if distribution is not None and distribution.lower() == 'redhat':
-            module.fail_json(msg='%s. You can also install python-ssl from EPEL' % to_native(e))
-        else:
-            module.fail_json(msg='%s' % to_native(e))
+        # distribution = get_distribution()
+        # if distribution is not None and distribution.lower() == 'redhat':
+        #    module.fail_json(msg='%s. You can also install python-ssl from EPEL' % to_native(e))
+        # else:
+        module.fail_json(msg='%s' % to_native(e))
     except (ConnectionError, ValueError) as e:
         module.fail_json(msg=to_native(e))
     except urllib_error.HTTPError as e:


### PR DESCRIPTION
##### SUMMARY
Update ansible_galaxy.flat_rest_api.urls to be based off the latest version of ansible's
lib/ansible/module_utils/urls.py (https://github.com/ansible/ansible/blob/15ce7c5bab781592cdd81a736ad530341e0fdfeb/lib/ansible/module_utils/urls.py)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request



##### GALAXY CLI VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
Ansible Galaxy CLI, version0.1.0
Linux, newswoop, 4.16.6-202.fc27.x86_64, #1 SMP Wed May 2 00:09:32 UTC 2018, x86_64
3.6.5 (default, Apr  4 2018, 15:01:18) 
[GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]/home/adrian/venvs/galaxy-cli-py3/bin/python
Using /home/adrian/.ansible/mazer.yml as config file


```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

