### PR TITLE
update HISTORY.rst with 0.2.0 info

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,16 @@
 History
 =======
 
+0.2.0 (2018-07-26)
+------------------
+
+* Support new
+  ~/.ansible/content/namespace/reponame/content_type/content_name layout
+* Create install receipts (.galaxy_install_info) on
+  install of repos and roles
+* 'list' and 'info' commands updated
+* Now requires and uses 'attrs' python module >=18.1.0
+
 0.1.0 (2018-04-18)
 ------------------
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

update HISTORY.rst with 0.2.0 info

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request


##### GALAXY CLI VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.1.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.16.6-202.fc27.x86_64, #1 SMP Wed May 2 00:09:32 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3/bin/mazer
python_version = 3.6.5 (default, Apr  4 2018, 15:01:18) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

