### PR TITLE
WIP: Configure setup() to use setup.cfg files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,19 @@
+[metadata]
+name = mazer
+description = Ansible content manager
+author = Red Hat, Inc.
+author_email = info@ansible.com
+classifiers =
+    Development Status :: 2 - Pre-Alpha
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Natural Language :: English
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.6
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+
 [bumpversion]
 current_version = 0.2.1
 commit = True

--- a/setup.py
+++ b/setup.py
@@ -32,27 +32,12 @@ entry_points = {
 }
 
 setup(
-    author="Red Hat, Inc.",
-    author_email='info@ansible.com',
-    classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
-        'Natural Language :: English',
-        "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-    ],
-    description="Ansible content manager",
     entry_points=entry_points,
     install_requires=requirements,
     license="GPLv3",
     long_description=readme + '\n\n' + history,
     include_package_data=True,
     keywords='mazer',
-    name='mazer',
     packages=find_packages(include=['ansible_galaxy', 'ansible_galaxy_cli',
                                     'ansible_galaxy.*', 'ansible_galaxy_cli.*']),
     setup_requires=setup_requirements,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Use setup.cfg over setup.py

This is more a feature request, to allow automation to introspect the python project to learn more about it.

##### ISSUE TYPE
 - Feature Pull Request


##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
HEAD

```

##### ADDITIONAL INFORMATION
This is WIP for now, but hopefully will allow zuul in ansible-network to do some cross project testing with mazer.