### PR TITLE
Add a sep installed_namespace_db, update install for new namespace format

### DIFF
--- a/ansible_galaxy/actions/info.py
+++ b/ansible_galaxy/actions/info.py
@@ -16,14 +16,21 @@ log = logging.getLogger(__name__)
 SKIP_INFO_KEYS = ("name", "description", "readme_html", "related", "summary_fields", "average_aw_composite", "average_aw_score", "url")
 
 REPO_TEMPLATE = """
-content_type: {content_type}
-namespace: {namespace}
-repo_name: {repo_name}
-name: {content_name}
-description: {description}
-scm: {repo_clone_url}"""
+label: {repo_label}
+namespace: {repo_namespace}
+name: {repo_name}
+format: {repo_format}
+latest_version: {repo_latest_version}
+description: {repo_description}
+scm: {repo_clone_url}
 
-CONTENT_TEMPLATE = """path: {path}"""
+{repo_contents}"""
+
+CONTENT_TEMPLATE = """    content_name: {content_name}
+    content_type: {content_type}
+    description: {content_description}
+"""
+
 
 INSTALLED_CONTENT_TEMPLATE = """
 name: {name}
@@ -31,18 +38,43 @@ version: {version}"""
 
 
 # FIXME: format?
-def _repr_remote_data(remote_data):
+def _repr_remote_repo(remote_data):
     log.debug('remote_data: %s', remote_data)
     # print(remote_data)
 
     # flatten some info for format simplicity
-    remote_data['namespace'] = remote_data['summary_fields']['namespace']['name']
-    remote_data['content_type'] = remote_data['summary_fields']['content_type']['description']
-    remote_data['content_type'] = remote_data['summary_fields']['content_type']['name']
-    # remote_data['description'] = remote_data['summary_fields']['content_type']['description']
-    remote_data['repo_clone_url'] = remote_data['summary_fields']['repository']['clone_url']
-    remote_data['repo_name'] = remote_data['summary_fields']['repository']['original_name']
-    remote_data['content_name'] = remote_data['name']
+    repo_namespace = remote_data['summary_fields']['namespace']['name']
+    repo_name = remote_data['name']
+    remote_data['repo_label'] = "{namespace}.{name}".format(namespace=repo_namespace, name=repo_name)
+    remote_data['repo_namespace'] = remote_data['summary_fields']['namespace']['name']
+    remote_data['repo_description'] = remote_data['description']
+    remote_data['repo_clone_url'] = remote_data['clone_url']
+    # remote_data['repo_name'] = remote_data['summary_fields']['repository']['original_name']
+    remote_data['repo_name'] = remote_data['name']
+    remote_data['repo_format'] = remote_data['format']
+
+    content_info_parts = []
+    content_objects = remote_data['summary_fields']['content_objects']
+    for content_object in content_objects:
+        content_data = {}
+        content_data['content_name'] = content_object['name']
+        content_data['content_type'] = content_object['content_type']
+        content_data['content_description'] = content_object['description']
+
+        content_str = CONTENT_TEMPLATE.format(**content_data)
+        log.debug('content_str: %s', content_str)
+        content_info_parts.append(content_str)
+
+    versions = remote_data['summary_fields']['versions']
+    try:
+        latest_version = versions[0].get('version', 'N/A')
+    except IndexError:
+        latest_version = ""
+
+    remote_data['repo_latest_version'] = latest_version
+
+    remote_data['repo_contents'] = '\n'.join(content_info_parts)
+
     log.debug(pprint.pformat(remote_data))
     return REPO_TEMPLATE.format(**remote_data)
     # return pprint.pformat(content_info)
@@ -60,13 +92,6 @@ def _repr_installed_content(installed_content):
                       'version': installed_content['version'],
                       'path': installed_content['installed_repository'].path}
     return INSTALLED_CONTENT_TEMPLATE.format(**installed_data)
-
-
-def _repr_content_info(content_info):
-    log.debug('content_info obj: %s', content_info)
-    content_data = {}
-    content_data['path'] = content_info.get('path', '')
-    return CONTENT_TEMPLATE.format(**content_data)
 
 
 # TODO: move to a repr for Role?
@@ -113,29 +138,30 @@ def info_content_specs(galaxy_context,
 
     for content_spec in content_specs:
 
-        content_username, repo_name, content_name = parse_content_name(content_spec)
+        galaxy_namespace, repo_name, content_name = parse_content_name(content_spec)
 
         log.debug('content_spec=%s', content_spec)
-        log.debug('content_username=%s', content_username)
+        log.debug('galaxy_username=%s', galaxy_namespace)
         log.debug('repo_name=%s', repo_name)
         log.debug('content_name=%s', content_name)
 
         repo_name = repo_name or content_name
         log.debug('repo_name2=%s', repo_name)
 
-        matcher = matchers.MatchNamespacesOrLabels(['%s.%s' % (content_username, repo_name)])
+        matcher = matchers.MatchNamespacesOrLabels(['%s.%s' % (galaxy_namespace, repo_name)])
 
         matched_repos = irdb.select(repository_match_filter=matcher)
 
         matched_contents = icdb.select(repository_match_filter=matcher)
         # log.debug('matched_contents: %s', list(matched_contents))
 
-        content_path = os.path.join(content_path, '%s.%s' % (content_username, repo_name))
+        content_path = os.path.join(content_path, '%s.%s' % (galaxy_namespace, repo_name))
 
         remote_data = False
         if not offline:
-            remote_data = api.lookup_content_by_name(content_username, repo_name, content_name)
-            display_callback(_repr_remote_data(remote_data))
+            # remote_data = api.lookup_content_by_name(galaxy_namespace, repo_name, content_name)
+            remote_data = api.lookup_repo_by_name(galaxy_namespace, repo_name)
+            display_callback(_repr_remote_repo(remote_data))
         else:
             for matched_content in matched_contents:
                 display_callback(_repr_installed_content(matched_content))

--- a/ansible_galaxy/actions/list.py
+++ b/ansible_galaxy/actions/list.py
@@ -27,7 +27,7 @@ def list(galaxy_context,
                              # 'installed_repo_namespace': repo.namespace,
                              # 'installed_repo_name': repo.name,
                              # 'installed_repo_path': repo.path,
-                             'installed_repo_id': '%s.%s' % (repo.namespace, repo.name),
+                             'installed_repo_id': '%s.%s' % (repo.namespace.namespace, repo.name),
                              })
         display_callback("repo={installed_repo_id}, type={type}, name={name}, version={version}".format(**content_dict))
 

--- a/ansible_galaxy/flat_rest_api/content.py
+++ b/ansible_galaxy/flat_rest_api/content.py
@@ -325,9 +325,10 @@ class GalaxyContent(object):
                 member_matches = archive.filter_members_by_fnmatch(tar_file_members,
                                                                    match_pattern)
 
-                namespaced_content_path = '%s/%s/%s' % (namespace_repo_name,
-                                                        content_sub_dir,
-                                                        content_name)
+                namespaced_content_path = '%s/%s/%s/%s' % (content_meta.namespace,
+                                                           content_meta.name,
+                                                           content_sub_dir,
+                                                           content_name)
 
                 log.debug('namespaced_content_path: %s', namespaced_content_path)
 
@@ -406,9 +407,10 @@ class GalaxyContent(object):
 
         log.debug('namespace_repo_name: %s', namespace_repo_name)
 
-        namespaced_content_path = '%s/%s/%s' % (namespace_repo_name,
-                                                'roles',
-                                                content_meta.name)
+        namespaced_content_path = '%s/%s/%s/%s' % (content_meta.namespace,
+                                                   content_meta.name,
+                                                   'roles',
+                                                   content_meta.name)
 
         log.debug('namespace: %s', content_meta.namespace)
         log.debug('namespaced_content_path: %s', namespaced_content_path)
@@ -418,7 +420,8 @@ class GalaxyContent(object):
             # rel_path ~  roles/some-role/meta/main.yml for ex
             rel_path = member.name[len(parent_dir) + 1:]
 
-            namespaced_role_rel_path = os.path.join(namespace_repo_name, 'roles', content_meta.name, rel_path)
+            # namespaced_role_rel_path = os.path.join(namespace_repo_name, 'roles', content_meta.name, rel_path)
+            namespaced_role_rel_path = os.path.join(content_meta.namespace, content_meta.name,  'roles', content_meta.name, rel_path)
 
             # log.debug('namespaced_role_rel_path: %s', namespaced_role_rel_path)
 

--- a/ansible_galaxy/installed_namespaces_db.py
+++ b/ansible_galaxy/installed_namespaces_db.py
@@ -1,0 +1,62 @@
+
+import logging
+import os
+
+from ansible_galaxy import matchers
+from ansible_galaxy.models.repository_namespace import RepositoryNamespace
+
+log = logging.getLogger(__name__)
+
+
+def get_namespace_paths(content_path):
+    # TODO: abstract this a bit?  one to make it easier to mock, but also
+    #       possibly to prepare for nested dirs, multiple paths, various
+    #       filters/whitelist/blacklist/excludes, caching, or respecting
+    #       fs ordering, etc
+    try:
+        # TODO: filter on any rules for what a namespace path looks like
+        #       may one being 'somenamespace.somename' (a dot sep ns and name)
+        #
+        namespace_paths = os.listdir(content_path)
+    except OSError as e:
+        log.exception(e)
+        log.warn('The content path %s did not exist so no content or repositories were found.',
+                 content_path)
+        namespace_paths = []
+
+    return namespace_paths
+
+
+def installed_namespace_iterator(galaxy_context,
+                                 match_filter=None):
+
+    namespace_match_filter = match_filter or matchers.MatchAll()
+
+    content_path = galaxy_context.content_path
+
+    namespace_paths = get_namespace_paths(content_path)
+
+    for namespace_path in namespace_paths:
+        log.debug('namespace_path: %s', namespace_path)
+        namespace_full_path = os.path.join(content_path, namespace_path)
+
+        repository_namespace = RepositoryNamespace(namespace=namespace_path,
+                                                   path=namespace_full_path)
+
+        log.debug('repo_namespace: %s', repository_namespace)
+        if namespace_match_filter(repository_namespace):
+            yield repository_namespace
+
+
+class InstalledNamespaceDatabase(object):
+    def __init__(self, installed_context=None):
+        self.installed_context = installed_context
+
+    def select(self, namespace_match_filter=None):
+        namespace_match_filter = namespace_match_filter or matchers.MatchAll()
+
+        installed_namespaces = installed_namespace_iterator(self.installed_context,
+                                                            match_filter=namespace_match_filter)
+
+        for matched_namespace in installed_namespaces:
+            yield matched_namespace

--- a/ansible_galaxy/installed_repository_db.py
+++ b/ansible_galaxy/installed_repository_db.py
@@ -58,7 +58,7 @@ def installed_repository_iterator(galaxy_context,
 
             repository_full_path = os.path.join(content_path, namespace.namespace, repository_path)
             # log.debug('repo_fll_path: %s', repository_full_path)
-            content_repository = ContentRepository(namespace=namespace.namespace,
+            content_repository = ContentRepository(namespace=namespace,
                                                    name=repository_path,
                                                    path=repository_full_path)
 

--- a/ansible_galaxy/installed_repository_db.py
+++ b/ansible_galaxy/installed_repository_db.py
@@ -1,8 +1,8 @@
 import logging
 import os
 
-from ansible_galaxy import content_spec_parse
 from ansible_galaxy import matchers
+from ansible_galaxy import installed_namespaces_db
 from ansible_galaxy.models.content_repository import ContentRepository
 
 log = logging.getLogger(__name__)
@@ -12,7 +12,7 @@ def repository_match_all(content_repository):
     return True
 
 
-def get_repository_paths(content_path):
+def get_repository_paths(namespace_path):
     # TODO: abstract this a bit?  one to make it easier to mock, but also
     #       possibly to prepare for nested dirs, multiple paths, various
     #       filters/whitelist/blacklist/excludes, caching, or respecting
@@ -21,41 +21,51 @@ def get_repository_paths(content_path):
         # TODO: filter on any rules for what a namespace path looks like
         #       may one being 'somenamespace.somename' (a dot sep ns and name)
         #
-        namespace_paths = os.listdir(content_path)
+        repository_paths = os.listdir(namespace_path)
     except OSError as e:
         log.exception(e)
-        log.warn('The content path %s did not exist so no content or repositories were found.',
-                 content_path)
-        namespace_paths = []
+        log.warn('The namespace path %s did not exist so no content or repositories were found.',
+                 namespace_path)
+        repository_paths = []
 
-    return namespace_paths
+    return repository_paths
 
 
 def installed_repository_iterator(galaxy_context,
-                                  match_filter=None):
+                                  namespace_match_filter=None,
+                                  repository_match_filter=None):
 
-    repository_match_filter = match_filter or matchers.MatchAll()
+    namespace_match_filter = namespace_match_filter or matchers.MatchAll()
+    repository_match_filter = repository_match_filter or matchers.MatchAll()
+
     content_path = galaxy_context.content_path
 
-    repository_paths = get_repository_paths(content_path)
+    installed_namespace_db = installed_namespaces_db.InstalledNamespaceDatabase(galaxy_context)
 
-    log.debug('repository_paths for content_path=%s: %s', content_path, repository_paths)
+    # repository_paths = get_repository_paths(content_path)
 
-    for repository_path in repository_paths:
-        # log.debug('repo_path: %s', repository_path)
-        # use the default 'local' style content_spec_parse and name resolver
-        spec_data = content_spec_parse.spec_data_from_string(repository_path)
+    # log.debug('repository_paths for content_path=%s: %s', content_path, repository_paths)
 
-        repository_full_path = os.path.join(content_path, repository_path)
-        # log.debug('repo_fll_path: %s', repository_full_path)
-        content_repository = ContentRepository(namespace=spec_data.get('namespace'),
-                                               name=spec_data.get('name'),
-                                               path=repository_full_path)
+    for namespace in installed_namespace_db.select(namespace_match_filter=namespace_match_filter):
+        log.debug('namespace: %s', namespace)
+        log.debug('namespace.path: %s', namespace.path)
 
-        # log.debug('content_repo: %s', content_repository)
-        # log.debug('match: %s(%s) %s', repository_match_filter, content_repository, repository_match_filter(content_repository))
-        if repository_match_filter(content_repository):
-            yield content_repository
+        repository_paths = get_repository_paths(namespace.path)
+
+        for repository_path in repository_paths:
+            # use the default 'local' style content_spec_parse and name resolver
+            # spec_data = content_spec_parse.spec_data_from_string(repository_path)
+
+            repository_full_path = os.path.join(content_path, namespace.namespace, repository_path)
+            # log.debug('repo_fll_path: %s', repository_full_path)
+            content_repository = ContentRepository(namespace=namespace.namespace,
+                                                   name=repository_path,
+                                                   path=repository_full_path)
+
+            # log.debug('content_repo: %s', content_repository)
+            # log.debug('match: %s(%s) %s', repository_match_filter, content_repository, repository_match_filter(content_repository))
+            if repository_match_filter(content_repository):
+                yield content_repository
 
 
 class InstalledRepositoryDatabase(object):
@@ -63,12 +73,14 @@ class InstalledRepositoryDatabase(object):
     def __init__(self, installed_context=None):
         self.installed_context = installed_context
 
-    def select(self, repository_match_filter=None):
+    def select(self, namespace_match_filter=None, repository_match_filter=None):
         # ie, default to select * more or less
-        repository_match_filter = repository_match_filter or repository_match_all
+        repository_match_filter = repository_match_filter or matchers.MatchAll()
+        namespace_match_filter = namespace_match_filter or matchers.MatchAll()
 
         installed_repositories = installed_repository_iterator(self.installed_context,
-                                                               match_filter=repository_match_filter)
+                                                               namespace_match_filter=namespace_match_filter,
+                                                               repository_match_filter=repository_match_filter)
 
         for matched_repository in installed_repositories:
             yield matched_repository

--- a/ansible_galaxy/matchers.py
+++ b/ansible_galaxy/matchers.py
@@ -46,5 +46,6 @@ class MatchNamespacesOrLabels(Match):
 
     def match(self, other):
         log.debug('self.namespaces_or_labels: %s other.namespace: %s other.label: %s', self.namespaces_or_labels, other.namespace, other.label)
+        # TODO: should this matcher require a namespace string or a namespace object? either?
         return any([other.label in self.namespaces_or_labels,
-                    other.namespace in self.namespaces_or_labels])
+                    other.namespace.namespace in self.namespaces_or_labels])

--- a/ansible_galaxy/models/content_repository.py
+++ b/ansible_galaxy/models/content_repository.py
@@ -3,6 +3,8 @@ import shutil
 
 import yaml
 
+from ansible_galaxy.models import repository_namespace
+
 log = logging.getLogger(__name__)
 
 # The galaxy_metadata will contain a dict that defines
@@ -71,14 +73,18 @@ class ContentRepository(object):
                  name=None,
                  label=None,
                  path=None):
+        # a RepositoryNamespace instance
         self.namespace = namespace
         self.name = name
         self.path = path
-        self.label = label or '%s.%s' % (self.namespace, self.name)
+        if self.namespace:
+            label = label or '%s.%s' % (self.namespace.namespace, self.name)
+        self.label = label
 
     @classmethod
     def from_content_spec_data(cls, content_spec_data):
-        return cls(namespace=content_spec_data.get('namespace'),
+        namespace = repository_namespace.RepositoryNamespace(namespace=content_spec_data.get('namespace'))
+        return cls(namespace=namespace,
                    name=content_spec_data.get('name'))
 
     def __repr__(self):

--- a/ansible_galaxy/models/repository_namespace.py
+++ b/ansible_galaxy/models/repository_namespace.py
@@ -1,0 +1,21 @@
+
+import logging
+
+
+log = logging.getLogger(__name__)
+
+# TODO: use 'attr' or similar
+
+
+class RepositoryNamespace(object):
+    def __init__(self,
+                 namespace=None,
+                 path=None):
+        self.namespace = namespace
+        self.path = path
+
+    def __repr__(self):
+        return '%s(namespace="%s", path="%s")' % \
+            (self.__class__.__name__,
+             self.namespace,
+             self.path)

--- a/ansible_galaxy/rest_api.py
+++ b/ansible_galaxy/rest_api.py
@@ -207,30 +207,6 @@ class GalaxyAPI(object):
         return {}
 
     @g_connect
-    def lookup_content_by_name(self, namespace, repo_name, content_name, content_type=None, notify=True):
-        self.log.debug('namespace=%s', namespace)
-        self.log.debug('repo_name=%s', repo_name)
-        self.log.debug('content_name=%s', content_name)
-        self.log.debug('content_type=%s', content_type)
-        self.log.debug('notify=%s', notify)
-
-        content_name = urlquote(content_name)
-        repo_name = urlquote(repo_name)
-
-        if notify:
-            self.log.info("- downloading content '%s', type '%s',repo_name '%s'  owned by %s", content_name, content_type, repo_name, namespace)
-
-        url = '%s/content/?name=%s&namespace__name=%s' % (self.baseurl, content_name, namespace)
-        data = self.__call_galaxy(url, http_method='GET')
-        if data["results"]:
-            return data["results"][0]
-
-        self.log.debug('No results found while looking for content by name for '
-                       'namespace=%s repo_name=%s content_name=%s',
-                       namespace, repo_name, content_name)
-        return {}
-
-    @g_connect
     def fetch_content_related(self, related_url):
         """
         Fetch the list of related items for the given role.

