### PR TITLE
Fix 'info' display errors

### DIFF
--- a/ansible_galaxy/flat_rest_api/content.py
+++ b/ansible_galaxy/flat_rest_api/content.py
@@ -190,6 +190,10 @@ class GalaxyContent(object):
         return self.content_meta.name
 
     @property
+    def label(self):
+        return self.content_meta.label
+
+    @property
     def version(self):
         return self.content_meta.version
 

--- a/ansible_galaxy/installed_content_db.py
+++ b/ansible_galaxy/installed_content_db.py
@@ -77,6 +77,7 @@ def installed_content_iterator(galaxy_context,
                     version = "(unknown version)"
                 # display_callback("- %s, %s" % (path_file, version))
 
+            log.debug('gr__dict__: %s', gr.__dict__)
             if not content_match_filter(gr):
                 log.debug('%s was not matched by content_match_filter: %s', gr, content_match_filter)
                 continue


### PR DESCRIPTION
##### SUMMARY
Fix 'info' display errors

Use installed_*_db in 'info' command

Fixes #96


<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request



##### GALAXY CLI VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.1.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.16.6-202.fc27.x86_64, #1 SMP Wed May 2 00:09:32 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3/bin/mazer
python_version = 3.6.5 (default, Apr  4 2018, 15:01:18) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

