### PR TITLE
Add MAZER_CONFIG env var to specify config file

### DIFF
--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -65,6 +65,18 @@ def exit_without_ignore(ignore_errors, msg=None, rc=1):
         raise cli_exceptions.GalaxyCliError(message)
 
 
+def get_config_path_from_env():
+    for env_var in ('MAZER_CONFIG', 'ANSIBLE_GALAXY_CONFIG'):
+        raw_config_file_path = os.environ.get(env_var, None)
+
+        if raw_config_file_path:
+            log.info("Using config file '%s' as specified by env var '%s'",
+                     raw_config_file_path, env_var)
+            return raw_config_file_path
+
+    return None
+
+
 class GalaxyCLI(cli.CLI):
     '''command to manage Ansible roles in shared repostories, the default of which is Ansible Galaxy *https://galaxy.ansible.com*.'''
 
@@ -176,7 +188,8 @@ class GalaxyCLI(cli.CLI):
 
     def run(self):
 
-        raw_config_file_path = os.environ.get('ANSIBLE_GALAXY_CONFIG', defaults.CONFIG_FILE)
+        raw_config_file_path = get_config_path_from_env() or defaults.CONFIG_FILE
+
         self.config_file_path = os.path.abspath(os.path.expanduser(raw_config_file_path))
 
         super(GalaxyCLI, self).run()


### PR DESCRIPTION
##### SUMMARY
For now, allow MAZER_CONFIG as well as ANSIBLE_GALAXY_CONFIG as env
vars to check that may specify which config file to use.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 


##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