--- a/tests/ansible_galaxy/test_installed_content_db.py
+++ b/tests/ansible_galaxy/test_installed_content_db.py
@@ -45,18 +45,22 @@ class MatchContentNamesFnmatch(object):
 
 
 def test_installed_content_iterator_empty(galaxy_context, mocker):
+    mocker.patch('ansible_galaxy.installed_namespaces_db.get_namespace_paths',
+                 return_value=iter(['foo', 'blip']))
     mocker.patch('ansible_galaxy.installed_repository_db.get_repository_paths',
-                 return_value=iter(['foo.bar', 'blip.baz']))
+                 return_value=iter(['bar', 'baz']))
 
     # The content type specific content iterator is determined at runtime, so we need to patch the value
     # of the 'roles' item in installed_repository_content_iterator_map to patch the right method used
     mocker.patch.dict('ansible_galaxy.installed_content_db.installed_repository_content_iterator_map',
-                      {'roles': mocker.Mock(return_value=iter(['/dev/null/content/foo.bar/roles/role-1', '/dev/null/content/blip.baz/roles/role-2']))})
+                      {'roles': mocker.Mock(return_value=iter(['/dev/null/content/foo/bar/roles/role-1', '/dev/null/content/blip/baz/roles/role-2']))})
 
     ici = installed_content_db.installed_content_iterator(galaxy_context,
                                                           content_type='roles')
