### PR TITLE
Clean up cli args and help. Rm -g, hide -t

### DIFF
--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -24,6 +24,7 @@ __metaclass__ = type
 
 import json
 import logging
+import optparse
 import os
 import sys
 
@@ -79,7 +80,7 @@ class GalaxyCLI(cli.CLI):
 
         # specific to actions
         if self.action == "info":
-            self.parser.set_usage("usage: %prog info [options] role_name[,version]")
+            self.parser.set_usage("usage: %prog info [options] repo_name[,version]")
 
         elif self.action == "init":
             self.parser.set_usage("usage: %prog init [options] role_name")
@@ -91,21 +92,20 @@ class GalaxyCLI(cli.CLI):
                                    help='The path to a role skeleton that the new role should be based upon.')
 
         elif self.action == "install":
-            self.parser.set_usage("usage: %prog install [options] [-r FILE | role_name(s)[,version] | scm+role_repo_url[,version] | tar_file(s)]")
+            self.parser.set_usage("usage: %prog install [options] [-r FILE | repo_name(s)[,version] | scm+repo_url[,version] | tar_file(s)]")
             self.parser.add_option('-i', '--ignore-errors', dest='ignore_errors', action='store_true', default=False,
-                                   help='Ignore errors and continue with the next specified role.')
+                                   help='Ignore errors and continue with the next specified repo.')
             self.parser.add_option('-n', '--no-deps', dest='no_deps', action='store_true', default=False, help='Don\'t download roles listed as dependencies')
             self.parser.add_option('-r', '--role-file', dest='role_file', help='A file containing a list of roles to be imported')
-            # TODO: test this with multi-content repos
-            self.parser.add_option('-g', '--keep-scm-meta', dest='keep_scm_meta', action='store_true',
-                                   default=False, help='Use tar instead of the scm archive option when packaging the role')
-            self.parser.add_option('-t', '--type', dest='content_type', default="all", help='A type of Galaxy Content to install: role, module, etc')
+            self.parser.add_option('-t', '--type', dest='content_type', default="all",
+                                   # help='A type of Galaxy Content to install: role, module, etc',
+                                   help=optparse.SUPPRESS_HELP)
             self.parser.add_option('--namespace', dest='namespace', default=None,
                                    help='The namespace to use when installing content (required for installs from local scm repo or archives)')
         elif self.action == "remove":
-            self.parser.set_usage("usage: %prog remove role1 role2 ...")
+            self.parser.set_usage("usage: %prog remove repo1 repo2 ...")
         elif self.action == "list":
-            self.parser.set_usage("usage: %prog list [role_name]")
+            self.parser.set_usage("usage: %prog list [repo_name]")
         elif self.action == "version":
             self.parser.set_usage("usage: %prog version")
 
@@ -123,7 +123,7 @@ class GalaxyCLI(cli.CLI):
                                    help='The path to the directory containing your galaxy content. The default is the content_path configured in your'
                                         'ansible.cfg file (/etc/ansible/content if not configured)', type='str')
         if self.action in ("init", "install"):
-            self.parser.add_option('-f', '--force', dest='force', action='store_true', default=False, help='Force overwriting an existing role')
+            self.parser.add_option('-f', '--force', dest='force', action='store_true', default=False, help='Force overwriting an existing repo')
 
     def parse(self):
         ''' create an options parser for bin/ansible '''

--- a/tests/ansible_galaxy_cli/cli/test_galaxy_upstream.py
+++ b/tests/ansible_galaxy_cli/cli/test_galaxy_upstream.py
@@ -189,11 +189,11 @@ class TestGalaxy(unittest.TestCase):
             self.assertIsInstance(galaxycli_obj.parser, ansible_galaxy_cli.cli.SortedOptParser)
             # self.assertIsInstance(galaxycli_obj.galaxy, ansible_galaxy.models.context.GalaxyContext)
             formatted_call = {
-                'info': 'usage: %prog info [options] role_name[,version]',
+                'info': 'usage: %prog info [options] repo_name[,version]',
                 'init': 'usage: %prog init [options] role_name',
-                'install': 'usage: %prog install [options] [-r FILE | role_name(s)[,version] | scm+role_repo_url[,version] | tar_file(s)]',
-                'list': 'usage: %prog list [role_name]',
-                'remove': 'usage: %prog remove role1 role2 ...',
+                'install': 'usage: %prog install [options] [-r FILE | repo_name(s)[,version] | scm+repo_url[,version] | tar_file(s)]',
+                'list': 'usage: %prog list [repo_name]',
+                'remove': 'usage: %prog remove repo1 repo2 ...',
                 'version': 'usage: %prog version',
             }
 


### PR DESCRIPTION
The '-g', '--keep-scm-meta' option isnt used
at the moment, so remove it.

The '-t', '--content-type' doesn't do much
at the moment, so hide it by default. Since
there is logic that references it, keep the option
attribute however.

Update some references of 'roles' to 'repos'

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 - Docs Pull Request


##### GALAXY CLI VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
Ansible Galaxy CLI, version0.1.0
Linux, newswoop, 4.16.6-202.fc27.x86_64, #1 SMP Wed May 2 00:09:32 UTC 2018, x86_64
3.6.5 (default, Apr  4 2018, 15:01:18) 
[GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]/home/adrian/venvs/galaxy-cli-py3/bin/python
Using /home/adrian/.ansible/mazer.yml as config file


```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

