### PR TITLE
Feature/publish

### DIFF
--- a/ansible_galaxy/actions/publish.py
+++ b/ansible_galaxy/actions/publish.py
@@ -1,0 +1,82 @@
+
+import hashlib
+import json
+import logging
+import os
+import tarfile
+
+from ansible_galaxy.rest_api import GalaxyAPI
+from ansible_galaxy import collection_artifact_manifest
+from ansible_galaxy import exceptions
+
+log = logging.getLogger(__name__)
+
+
+def _get_file_checksum(file_path):
+    checksum = hashlib.sha256()
+    with open(file_path, "rb") as f:
+        for byte_block in iter(lambda: f.read(4096), b""):
+            checksum.update(byte_block)
+    return checksum.hexdigest()
+
+
+def _publish(galaxy_context,
+             archive_path,
+             display_callback=None):
+
+    results = {
+        'errors': [],
+        'success': True
+    }
+
+    archive = tarfile.open(archive_path, 'r')
+    top_dir = os.path.commonprefix(archive.getnames())
+    manifest_path = os.path.join(top_dir,
+                                 collection_artifact_manifest.COLLECTION_MANIFEST_FILENAME)
+    try:
+        manifest_file = archive.extractfile(manifest_path)
+    except tarfile.TarError as exc:
+        raise exceptions.GalaxyPublishError(str(exc), archive_path=archive_path)
+
+    try:
+        manifest = collection_artifact_manifest.load(manifest_file)
+    except Exception as exc:
+        raise exceptions.GalaxyPublishError(str(exc), archive_path=archive_path)
+
+    display_callback(json.dumps(manifest.collection_info))
+
+    api = GalaxyAPI(galaxy_context)
+
+    collection_name = manifest.collection_info.name
+    namespace_name = manifest.collection_info.namespace
+
+    log.debug("Attempting to fetch Galaxy namespace %s" % namespace_name)
+    namespace = api.fetch_namespace(namespace_name)
+
+    namespace_id = namespace.get('id')
+    data = {
+        'sha256': _get_file_checksum(archive_path),
+        'name': collection_name,
+        'version': manifest.collection_info.version
+    }
+    log.debug("Publishing file %s with data: %s" % (archive_path, json.dumps(data)))
+    api.publish_file(namespace_id, data, archive_path)
+    return results
+
+
+def publish(galaxy_context, archive_path, display_callback):
+
+    results = _publish(galaxy_context,
+                       archive_path,
+                       display_callback=display_callback)
+
+    log.debug('cli publish action results: %s', json.dumps(results))
+
+    if results['errors']:
+        for error in results['errors']:
+            display_callback(error)
+
+    if results['success']:
+        return os.EX_OK  # 0
+
+    return os.EX_SOFTWARE  # 70

--- a/ansible_galaxy/exceptions/__init__.py
+++ b/ansible_galaxy/exceptions/__init__.py
@@ -70,3 +70,16 @@ class GalaxyArchiveError(GalaxyClientError):
         archive_path = kwargs.pop('archive_path', None)
         super(GalaxyArchiveError, self).__init__(*args, **kwargs)
         self.archive_path = archive_path
+
+
+class GalaxyPublishError(GalaxyClientError):
+    ''' Raised for errors related to publish command '''
+
+    def __init__(self, msg, *args, **kwargs):
+        self.msg = msg
+        self.archive_path = kwargs.pop('archive_path', None)
+        super(GalaxyPublishError, self).__init__(*args, **kwargs)
+
+    def __str__(self, *args, **kwargs):
+        msg = 'Error publishing %s - %s' % (self.archive_path, self.msg)
+        return msg

--- a/ansible_galaxy/flat_rest_api/urls.py
+++ b/ansible_galaxy/flat_rest_api/urls.py
@@ -72,13 +72,13 @@ urllib_request.HTTPRedirectHandler.http_error_308 = urllib_request.HTTPRedirectH
 try:
     from six.moves.urllib.parse import urlparse, urlunparse
     HAS_URLPARSE = True
-except:
+except ImportError:
     HAS_URLPARSE = False
 
 try:
     import ssl
     HAS_SSL = True
-except:
+except ImportError:
     HAS_SSL = False
 
 try:
@@ -126,14 +126,11 @@ if not HAS_SSLCONTEXT and HAS_SSL:
         libssl_name = ctypes.util.find_library('ssl')
         libssl = ctypes.CDLL(libssl_name)
         for method in ('TLSv1_1_method', 'TLSv1_2_method'):
-            try:
-                libssl[method]
+            if libssl.get(method):
                 # Found something - we'll let openssl autonegotiate and hope
                 # the server has disabled sslv2 and 3.  best we can do.
                 PROTOCOL = ssl.PROTOCOL_SSLv23
                 break