+    log.debug('ici: %s', ici)
 
     installed_content = list(ici)
+    log.debug('installed_content: %s', installed_content)
     assert installed_content[0]['content_data'].name == 'role-1'
 
 

--- a/tests/ansible_galaxy/test_matchers.py
+++ b/tests/ansible_galaxy/test_matchers.py
@@ -3,10 +3,15 @@ import pytest
 
 from ansible_galaxy import matchers
 from ansible_galaxy.models.content_repository import ContentRepository
+from ansible_galaxy.models import repository_namespace
 
 log = logging.getLogger(__name__)
 
-CR = ContentRepository
+
+def CR(namespace=None, name=None):
+    ns = repository_namespace.RepositoryNamespace(namespace=namespace)
+    return ContentRepository(namespace=ns,
+                             name=name)
 
 
 @pytest.mark.parametrize("matcher_class,matcher_args,candidates, expected", [
@@ -64,5 +69,5 @@ def test_match_all(matcher_class, matcher_args, candidates, expected):
     for candidate in candidates:
         res = matcher(candidate)
 
-        log.debug('res: %s, candidate=%s, expected=%s', res, candidate, expected)
-        assert res is expected, 'res %s for candidate=%s was not %s' % (res, candidate, expected)
+        log.debug('res: %s, matcher=%s, candidate=%s, expected=%s', res, matcher, candidate, expected)
+        assert res is expected, 'res %s for matcher=%s candidate=%s was not %s' % (res, matcher, candidate, expected)

--- a/tests/ansible_galaxy/test_rest_api.py
+++ b/tests/ansible_galaxy/test_rest_api.py
@@ -459,57 +459,6 @@ def test_galaxy_api_fetch_content_related_no_results(mocker, galaxy_api):
     assert len(res) == 0
 
 
-def test_galaxy_api_lookup_content_by_name(mocker, galaxy_api):
-    mocker.patch('ansible_galaxy.rest_api.open_url',
-                 new=FauxUrlResponder(
-                     [
-                         FauxUrlOpenResponse(data={'stuff': [1, 2, 3],
-                                                   'results': [{'foo1': 11, 'foo2': 12}]
-                                                   },
-                                             url='blippyblopfakeurl'),
-                     ]
-                 ))
-
-    namespace = 'alikins'
-    repo_name = 'role-awx'
-    content_name = 'role-awx'
-    content_type = 'role'
-
-    res = galaxy_api.lookup_content_by_name(namespace, repo_name, content_name, content_type)
-
-    log.debug('res: %s', res)
-
-    assert isinstance(res, dict)
-    assert 'foo1' in res
-
-
-def test_galaxy_api_lookup_content_by_name_empty_results(mocker, galaxy_api):
-    mocker.patch('ansible_galaxy.rest_api.open_url',
-                 new=FauxUrlResponder(
-                     [
-                         FauxUrlOpenResponse(data={'stuff': [1, 2, 3],
-                                                   'results': [],
-                                                   },
-                                             url='blippyblopfakeurl'),
-                     ]
-                 ))
-
-    namespace = 'alikins'
-    repo_name = 'role-awx'
-    content_name = 'role-awx'
-    content_type = 'role'
-
-    res = galaxy_api.lookup_content_by_name(namespace, repo_name, content_name, content_type,
-                                            notify=False)
-
-    log.debug('res: %s', res)
-
-    assert isinstance(res, dict)
-
-    # expect an empty dict returned in this case
-    assert res == {}
-
-
 def test_user_agent():
     res = rest_api.user_agent()
     assert res.startswith('Mazer/%s' % ansible_galaxy.__version__)

--- a/tests/ansible_galaxy_cli/cli/test_galaxy_upstream.py
+++ b/tests/ansible_galaxy_cli/cli/test_galaxy_upstream.py
@@ -71,7 +71,7 @@ class TestGalaxy(unittest.TestCase):
         gc.parse()
         gc.run()
         cls.role_dir = "./delete_me"
-        cls.role_name = "delete_me"
+        cls.role_name = "unittest.delete_me"
 
         # add a meta/main.yml
         test_dir = os.path.join(cls.role_dir, 'meta')
@@ -97,6 +97,7 @@ class TestGalaxy(unittest.TestCase):
         dep_lines = ["- 'src': '%s'\n" % cls.role_tar,
                      "  'name': '%s'\n" % cls.role_name,
                      "  'path': '%s'\n" % cls.role_path]
+        log.debug('dep_lines: %s', dep_lines)
         for dep_line in dep_lines:
             fd.write(dep_line)
 
@@ -149,15 +150,24 @@ class TestGalaxy(unittest.TestCase):
 
     def test_execute_remove(self):
         # installing role
-        gc = GalaxyCLI(args=["ansible-galaxy", "install", "-p", self.role_path, "-r", self.role_req, '--force'])
+        log.debug('self.role_path: %s', self.role_path)
+        log.debug('self.role_req: %s', self.role_req)
+
+        gc = GalaxyCLI(args=["ansible-galaxy", "install", "--content-path", self.role_path, "-r", self.role_req, '--force'])
         gc.parse()
         gc.run()
 
+        log.debug('self.role_name: %s', self.role_name)
         # location where the role was installed
         role_file = os.path.join(self.role_path, self.role_name)
 
+        log.debug('role_file: %s', role_file)
+
         # removing role
-        gc = GalaxyCLI(args=["ansible-galaxy", "remove", role_file, self.role_name])
+        # args = ["ansible-galaxy", "remove", role_file, self.role_name]
+        args = ["ansible-galaxy", "remove", self.role_name]
+        log.debug('args: %s', args)
+        gc = GalaxyCLI(args=args)
         gc.parse()
         gc.run()
 


### PR DESCRIPTION
##### SUMMARY
Add a sep installed_namespace_db

To find repos, first find namespaces.
To find content, first fine namespaces, then repos,
then content.

This also makes 'install' install to ~/.ansible/content/namespace/reponame/*

<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request



##### GALAXY CLI VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.1.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.16.6-202.fc27.x86_64, #1 SMP Wed May 2 00:09:32 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3/bin/mazer
python_version = 3.6.5 (default, Apr  4 2018, 15:01:18) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

