### PR TITLE
Global content install

### DIFF
--- a/ansible_galaxy/config/config.py
+++ b/ansible_galaxy/config/config.py
@@ -11,13 +11,15 @@ class Config(object):
     def __init__(self):
         self.server = {}
         self.content_path = None
+        self.global_content_path = None
         self.options = {}
 
     def as_dict(self):
         return collections.OrderedDict([
-                ('server', self.server),
-                ('content_path', self.content_path),
-                ('options', self.options),
+            ('server', self.server),
+            ('content_path', self.content_path),
+            ('global_content_path', self.global_content_path),
+            ('options', self.options),
         ])
 
     @classmethod
@@ -25,6 +27,7 @@ class Config(object):
         inst = cls()
         inst.server = data.get('server', inst.server)
         inst.content_path = data.get('content_path', inst.content_path)
+        inst.global_content_path = data.get('global_content_path', inst.global_content_path)
         inst.options = data.get('options', inst.options)
         return inst
 
@@ -36,6 +39,11 @@ def load(full_file_path):
     _default_conf_data = collections.OrderedDict(defaults.DEFAULTS)
 
     config_data = config_file_data or _default_conf_data
+
+    for key in _default_conf_data:
+        # If an expected key is not defined, set it to the default value
+        if key not in config_data:
+            config_data[key] = _default_conf_data[key]
 
     log.debug('config_data: %s', config_data)
 

--- a/ansible_galaxy/config/defaults.py
+++ b/ansible_galaxy/config/defaults.py
@@ -16,12 +16,13 @@ def get_config_path():
 # a list of tuples that is fed to an OrderedDict
 DEFAULTS = [
     ('server',
-     {'url': 'https://galaxy-qa.ansible.com',
+     {'url': 'https://galaxy.ansible.com',
       'ignore_certs': False}
      ),
 
     # In order of priority
     ('content_path', '~/.ansible/content'),
+    ('global_content_path', '/usr/share/ansible/content'),
 
     # runtime options
     ('options',

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,7 +2,8 @@ coverage
 flake8
 mock
 pip
-pytest
+pytest>=3.6
+pytest-django>=3.4.2
 pytest-cov
 pytest-runner
 pytest-mock

--- a/tests/ansible_galaxy/config/test_config.py
+++ b/tests/ansible_galaxy/config/test_config.py
@@ -6,7 +6,7 @@ from ansible_galaxy.config import config
 
 log = logging.getLogger(__name__)
 
-CONFIG_SECTIONS = ['server', 'content_path', 'options']
+CONFIG_SECTIONS = ['server', 'content_path', 'global_content_path', 'options']
 
 
 def assert_object(config_obj):
@@ -66,6 +66,7 @@ def test_config_as_dict():
         ('server', {'url': 'some_url_value',
                     'ignore_certs': True}),
         ('content_path', None),
+        ('global_content_path', None),
         ('options', {'some_option': 'some_option_value'}),
     ])
 

--- a/tests/ansible_galaxy/config/test_config_file.py
+++ b/tests/ansible_galaxy/config/test_config_file.py
@@ -62,6 +62,7 @@ server:
   ignore_certs: true
   url: https://someserver.example.com
 content_path: ~/.ansible/some_content_path
+global_content_path: /usr/local/share
 options:
   role_skeleton_ignore:
     - ^.git$
@@ -89,6 +90,7 @@ def test_load_valid_yaml():
     assert config_data['server']['url'] == 'https://someserver.example.com'
     assert config_data['server']['ignore_certs'] is True
     assert config_data['content_path'] == '~/.ansible/some_content_path'
+    assert config_data['global_content_path'] == '/usr/local/share'
     assert config_data['options']['role_skeleton_path'] == '~/.some_skeleton'
 
 


### PR DESCRIPTION
- Adds `global_content_path` to the config file with a default value of `/usr/share/ansible/content`.
- Adds `-g` and `--global` options to the *install* command. When specified, content is installed to the global content path.
