### PR TITLE
Rm --roles-path cli option

### DIFF
--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -116,9 +116,6 @@ class GalaxyCLI(cli.CLI):
         if self.action not in ("init", "version"):
             # NOTE: while the option type=str, the default is a list, and the
             # callback will set the value to a list.
-            self.parser.add_option('-p', '--roles-path', dest='roles_path', action="append", default=[],
-                                   help='The path to the directory containing your roles. The default is the roles_path configured in your ansible.cfg'
-                                        'file (/etc/ansible/roles if not configured)', type='str')
             self.parser.add_option('-C', '--content-path', dest='content_path',
                                    help='The path to the directory containing your galaxy content. The default is the content_path configured in your'
                                         'ansible.cfg file (/etc/ansible/content if not configured)', type='str')
@@ -287,13 +284,6 @@ class GalaxyCLI(cli.CLI):
                 "- invalid Galaxy Content type provided: %s\n  - Expected one of: %s" %
                 (self.options.content_type, ", ".join(CONTENT_TYPES))
             )
-
-        # TODO: mv to GalaxyContext constructor
-        # If someone provides a --roles-path at the command line, we assume this is
-        # for use with a legacy role and we want to maintain backwards compat
-        if self.options.roles_path:
-            self.log.warn('Assuming content is of type "role" since --role-path was used')
-            install_content_type = 'role'
 
         self.log.debug('self.options: %s', self.options)
         galaxy_context = self._get_galaxy_context(self.options, self.config)


### PR DESCRIPTION
##### SUMMARY
Rm --roles-path cli option

The --roles-path option is no longer needed for ansible-galaxy
compatibility, so remove it.

Fixes #95


##### ISSUE TYPE

 - Bugfix Pull Request


##### GALAXY CLI VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.2.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.16.6-202.fc27.x86_64, #1 SMP Wed May 2 00:09:32 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3-2/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3-2/bin/python3.6

```