-            except AttributeError:
-                pass
         del libssl
 
 
@@ -151,8 +148,6 @@ except ImportError:
 if not HAS_MATCH_HOSTNAME:
     # The following block of code is under the terms and conditions of the
     # Python Software Foundation License
-
-    """The match_hostname() function from Python 3.4, essential when using SSL."""
 
     class CertificateError(ValueError):
         pass

--- a/ansible_galaxy/multipart_form.py
+++ b/ansible_galaxy/multipart_form.py
@@ -1,0 +1,70 @@
+import mimetypes
+import io
+
+
+class MultiPartForm(object):
+    """
+    Accumulate the data to be used when posting a form.
+    Borrowed from https://blog.thesparktree.com/the-unfortunately-long-story-dealing-with
+    """
+
+    def __init__(self):
+        self.form_fields = []
+        self.files = []
+        self.boundary = 'FORM-BOUNDRY'
+        return
+
+    def get_content_type(self):
+        return 'multipart/form-data; boundary=%s' % self.boundary
+
+    def add_field(self, name, value):
+        """Add a simple field to the form data."""
+        self.form_fields.append((name, value))
+        return
+
+    def add_file(self, fieldname, filename, fileHandle, mimetype=None):
+        """Add a file to be uploaded."""
+        body = fileHandle.read()
+        if mimetype is None:
+            mimetype = mimetypes.guess_type(filename)[0] or 'application/octet-stream'
+        self.files.append((fieldname, filename, mimetype, body))
+        return
+
+    def get_binary(self):
+        """Return a binary buffer containing the form data, including attached files."""
+        part_boundary = '--' + self.boundary
+
+        binary = io.BytesIO()
+        needsCLRF = False
+        # Add the form fields
+        for name, value in self.form_fields:
+            if needsCLRF:
+                binary.write(str.encode('\r\n', 'utf-8'))
+            needsCLRF = True
+
+            block = [part_boundary,
+                     'Content-Disposition: form-data; name="%s"' % name,
+                     '',
+                     value
+                     ]
+            binary.write(str.encode('\r\n'.join(block), 'utf-8'))
+
+        # Add the files to upload
+        for field_name, filename, content_type, body in self.files:
+            if needsCLRF:
+                binary.write(str.encode('\r\n', 'utf-8'))
+            needsCLRF = True
+
+            block = [part_boundary,
+                     str('Content-Disposition: file; name="%s"; filename="%s"' %
+                         (field_name, filename)),
+                     'Content-Type: %s' % content_type,
+                     ''
+                     ]
+            binary.write(str.encode('\r\n'.join(block), 'utf-8'))
+            binary.write(str.encode('\r\n', 'utf-8'))
+            binary.write(body)
+
+        # add closing boundary marker,
+        binary.write(str.encode('\r\n--' + self.boundary + '--\r\n', 'utf-8'))
+        return binary

--- a/ansible_galaxy_cli/cli/__init__.py
+++ b/ansible_galaxy_cli/cli/__init__.py
@@ -39,7 +39,7 @@ log = logging.getLogger(__name__)
 class SortedOptParser(optparse.OptionParser):
     '''Optparser which sorts the options by opt before outputting --help'''
 
-    def format_help(self, formatter=None, epilog=None):
+    def format_help(self, formatter=Nones):
         self.option_list.sort(key=operator.methodcaller('get_opt_string'))
         return optparse.OptionParser.format_help(self, formatter=None)
 
