### PR TITLE
Fix install if a role name is substring of another role

### DIFF
--- a/ansible_galaxy/flat_rest_api/content.py
+++ b/ansible_galaxy/flat_rest_api/content.py
@@ -274,7 +274,10 @@ class GalaxyContent(object):
             for content_name in content_names:
                 files_to_extract = []
 
-                match_pattern = '%s/%s/%s*' % (parent_dir, content_sub_dir, content_name)
+                # TODO: This only works for roles/apbs that have a dir matching the content
+                #       name. For other content like plugins or modules, we need to match
+                #       on parent_dir/content_sub_dir/content_name (/modules/my_module.py)
+                match_pattern = '%s/%s/%s/*' % (parent_dir, content_sub_dir, content_name)
 
                 member_matches = archive.filter_members_by_fnmatch(tar_file_members,
                                                                    match_pattern)


### PR DESCRIPTION
##### SUMMARY
The fnmatch to select the files to extract from the tar
archive was too eager ('top_dir/roles/rolename*') and
would match 'top_dir/roles/katello_client' when attempting
to match just 'top_dir/roles/katello'.

Since 'katello_client' would be installed as part of installing
'katello', then the install of 'katello_client' would fail since
it was already on the file system.

Fixes #112

##### ISSUE TYPE

 - Bugfix Pull Request



##### GALAXY CLI VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.2.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.16.6-202.fc27.x86_64, #1 SMP Wed May 2 00:09:32 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-py27/bin/mazer
python_version = 2.7.15 (default, May 15 2018, 15:37:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-py27/bin/python

```


##### ADDITIONAL INFORMATION
For a case like #112, the details of when/where the install errors happen 
will depend on the state of the repo, the way the tar archive is constructed, and
what order the set of content names provides. If the ordering of all that results in
the shorter sub string name being installed first, then it will fail. iow, it's not
hard to reproduce the bug, but it is also not 100% predictable.