### PR TITLE
Fix 'GALAXY CLI' ref in issue templ, file encodings

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -8,9 +8,9 @@ about: If something isn't working as expected 🤔.
 Verify first that your issue/request is not already reported on GitHub.
  -->
 
-## Bug Report 
+## Bug Report
 
-##### GALAXY CLI VERSION
+##### MAZER VERSION
 <!--- Paste, BELOW THIS COMMENT, verbatim output from "mazer version" between quotes below -->
 ```
 
@@ -36,7 +36,7 @@ For new features, show how the feature would be used. -->
 <!-- If using a requirements.yml file, paste the contents of that file between the quotes below --->
 ```yml
 
-``` 
+```
 
 <!--- You can also paste gist.github.com links for larger files -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ the change does.-->
  - Docs Pull Request
 
 
-##### GALAXY CLI VERSION
+##### MAZER VERSION
 <!--- Paste verbatim output from "mazer version" between quotes below -->
 ```
 


### PR DESCRIPTION

##### SUMMARY
Fix 'GALAXY CLI' ref in issue templ, file encodings

The Bug_report.md file had DOS new line chars in it,
so this also converts it to UNIX new line chars.

<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request


##### GALAXY CLI VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.2.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.16.6-202.fc27.x86_64, #1 SMP Wed May 2 00:09:32 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3-2/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3-2/bin/python3.6

```