@@ -51,6 +51,7 @@ class InvalidOptsParser(SortedOptParser):
     Meant for the special case where we need to take care of help and version
     but may not know the full range of options yet.  (See it in use in set_action)
     '''
+
     def __init__(self, parser):
         # Since this is special purposed to just handle help and version, we
         # take a pre-existing option parser here and set our options from
@@ -134,7 +135,7 @@ class CLI(six.with_metaclass(ABCMeta, object)):
             # without knowing action, we only know of a subset of the options
             # that could be legal for this command
             tmp_parser = InvalidOptsParser(self.parser)
-            tmp_options, tmp_args = tmp_parser.parse_args(self.args)
+            tmp_options, _ = tmp_parser.parse_args(self.args)
             if not(hasattr(tmp_options, 'help') and tmp_options.help) or (hasattr(tmp_options, 'version') and tmp_options.version):
                 raise cli_exceptions.CliOptionsError("Missing required action")
 

--- a/ansible_galaxy_cli/cli/__init__.py
+++ b/ansible_galaxy_cli/cli/__init__.py
@@ -39,7 +39,7 @@ log = logging.getLogger(__name__)
 class SortedOptParser(optparse.OptionParser):
     '''Optparser which sorts the options by opt before outputting --help'''
 
-    def format_help(self, formatter=Nones):
+    def format_help(self, formatter=None):
         self.option_list.sort(key=operator.methodcaller('get_opt_string'))
         return optparse.OptionParser.format_help(self, formatter=None)
 

--- a/tests/ansible_galaxy_cli/cli/test_galaxy.py
+++ b/tests/ansible_galaxy_cli/cli/test_galaxy.py
@@ -72,3 +72,10 @@ def test_run_info():
     cli.parse()
     with pytest.raises(cli_exceptions.CliOptionsError, match="you must specify a user/role name"):
         cli.run()
+
+
+def test_publish_no_args():
+    cli = galaxy.GalaxyCLI(args=['publish'])
+    cli.parse()
+    with pytest.raises(cli_exceptions.CliOptionsError, match="you must specify a path"):
+        cli.run()

--- a/tests/ansible_galaxy_cli/cli/test_galaxy_upstream.py
+++ b/tests/ansible_galaxy_cli/cli/test_galaxy_upstream.py
@@ -191,11 +191,12 @@ class TestGalaxy(unittest.TestCase):
                 'info': 'usage: %prog info [options] repo_name[,version]',
                 'install': 'usage: %prog install [options] [-r FILE | repo_name(s)[,version] | scm+repo_url[,version] | tar_file(s)]',
                 'list': 'usage: %prog list [repo_name]',
+                'publish': 'usage: %prog publish [options] archive_path',
                 'remove': 'usage: %prog remove repo1 repo2 ...',
                 'version': 'usage: %prog version',
             }
 
-            first_call = 'usage: %prog [build|info|install|list|remove|version] [--help] [options] ...'
+            first_call = 'usage: %prog [build|info|install|list|publish|remove|version] [--help] [options] ...'
             second_call = formatted_call[action]
             calls = [call(first_call), call(second_call)]
             mocked_usage.assert_has_calls(calls)
@@ -229,6 +230,12 @@ class TestGalaxy(unittest.TestCase):
         ''' testing the options parser when the action 'list' is given '''
         gc = GalaxyCLI(args=["ansible-galaxy", "list"])
         self.run_parse_common(gc, "list")
+        self.assertEqual(gc.options.verbosity, 0)
+
+    def test_parse_publish(self):
+        ''' testing the options parser when the action 'publish' is given '''
+        gc = GalaxyCLI(args=["ansible-galaxy", "publish"])
+        self.run_parse_common(gc, "publish")
         self.assertEqual(gc.options.verbosity, 0)
 
     def test_parse_remove(self):


### PR DESCRIPTION
Adds `publish` command to perform a multipart form file upload. 

```
Usage: mazer publish [options] archive_path

Options:
  -h, --help            show this help message and exit
  -c, --ignore-certs    Ignore SSL certificate validation errors.
  -s SERVER_URL, --server=SERVER_URL
                        The API server destination
  -v, --verbose         verbose mode (-vvv for more, -vvvv to enable
                        connection debugging)
```

Tested against the following Django view:

```
import json
import logging
import os
import tempfile
import tarfile

from galaxy.api.views import base_views
from rest_framework.parsers import MultiPartParser, FormParser
from rest_framework.response import Response
from rest_framework import status


__all__ = [
    'FileUploadView',
]

logger = logging.getLogger(__name__)


def _handle_file(f, name, version):
    tmp_path = tempfile.mkdtemp()
    archive_path = os.path.join(tmp_path, '%s-%s.tar.gz' % (name, version))
    with open(archive_path, 'wb+') as destination:
        for chunk in f.chunks():
            destination.write(chunk)
    return archive_path


class FileUploadView(base_views.APIView):
    parser_classes = (MultiPartParser, FormParser)

    def post(self, request, *args, **kwargs):

        file_obj = request.data['file']
        checksum = request.data.get('sha256')
        name = request.data.get('name')
        version = request.data.get('version')
        logger.debug('checksum: %s  name: %s  version: %s' %
                     (checksum, name, version))

        archive_path = _handle_file(file_obj, name, version)
        archive = tarfile.open(archive_path, mode='r')
        top_dir = os.path.commonprefix(archive.getnames())
        manifest_path = os.path.join(top_dir, 'MANIFEST.json')
        manifest_file = archive.extractfile(manifest_path)
        manifest_data = json.load(manifest_file)
        logger.debug(json.dumps(manifest_data))

        return Response(status=status.HTTP_201_CREATED)

```

**NOTE**:  This is just the first iteration to establish a working `publish` command. It does not yet handle whatever results will come back from Galaxy. Presumably it will need to wait for, and possibly long pull, to get upload/import status messages as they become available. Additionally options, like `--no-wait`, may also be desirable. 