### PR TITLE
Remove py3 only 'exist_ok' makedirs flag

### DIFF
--- a/ansible_galaxy/actions/build.py
+++ b/ansible_galaxy/actions/build.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 def ensure_output_dir(output_path):
     if not os.path.isdir(output_path):
         log.debug('Creating output_path: %s', output_path)
-        os.makedirs(output_path, exist_ok=True)
+        os.makedirs(output_path)
     return output_path
 
 


### PR DESCRIPTION
##### SUMMARY
Fix py3 ism that causes errors on py2 when creating the 'releases/' dir.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.2.1
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.17.14-102.fc27.x86_64, #1 SMP Wed Aug 15 12:26:40 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py27/bin/mazer
python_version = 2.7.15 (default, May 15 2018, 15:37:31) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py27/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

