### PR TITLE
Add a custom user-agent to http requests

### DIFF
--- a/tests/ansible_galaxy/test_rest_api.py
+++ b/tests/ansible_galaxy/test_rest_api.py
@@ -2,6 +2,7 @@ import io
 import logging
 import json
 import ssl
+import sys
 
 import pytest
 import mock
@@ -9,6 +10,7 @@ import mock
 from six.moves.urllib.error import HTTPError
 from six import text_type
 
+import ansible_galaxy
 from ansible_galaxy import exceptions
 from ansible_galaxy.models.context import GalaxyContext
 from ansible_galaxy import rest_api
@@ -506,3 +508,11 @@ def test_galaxy_api_lookup_content_by_name_empty_results(mocker, galaxy_api):
 
     # expect an empty dict returned in this case
     assert res == {}
+
+
+def test_user_agent():
+    res = rest_api.user_agent()
+    assert res.startswith('Mazer/%s' % ansible_galaxy.__version__)
+    assert sys.platform in res
+    assert 'python:' in res
+    assert 'ansible_galaxy' in res


### PR DESCRIPTION
##### SUMMARY
Add a custom user-agent to http requests

user_agent() builder, use plain open_url for now

add user_agent() to create a user agent string like:

    Mazer/0.1.0 (linux; python:3.6.5) ansible_galaxy/0.1.0

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request
 - Docs Pull Request


##### GALAXY CLI VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

