### PR TITLE
generate man page via rst and rst2man

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# generated docs
+docs/man/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,28 @@ RST_DOCS_DIR=docs/rst
 	dev/bumpversion-path dev/bumpversion-minor dev/bumpversion-major
 .DEFAULT_GOAL := help
 
+# This doesn't evaluate until it's called. The -D argument is the
+# directory of the target file ($@), kinda like `dirname`.
+MANPAGES ?= $(patsubst %.rst.in,%,$(wildcard ./docs/man/man1/mazer*.1.rst.in))
+ifneq ($(shell which rst2man 2>/dev/null),)
+RST2MAN = rst2man $< $@
+else ifneq ($(shell which rst2man.py 2>/dev/null),)
+RST2MAN = rst2man.py $< $@
+else
+RST2MAN = @echo "ERROR: rst2man from docutils command is not installed but is required to build $(MANPAGES)" && exit 1
+endif
+GENERATE_CLI = docs/bin/generate_man.py
+
+# Regenerate %.1.rst if %.1.rst.in has been modified more
+# recently than %.1.rst.
+%.1.rst: %.1.rst.in
+	sed "s/%VERSION%/$(VERSION)/" $< > $@
+	rm $<
+
+# Regenerate %.1 if %.1.rst or ansible_galaxy/__init__.py (where __version__ is defined)
+# has been modified more recently than %.1. (Implicitly runs the %.1.rst recipe)
+%.1: %.1.rst ansible_galaxy/__init__.py
+	$(RST2MAN)
 
 clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
 
@@ -46,6 +68,14 @@ docs: ## generate Sphinx HTML documentation, including API docs
 	sphinx-apidoc -o $(RST_DOCS_DIR) ansible_galaxy_cli
 	$(MAKE) -C $(RST_DOCS_DIR) clean
 	$(MAKE) -C $(RST_DOCS_DIR) html
