### PR TITLE
Fix attrs dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,3 @@
-six
-PyYaml
+--index-url https://pypi.python.org/simple/
 
-# for loading yaml into ordered dicts
-yamlloader
-
-# TODO: we can likely eliminate this
-jinja2
-
-# Used if we need offline version compares
-semver
-
-# used for data classes
-# 18.1.0 introduces the 'factory' keyword
-attrs>=18.1.0
+-e .

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,11 @@ with open('HISTORY.rst') as history_file:
 requirements = ['six',
                 'PyYaml',
                 'jinja2',
+                'semver',
                 'yamlloader',
+                # used for data classes
+                # 18.1.0 introduces the 'factory' keyword
+                'attrs>=18.1.0',
                 ]
 
 setup_requirements = ['pytest-runner', ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py26, py27, py36, flake8
+envlist = py27, py36, flake8
 
 [travis]
 python =
     3.6: py36
     2.7: py27
-    2.6: py26
 
 [testenv:flake8]
 basepython = python


### PR DESCRIPTION
##### SUMMARY
Fix deps on 'attrs'

The dep was included in requirements.txt but not in setup.py

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
  - Bugfix Pull Request



##### GALAXY CLI VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.2.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.16.6-202.fc27.x86_64, #1 SMP Wed May 2 00:09:32 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-py27/bin/mazer
python_version = 2.7.15 (default, May 15 2018, 15:37:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-py27/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

