### PR TITLE
Mv cli 'version' logic to ansible_galaxy.action.version

### DIFF
--- a/ansible_galaxy/actions/version.py
+++ b/ansible_galaxy/actions/version.py
@@ -1,0 +1,46 @@
+import logging
+import os
+import sys
+
+from ansible_galaxy.utils.text import to_text
+
+log = logging.getLogger(__name__)
+
+VERSION_FIELDS = ('name', 'version', 'config_file', 'uname', 'executable_location', 'python_version', 'python_executable')
+
+
+def version_data(config_file_path, cli_version, argv):
+    data = {}
+
+    data['name'] = 'mazer'
+    data['version'] = cli_version
+    data['executable_location'] = argv[0]
+    data['uname'] = u', '.join(os.uname())
+
+    sys_ver = u"%s" % ''.join(sys.version.splitlines())
+
+    data['python_version'] = sys_ver
+    data['python_executable'] = sys.executable
+
+    if config_file_path:
+        data['config_file'] = to_text(config_file_path)
+    else:
+        data['config_file'] = u'No config file found; using defaults'
+
+    return data
+
+
+def version_repr(version_data):
+    lines = []
+
+    for field in VERSION_FIELDS:
+        lines.append(u'%s = %s' % (field, version_data.get(field, '')))
+
+    buf = u'\n'.join(lines)
+    return buf
+
+
+def version(config_file_path, cli_version, display_callback=None):
+    version_buf = version_repr(version_data(config_file_path, cli_version, sys.argv))
+    display_callback(version_buf)
+    return 0

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -34,12 +34,12 @@ from ansible_galaxy.actions import info
 from ansible_galaxy.actions import init
 from ansible_galaxy.actions import list as list_action
 from ansible_galaxy.actions import remove
+from ansible_galaxy.actions import version
 from ansible_galaxy.config import defaults
 from ansible_galaxy.config import config
 from ansible_galaxy_cli import exceptions as cli_exceptions
 from ansible_galaxy import matchers
 from ansible_galaxy.models.context import GalaxyContext
-from ansible_galaxy.utils.text import to_text
 
 from ansible_galaxy import rest_api
 
@@ -351,11 +351,6 @@ class GalaxyCLI(cli.CLI):
                                 display_callback=self.display)
 
     def execute_version(self):
-        self.display('Ansible Galaxy CLI, version', galaxy_cli_version)
-        self.display(', '.join(os.uname()))
-        self.display(sys.version, sys.executable)
-        if self.config_file_path:
-            self.display(u"Using %s as config file" % to_text(self.config_file_path))
-        else:
-            self.display(u"No config file found; using defaults")
-        return True
+        return version.version(config_file_path=self.config_file_path,
+                               cli_version=galaxy_cli_version,
+                               display_callback=self.display)

--- a/tests/ansible_galaxy/actions/test_version.py
+++ b/tests/ansible_galaxy/actions/test_version.py
@@ -1,0 +1,70 @@
+import logging
+
+from ansible_galaxy.actions import version
+
+log = logging.getLogger(__name__)
+
+
+def test_version_data():
+    config_path = '/dev/null/some/faux/mazer.yml'
+    cli_version = '1.2.3'
+    args = ['/bin/mazer', 'version']
+
+    res = version.version_data(config_file_path=config_path,
+                               cli_version=cli_version,
+                               argv=args)
+
+    log.debug('res: %s', res)
+
+    assert isinstance(res, dict)
+
+    for field in version.VERSION_FIELDS:
+        assert field in res
+
+    assert res['config_file'] == config_path
+    assert res['version'] == cli_version
+    assert res['executable_location'] == args[0]
+
+
+def test_version():
+    config_path = '/dev/null/some/faux/mazer.yml'
+    cli_version = '1.2.3'
+    # args = ['/bin/mazer', 'version']
+
+    display_items = []
+
+    def callback(*args):
+        for arg in args:
+            display_items.append(arg)
+
+    res = version.version(config_file_path=config_path,
+                          cli_version=cli_version,
+                          display_callback=callback)
+
+    assert res == 0
+
+    log.debug('display_items: %s', display_items)
+
+    lines = display_items[0].splitlines()
+    assert 'mazer' in lines[0]
+
+
+def test_version_repr():
+    config_path = '/dev/null/some/faux/mazer.yml'
+    cli_version = '1.2.3'
+    args = ['/bin/mazer', 'version']
+
+    data = version.version_data(config_file_path=config_path,
+                                cli_version=cli_version,
+                                argv=args)
+
+    res = version.version_repr(data)
+    assert 'mazer.yml' in res
+
+
+def test_version_repr_empty_data():
+    data = {}
+    res = version.version_repr(data)
+
+    assert 'name =' in res
+    assert 'version =' in res


### PR DESCRIPTION
##### SUMMARY
Mv cli 'version' logic to ansible_galaxy.action.version

Update the version format to look more like the
'ansible --version' output.

Add unit tests. 

a little overkill after I noticed the 'mazer version' output had a line like
```
Ansible Galaxy CLI, version0.1.0
```

New format is also slightly easier to parse for something like the issue triage bots

<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request



##### GALAXY CLI VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.1.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.16.6-202.fc27.x86_64, #1 SMP Wed May 2 00:09:32 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3/bin/mazer
python_version = 3.6.5 (default, Apr  4 2018, 15:01:18) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