+
+.PHONY: generate_rst
+generate_man_rst: ansible_galaxy_cli/cli/*.py
+	mkdir -p ./docs/man/man1/ ; \
+	PYTHONPATH=./lib $(GENERATE_CLI) --template-file=docs/templates/man.j2 --output-dir=docs/man/man1/ --output-format man ansible_galaxy_cli/cli/*.py
+
+man: generate_man_rst
+	$(MAKE) $(MANPAGES)
 
 dev/bumpversion-patch:
 	bumpversion --verbose patch

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -203,7 +203,7 @@ class GalaxyCLI(cli.CLI):
     # TODO: most of this logic should be out of cli class
     def execute_init(self):
         """
-        creates the skeleton framework of a role that complies with the galaxy metadata format.
+        Creates the skeleton framework of a role that complies with the galaxy metadata format.
         """
 
         init_path = self.options.init_path
@@ -247,7 +247,7 @@ class GalaxyCLI(cli.CLI):
 
     def execute_info(self):
         """
-        prints out detailed information about an installed role as well as info available from the galaxy API.
+        Show detailed information about an installed role as well as info available from the galaxy API.
         """
 
         if len(self.args) == 0:
@@ -267,8 +267,10 @@ class GalaxyCLI(cli.CLI):
 
     def execute_install(self):
         """
-        uses the args list of roles to be installed, unless -f was specified. The list of roles
-        can be a name (which will be downloaded via the galaxy API and github), or it can be a local .tar.gz file.
+        Install the args list of roles to be installed, unless -f was specified.
+
+        The list of roles can be a name (which will be downloaded via the galaxy API and github),
+        or it can be a local .tar.gz file.
         """
 
         install_content_type = self.options.content_type
@@ -319,7 +321,7 @@ class GalaxyCLI(cli.CLI):
 
     def execute_remove(self):
         """
-        removes the list of roles passed as arguments from the local system.
+        Removes the list of roles from the local system.
         """
 
         if len(self.args) == 0:
@@ -336,7 +338,7 @@ class GalaxyCLI(cli.CLI):
 
     def execute_list(self):
         """
-        lists the roles installed on the local system or matches a single role passed as an argument.
+        Lists the roles installed on the local system or matches a single role passed as an argument.
         """
 
         galaxy_context = self._get_galaxy_context(self.options, self.config)

--- a/docs/bin/generate_man.py
+++ b/docs/bin/generate_man.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python
+
+import optparse
+import os
+import pprint
+import sys
+
+from jinja2 import Environment, FileSystemLoader
+
+from ansible.module_utils._text import to_bytes
+
+
+def generate_parser():
+    p = optparse.OptionParser(
+        version='%prog 1.0',
+        usage='usage: %prog [options]',
+        description='Generate cli documentation from cli docstrings',
+    )
+
+    p.add_option("-t", "--template-file", action="store", dest="template_file", default="../templates/man.j2", help="path to jinja2 template")
+    p.add_option("-o", "--output-dir", action="store", dest="output_dir", default='/tmp/', help="Output directory for rst files")
+    p.add_option("-f", "--output-format", action="store", dest="output_format", default='man', help="Output format for docs (the default 'man' or 'rst')")
+    return p
+
+
+# from https://www.python.org/dev/peps/pep-0257/
+def trim_docstring(docstring):
+    if not docstring:
+        return ''
+    # Convert tabs to spaces (following the normal Python rules)
+    # and split into a list of lines:
+    lines = docstring.expandtabs().splitlines()
+    # Determine minimum indentation (first line doesn't count):
+    indent = sys.maxsize
+    for line in lines[1:]:
+        stripped = line.lstrip()
+        if stripped:
+            indent = min(indent, len(line) - len(stripped))
+    # Remove indentation (first line is special):
+    trimmed = [lines[0].strip()]
+    if indent < sys.maxsize:
+        for line in lines[1:]:
+            trimmed.append(line[indent:].rstrip())
+    # Strip off trailing and leading blank lines:
+    while trimmed and not trimmed[-1]:
+        trimmed.pop()
+    while trimmed and not trimmed[0]:
+        trimmed.pop(0)
+    # Return a single string:
+    return '\n'.join(trimmed)
+
+
+def get_options(optlist):
+    ''' get actual options '''
+
+    opts = []
+    for opt in optlist:
+        res = {
+            'desc': opt.help,
+            'options': opt._short_opts + opt._long_opts
+        }
+        if opt.action == 'store':
+            res['arg'] = opt.dest.upper()
+        opts.append(res)
+
+    return opts
+
+
+def get_option_groups(option_parser):
+    groups = []
+    for option_group in option_parser.option_groups:
+        group_info = {}
+        group_info['desc'] = option_group.get_description()
+        group_info['options'] = option_group.option_list
+        group_info['group_obj'] = option_group
+        groups.append(group_info)
+    return groups
+
+
+def opt_doc_list(cli):
+    ''' iterate over options lists '''
+
+    results = []
+    for option_group in cli.parser.option_groups:
+        results.extend(get_options(option_group.option_list))
+
+    results.extend(get_options(cli.parser.option_list))
+
+    return results
+
+
+# def opts_docs(cli, name):
+def opts_docs(cli_class_name, cli_module_name):
+    ''' generate doc structure from options '''
+
+    cli_name = 'ansible-%s' % cli_module_name
+    if cli_module_name == 'adhoc':
+        cli_name = 'ansible'
+
+    # WIth no action/subcommand
+    # shared opts set
+    # instantiate each cli and ask its options
+    cli_klass = getattr(__import__("ansible.cli.%s" % cli_module_name,
+                                   fromlist=[cli_class_name]), cli_class_name)
+    cli = cli_klass([])
+
+    # parse the common options
+    try:
+        cli.parse()
+    except:
+        pass
+
+    # base/common cli info
+    docs = {
+        'cli': cli_module_name,
+        'cli_name': cli_name,
+        'usage': cli.parser.usage,
+        'short_desc': cli.parser.description,
+        'long_desc': trim_docstring(cli.__doc__),
+        'actions': {},
+    }
+    option_info = {'option_names': [],
+                   'options': [],
+                   'groups': []}
+
+    for extras in ('ARGUMENTS'):
+        if hasattr(cli, extras):
+            docs[extras.lower()] = getattr(cli, extras)
+
+    common_opts = opt_doc_list(cli)
+    groups_info = get_option_groups(cli.parser)
+    shared_opt_names = []
+    for opt in common_opts:
+        shared_opt_names.extend(opt.get('options', []))
+
+    option_info['options'] = common_opts
+    option_info['option_names'] = shared_opt_names
+
+    option_info['groups'].extend(groups_info)
+
+    docs.update(option_info)
+
+    # now for each action/subcommand
+    # force populate parser with per action options
+
+    # use class attrs not the attrs on a instance (not that it matters here...)
+    for action in getattr(cli_klass, 'VALID_ACTIONS', ()):
+        # instantiate each cli and ask its options
+        action_cli_klass = getattr(__import__("ansible.cli.%s" % cli_module_name,
+                                              fromlist=[cli_class_name]), cli_class_name)
+        # init with args with action added?
+        cli = action_cli_klass([])
+        cli.args.append(action)
+
+        try:
+            cli.parse()
+        except:
+            pass
+
+        # FIXME/TODO: needed?
+        # avoid dupe errors
+        cli.parser.set_conflict_handler('resolve')
+
+        cli.set_action()
+
+        action_info = {'option_names': [],
+                       'options': []}
+        # docs['actions'][action] = {}
+        # docs['actions'][action]['name'] = action
+        action_info['name'] = action
+        action_info['desc'] = trim_docstring(getattr(cli, 'execute_%s' % action).__doc__)
+
+        # docs['actions'][action]['desc'] = getattr(cli, 'execute_%s' % action).__doc__.strip()
+        action_doc_list = opt_doc_list(cli)
+
+        uncommon_options = []
+        for action_doc in action_doc_list:
+            # uncommon_options = []
+
+            option_aliases = action_doc.get('options', [])
+            for option_alias in option_aliases:
+
+                if option_alias in shared_opt_names:
+                    continue
+
+                # TODO: use set
+                if option_alias not in action_info['option_names']:
+                    action_info['option_names'].append(option_alias)
+
+                if action_doc in action_info['options']:
+                    continue
+
+                uncommon_options.append(action_doc)
+
+            action_info['options'] = uncommon_options
+
+        docs['actions'][action] = action_info
+
+    docs['options'] = opt_doc_list(cli)
+    return docs
+
+
+if __name__ == '__main__':
+
+    parser = generate_parser()
+
+    options, args = parser.parse_args()
+
+    template_file = options.template_file
+    template_path = os.path.expanduser(template_file)
+    template_dir = os.path.abspath(os.path.dirname(template_path))
+    template_basename = os.path.basename(template_file)
+
+    output_dir = os.path.abspath(options.output_dir)
+    output_format = options.output_format
+
+    cli_modules = args
+
+    # various cli parsing things checks sys.argv if the 'args' that are passed in are []
+    # so just remove any args so the cli modules dont try to parse them resulting in warnings
+    sys.argv = [sys.argv[0]]
+    # need to be in right dir
+    os.chdir(os.path.dirname(__file__))
+
+    allvars = {}
+    output = {}
+    cli_list = []
+    cli_bin_name_list = []
+
+    # for binary in os.listdir('../../lib/ansible/cli'):
+    for cli_module_name in cli_modules:
+        binary = os.path.basename(os.path.expanduser(cli_module_name))
+
+        if not binary.endswith('.py'):
+            continue
+        elif binary == '__init__.py':
+            continue
+
+        cli_name = os.path.splitext(binary)[0]
+
+        if cli_name == 'adhoc':
+            cli_class_name = 'AdHocCLI'
+            # myclass = 'AdHocCLI'
+            output[cli_name] = 'ansible.1.rst.in'
+            cli_bin_name = 'ansible'
+        else:
+            # myclass = "%sCLI" % libname.capitalize()
+            cli_class_name = "%sCLI" % cli_name.capitalize()
+            output[cli_name] = 'ansible-%s.1.rst.in' % cli_name
+            cli_bin_name = 'ansible-%s' % cli_name
+
+        # FIXME:
+        allvars[cli_name] = opts_docs(cli_class_name, cli_name)
+        cli_bin_name_list.append(cli_bin_name)
+
+    cli_list = allvars.keys()
+
+    doc_name_formats = {'man': '%s.1.rst.in',
+                        'rst': '%s.rst'}
+
+    for cli_name in cli_list:
+
+        # template it!
+        env = Environment(loader=FileSystemLoader(template_dir))
+        template = env.get_template(template_basename)
+
+        # add rest to vars
+        tvars = allvars[cli_name]
+        tvars['cli_list'] = cli_list
+        tvars['cli_bin_name_list'] = cli_bin_name_list
+        tvars['cli'] = cli_name
+        if '-i' in tvars['options']:
+            print('uses inventory')
+
+        manpage = template.render(tvars)
+        filename = os.path.join(output_dir, doc_name_formats[output_format] % tvars['cli_name'])
+
+        with open(filename, 'wb') as f:
+            f.write(to_bytes(manpage))
+            print("Wrote doc to %s" % filename)

--- a/docs/bin/generate_man.py
+++ b/docs/bin/generate_man.py
@@ -7,7 +7,7 @@ import sys
 
 from jinja2 import Environment, FileSystemLoader
 
-from ansible.module_utils._text import to_bytes
+from ansible_galaxy.utils.text import to_bytes
 
 
 def generate_parser():
@@ -93,14 +93,12 @@ def opt_doc_list(cli):
 def opts_docs(cli_class_name, cli_module_name):
     ''' generate doc structure from options '''
 
-    cli_name = 'ansible-%s' % cli_module_name
-    if cli_module_name == 'adhoc':
-        cli_name = 'ansible'
+    cli_name = "mazer"
 
     # WIth no action/subcommand
     # shared opts set
     # instantiate each cli and ask its options
-    cli_klass = getattr(__import__("ansible.cli.%s" % cli_module_name,
+    cli_klass = getattr(__import__("ansible_galaxy_cli.cli.%s" % cli_module_name,
                                    fromlist=[cli_class_name]), cli_class_name)
     cli = cli_klass([])
 
@@ -146,7 +144,7 @@ def opts_docs(cli_class_name, cli_module_name):
     # use class attrs not the attrs on a instance (not that it matters here...)
     for action in getattr(cli_klass, 'VALID_ACTIONS', ()):
         # instantiate each cli and ask its options
-        action_cli_klass = getattr(__import__("ansible.cli.%s" % cli_module_name,
+        action_cli_klass = getattr(__import__("ansible_galaxy_cli.cli.%s" % cli_module_name,
                                               fromlist=[cli_class_name]), cli_class_name)
         # init with args with action added?
         cli = action_cli_klass([])
@@ -246,8 +244,10 @@ if __name__ == '__main__':
         else:
             # myclass = "%sCLI" % libname.capitalize()
             cli_class_name = "%sCLI" % cli_name.capitalize()
-            output[cli_name] = 'ansible-%s.1.rst.in' % cli_name
-            cli_bin_name = 'ansible-%s' % cli_name
+            # output[cli_name] = 'ansible-%s.1.rst.in' % cli_name
+            output[cli_name] = 'mazer.1.rst.in'
+            # cli_bin_name = 'ansible-%s' % cli_name
+            cli_bin_name = 'mazer'
 
         # FIXME:
         allvars[cli_name] = opts_docs(cli_class_name, cli_name)

--- a/docs/templates/man.j2
+++ b/docs/templates/man.j2
@@ -1,0 +1,124 @@
+{% set name = ('ansible' if cli == 'adhoc' else 'ansible-%s' % cli) -%}
+{{name}}
+{{ '=' * ( name|length|int ) }}
+
+{{ '-' * ( short_desc|default('')|string|length|int ) }}
+{{short_desc|default('')}}
+{{ '-' * ( short_desc|default('')|string|length|int ) }}
+
+:Version:        Ansible %VERSION%
+:Manual section: 1
+:Manual group:   System administration commands
+
+
+
+SYNOPSIS
+--------
+{{ usage|replace('%prog', name) }}
+
+
+DESCRIPTION
+-----------
+{{ long_desc|default('', True)|wordwrap }}
+
+{% if options %}
+COMMON OPTIONS
+--------------
+{% for option in options|sort(attribute='options') %}
+{% for switch in option['options'] %}**{{switch}}**{% if option['arg'] %} '{{option['arg']}}'{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}
+
+  {{ option['desc'] }}
+{% endfor %}
+{% endif %}
+
+{% if arguments %}
+ARGUMENTS
+---------
+
+{% for arg in arguments %}
+{{ arg }}
+
+{{ (arguments[arg]|default(' '))|wordwrap }}
+
+{% endfor %}
+{% endif %}
+
+{% if actions %}
+ACTIONS
+-------
+{% for action in actions %}
+**{{ action }}**
+  {{ (actions[action]['desc']|default(' '))}}
+
+{% if actions[action]['options'] %}
+{% for option in actions[action]['options']|sort(attribute='options') %}
+{% for switch in option['options'] if switch in actions[action]['option_names'] %}  **{{switch}}**{% if option['arg'] %} '{{option['arg']}}'{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}
+
+        {{ (option['desc']) }}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+
+{% if inventory %}
+INVENTORY
+---------
+
+Ansible stores the hosts it can potentially operate on in an inventory.
+This can be an YAML file, ini-like file, a script, directory, list, etc.
+For additional options, see the documentation on https://docs.ansible.com/.
+
+{% endif %}
+ENVIRONMENT
+-----------
+
+The following environment variables may be specified.
+
+{% if inventory %}
+ANSIBLE_INVENTORY  -- Override the default ansible inventory file
+
+{% endif %}
+{% if library %}
+ANSIBLE_LIBRARY -- Override the default ansible module library path
+
+{% endif %}
+ANSIBLE_CONFIG -- Override the default ansible config file
+
+Many more are available for most options in ansible.cfg
+
+
+FILES
+-----
+
+{% if inventory %}
+/etc/ansible/hosts -- Default inventory file
+
+{% endif %}
+/etc/ansible/ansible.cfg -- Config file, used if present
+
+~/.ansible.cfg -- User config file, overrides the default config if present
+
+
+AUTHOR
+------
+
+Ansible was originally written by Michael DeHaan.
+
+
+COPYRIGHT
+---------
+
+Copyright © 2017 Red Hat, Inc | Ansible.
+Ansible is released under the terms of the GPLv3 License.
+
+
+SEE ALSO
+--------
+
+{% for other in cli_list|sort %}{% if other != cli %}**ansible{% if other != 'adhoc' %}-{{other}}{% endif %}** (1){% if not loop.last %}, {% endif %}{% endif %}{% endfor %}
+
+Extensive documentation is available in the documentation site:
+<https://docs.ansible.com>.
+IRC and mailing list info can be found in file CONTRIBUTING.md,
+available in: <https://github.com/ansible/ansible>

--- a/docs/templates/man.j2
+++ b/docs/templates/man.j2
@@ -1,4 +1,4 @@
-{% set name = cli -%}
+{% set name = 'mazer' -%}
 {{name}}
 {{ '=' * ( name|length|int ) }}
 

--- a/docs/templates/man.j2
+++ b/docs/templates/man.j2
@@ -1,4 +1,4 @@
-{% set name = ('ansible' if cli == 'adhoc' else 'ansible-%s' % cli) -%}
+{% set name = cli -%}
 {{name}}
 {{ '=' * ( name|length|int ) }}
 
@@ -6,7 +6,7 @@
 {{short_desc|default('')}}
 {{ '-' * ( short_desc|default('')|string|length|int ) }}
 
-:Version:        Ansible %VERSION%
+:Version:        Mazer %VERSION%
 :Manual section: 1
 :Manual group:   System administration commands
 
@@ -61,43 +61,17 @@ ACTIONS
 {% endif %}
 
 
-{% if inventory %}
-INVENTORY
----------
-
-Ansible stores the hosts it can potentially operate on in an inventory.
-This can be an YAML file, ini-like file, a script, directory, list, etc.
-For additional options, see the documentation on https://docs.ansible.com/.
-
-{% endif %}
 ENVIRONMENT
 -----------
 
 The following environment variables may be specified.
 
-{% if inventory %}
-ANSIBLE_INVENTORY  -- Override the default ansible inventory file
-
-{% endif %}
-{% if library %}
-ANSIBLE_LIBRARY -- Override the default ansible module library path
-
-{% endif %}
-ANSIBLE_CONFIG -- Override the default ansible config file
-
-Many more are available for most options in ansible.cfg
 
 
 FILES
 -----
 
-{% if inventory %}
-/etc/ansible/hosts -- Default inventory file
-
-{% endif %}
-/etc/ansible/ansible.cfg -- Config file, used if present
-
-~/.ansible.cfg -- User config file, overrides the default config if present
+~/.ansible/mazer.yml -- User config file, overrides the default config if present
 
 
 AUTHOR
@@ -109,16 +83,14 @@ Ansible was originally written by Michael DeHaan.
 COPYRIGHT
 ---------
 
-Copyright © 2017 Red Hat, Inc | Ansible.
-Ansible is released under the terms of the GPLv3 License.
+Copyright © 2018 Red Hat, Inc | Ansible.
+Mazer is released under the terms of the GPLv3 License.
 
 
 SEE ALSO
 --------
 
-{% for other in cli_list|sort %}{% if other != cli %}**ansible{% if other != 'adhoc' %}-{{other}}{% endif %}** (1){% if not loop.last %}, {% endif %}{% endif %}{% endfor %}
-
 Extensive documentation is available in the documentation site:
-<https://docs.ansible.com>.
+<https://galaxy.ansible.com/docs>.
 IRC and mailing list info can be found in file CONTRIBUTING.md,
-available in: <https://github.com/ansible/ansible>
+available in: <https://github.com/ansible/mazer>


### PR DESCRIPTION
##### SUMMARY
Generate mazer man page via the auto-man tools based on
those from ansible at https://galaxy-qa.ansible.com/docs/mazer/configure.html#mazer-yml

`make man`  should generate a docs/man/man1/mazer.1

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Docs Pull Request


##### GALAXY CLI VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.1.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.16.6-202.fc27.x86_64, #1 SMP Wed May 2 00:09:32 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3/bin/mazer
python_version = 3.6.5 (default, Apr  4 2018, 15:01:18) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

