### PR TITLE
Add --editable install option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ install:
   - pip install -r requirements_test.txt
 
 script:
-  - flake8 ansible_galaxy_cli ansible_galaxy
+  - make lint 
   - python setup.py pytest

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr .pytest_cache
 
 lint: ## check style with flake8
-	flake8 ansible_galaxy_cli tests
+	flake8 ansible_galaxy_cli ansible_galaxy tests
 
 test: ## run tests quickly with the default Python
 	py.test

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -101,6 +101,8 @@ class GalaxyCLI(cli.CLI):
             self.parser.add_option('-g', '--global', dest='global_install', action='store_true',
                                    help='Install content to the path containing your global or system-wide content. The default is the '
                                    'global_content_path configured in your mazer.yml file (/usr/share/ansible/content, if not configured)')
+            self.parser.add_option('-e', '--editable', dest='editable_install', action='store_true',
+                                   help='Link a local directory into the content path for development and testing')
             self.parser.add_option('-i', '--ignore-errors', dest='ignore_errors', action='store_true', default=False,
                                    help='Ignore errors and continue with the next specified repo.')
             self.parser.add_option('-n', '--no-deps', dest='no_deps', action='store_true', default=False, help='Don\'t download roles listed as dependencies')
@@ -303,6 +305,7 @@ class GalaxyCLI(cli.CLI):
 
         try:
             rc = install.install_content_specs(galaxy_context,
+                                               editable=self.options.editable_install,
                                                content_spec_strings=requested_content_specs,
                                                install_content_type=install_content_type,
                                                namespace_override=self.options.namespace,

--- a/tests/ansible_galaxy/test_content_spec.py
+++ b/tests/ansible_galaxy/test_content_spec.py
@@ -1,9 +1,10 @@
 import logging
 import os
-
+import tempfile
 import pytest
 
 from ansible_galaxy import content_spec
+from ansible_galaxy import exceptions
 from ansible_galaxy.models.content_spec import ContentSpec
 
 log = logging.getLogger(__name__)
@@ -63,3 +64,21 @@ def test_content_spec_from_string(content_spec_case):
 
     # assert attr.asdict(result) == attr.asdict(content_spec_case['expected'])
     assert result == content_spec_case['expected']
+
+
+def test_content_spec_editable():
+    tmpdir = tempfile.mkdtemp()
+    result = content_spec.content_spec_from_string(tmpdir, editable=True)
+    os.rmdir(tmpdir)
+    assert result.name == tmpdir
+    assert result.fetch_method == 'EDITABLE'
+
+
+@pytest.mark.xfail(raises=exceptions.GalaxyError)
+def test_content_spec_fail():
+    content_spec.content_spec_from_string('foo.')
+
+
+@pytest.mark.xfail(raises=exceptions.GalaxyError)
+def test_content_editable_fail():
+    content_spec.content_spec_from_string('foo', editable=True)

--- a/tests/ansible_galaxy/test_content_spec_parse.py
+++ b/tests/ansible_galaxy/test_content_spec_parse.py
@@ -4,7 +4,6 @@ import pytest
 
 from ansible_galaxy import content_spec_parse
 from ansible_galaxy import exceptions
-from ansible_galaxy import galaxy_content_spec
 
 log = logging.getLogger(__name__)
 

--- a/tests/ansible_galaxy_cli/test_ansible_galaxy_cli.py
+++ b/tests/ansible_galaxy_cli/test_ansible_galaxy_cli.py
@@ -6,7 +6,6 @@
 import pytest
 
 
-
 @pytest.fixture
 def response():
     """Sample pytest fixture.


### PR DESCRIPTION
##### SUMMARY
mazer install --editable|-e option for "installing" a local checkout into content path via symlinks.

##### ISSUE TYPE

 - Feature Pull Request

##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

