### PR TITLE
Split out RepositoryArchive impl into models and load/save

### DIFF
--- a/ansible_galaxy/actions/install.py
+++ b/ansible_galaxy/actions/install.py
@@ -282,25 +282,28 @@ def install_repository(galaxy_context,
     #        We can get that from the galaxy API though.
     #
     # FIXME: exc handling
+
+    installed_repositories = []
+
     try:
-        install_repositories = install.install(galaxy_context,
-                                               fetcher,
-                                               fetch_results,
-                                               repository_spec=fetched_repository_spec,
-                                               force_overwrite=force_overwrite)
+        installed_repositories = install.install(galaxy_context,
+                                                 fetcher,
+                                                 fetch_results,
+                                                 repository_spec=fetched_repository_spec,
+                                                 force_overwrite=force_overwrite,
+                                                 display_callback=display_callback)
     except exceptions.GalaxyError as e:
         msg = "- %s was NOT installed successfully: %s "
         display_callback(msg % (fetched_repository_spec.label, e), level='warning')
         log.warning(msg, fetched_repository_spec.label, str(e))
         raise_without_ignore(ignore_errors, e)
 
-    log.debug('installed result: %s', install_repositories)
-
-    if not install_repositories:
+    if not installed_repositories:
         log.warning("- %s was NOT installed successfully.", fetched_repository_spec.label)
         raise_without_ignore(ignore_errors)
 
-    log.debug('installed: %s', pprint.pformat(install_repositories))
+    log.debug('installed: %s', pprint.pformat(installed_repositories))
+
     if no_deps:
         log.warning('- %s was installed but any deps will not be installed because of no_deps',
                     fetched_repository_spec.label)
@@ -315,7 +318,7 @@ def install_repository(galaxy_context,
     deps_and_reqs_set = set()
 
     # install dependencies, if we want them
-    for installed_repository in install_repositories:
+    for installed_repository in installed_repositories:
         log.debug('installed_repository: %s', installed_repository)
 
         # convert deps/reqs to sets. Losing any ordering, but avoids dupes

--- a/ansible_galaxy/install.py
+++ b/ansible_galaxy/install.py
@@ -10,6 +10,7 @@ import attr
 from ansible_galaxy import repository_archive
 from ansible_galaxy import exceptions
 from ansible_galaxy import installed_repository_db
+from ansible_galaxy.models.install_destination import InstallDestinationInfo
 from ansible_galaxy.fetch import fetch_factory
 
 log = logging.getLogger(__name__)
@@ -140,10 +141,10 @@ def install(galaxy_context,
 
     # TODO: this is figuring out the archive type (multi-content collection or a trad role)
     #       could potentially pull this up a layer
-    content_archive_ = repository_archive.load_archive(archive_path)
+    repo_archive_ = repository_archive.load_archive(archive_path)
 
-    log.debug('content_archive_: %s', content_archive_)
-    log.debug('content_archive_.info: %s', content_archive_.info)
+    log.debug('repo_archive_: %s', repo_archive_)
+    log.debug('repo_archive_.info: %s', repo_archive_.info)
 
     # we strip off any higher-level directories for all of the files contained within
     # the tar file here. The default is 'github_repo-target'. Gerrit instances, on the other
@@ -155,10 +156,29 @@ def install(galaxy_context,
 
         os.makedirs(galaxy_context.content_path)
 
+    # Build up all the info about where the repository will be installed to
+    namespaced_repository_path = '%s/%s' % (repository_spec.namespace,
+                                            repository_spec.name)
+
+    install_info_path = os.path.join(galaxy_context.content_path,
+                                     namespaced_repository_path,
+                                     'meta/.galaxy_install_info')
+
+    # extract_archive_to_dir depends on the repo_archive type, so ask it
+    extract_archive_to_dir = os.path.join(galaxy_context.content_path,
+                                          namespaced_repository_path,
+                                          repo_archive_.repository_dest_root_subpath(repository_spec.name))
+
+    destination_info = InstallDestinationInfo(destination_root_dir=galaxy_context.content_path,
+                                              repository_spec=repository_spec,
+                                              extract_archive_to_dir=extract_archive_to_dir,
+                                              namespaced_repository_path=namespaced_repository_path,
+                                              install_info_path=install_info_path,
+                                              force_overwrite=force_overwrite)
+
     # A list of InstallationResults
-    res = content_archive_.install(repository_spec=repository_spec,
-                                   extract_to_path=galaxy_context.content_path,
-                                   force_overwrite=force_overwrite)
+    res = repo_archive_.save(repository_spec=repository_spec,
+                             destination_info=destination_info)
     just_installed_spec_and_results.append((repository_spec, res))
 
     if display_callback:

--- a/ansible_galaxy/install.py
+++ b/ansible_galaxy/install.py
@@ -177,8 +177,11 @@ def install(galaxy_context,
                                               force_overwrite=force_overwrite)
 
     # A list of InstallationResults
-    res = repo_archive_.save(repository_spec=repository_spec,
-                             destination_info=destination_info)
+    res = repository_archive.install(repo_archive_,
+                                     repository_spec=repository_spec,
+                                     destination_info=destination_info,
+                                     display_callback=display_callback)
+
     just_installed_spec_and_results.append((repository_spec, res))
 
     if display_callback:

--- a/ansible_galaxy/models/install_destination.py
+++ b/ansible_galaxy/models/install_destination.py
@@ -1,0 +1,39 @@
+import logging
+import os
+
+import attr
+
+from ansible_galaxy.models.repository_spec import RepositorySpec
+
+log = logging.getLogger(__name__)
+
+
+@attr.s(frozen=True)
+class InstallDestinationInfo(object):
+    destination_root_dir = attr.ib()
+    repository_spec = attr.ib(type=RepositorySpec)
+
+    # NOTE: destination_root_dir is the root of where the install begins
+    #       but extract_archive_to is where the archive is extract to.
+    #       The normal case (collection or multi-content archives) these values
+    #       are the same (for ex, ~/.ansible/content/alikins/some_collection), but
+    #       for trad roles they are different (for ex,
+    #       destination_root_dir=~/.ansible/content/geerlingguy/ntp when
+    #       extract_archive_to_dir=~/.ansible/content/geerlingguy/ntp/roles/ntp)
+    extract_archive_to_dir = attr.ib()
+
+    # 'alikins/collections_reqs_test/'
+    namespaced_repository_path = attr.ib()
+
+    install_info_path = attr.ib()
+
+    force_overwrite = attr.ib(default=False)
+
+    @property
+    def path(self):
+        '''The full path to the eventually installed repository
+
+        For, /home/user/.ansible/content/geerlingguy/ntp
+        '''
+        return os.path.join(self.destination_root_dir,
+                            self.namespaced_repository_path)

--- a/ansible_galaxy/models/repository_archive.py
+++ b/ansible_galaxy/models/repository_archive.py
@@ -15,6 +15,7 @@ class RepositoryArchiveInfo(object):
     # signature?
 
 
+# FIXME: unused?
 @attr.s(frozen=True)
 class RepositoryArchive(object):
     # Can be created from a collection archive, a collection artifact archive,

--- a/ansible_galaxy/models/repository_archive.py
+++ b/ansible_galaxy/models/repository_archive.py
@@ -1,3 +1,6 @@
+import os
+import tarfile
+
 import attr
 
 
@@ -15,9 +18,37 @@ class RepositoryArchiveInfo(object):
     # signature?
 
 
-# FIXME: unused?
 @attr.s(frozen=True)
 class RepositoryArchive(object):
-    # Can be created from a collection archive, a collection artifact archive,
-    # or a trad role archive, or a trad role archive artifact.
     info = attr.ib(type=RepositoryArchiveInfo)
+    tar_file = attr.ib(type=tarfile.TarFile, default=None)
+
+    META_INSTALL = os.path.join('meta', '.galaxy_install_info')
+
+    def repository_dest_root_subpath(self, repository_name):
+        '''The relative path inside the installed content where extract should consider the root
+
+        A collection archive for 'my_namespace.my_content' will typically be extracted to
+        '~/.ansible/content/my_namespace/my_content' in which case the content_dest_root_subpath
+        should return just '/'.
+
+        But Role archives will be extracted into a 'roles' sub dir of the typical path.
+        ie, a 'my_namespace.my_role' role archive will need to be extracted to
+        '~/.ansible/content/my_namespace/roles/my_role/' in which case the content_dest_root_subpatch
+        should return 'roles/my_roles' (ie, 'roles/%s' % content_name)
+        '''
+        return ''
+
+
+@attr.s(frozen=True)
+class TraditionalRoleRepositoryArchive(RepositoryArchive):
+    ROLES_SUBPATH = 'roles'
+
+    def repository_dest_root_subpath(self, repository_name):
+        '''Traditional role archive repository gets installed into subpath of 'roles/CONTENT_NAME/'''
+        return os.path.join(self.ROLES_SUBPATH, repository_name)
+
+
+@attr.s(frozen=True)
+class CollectionRepositoryArchive(RepositoryArchive):
+    pass

--- a/ansible_galaxy/repository_archive.py
+++ b/ansible_galaxy/repository_archive.py
@@ -124,28 +124,6 @@ class BaseRepositoryArchive(object):
         '''
         return ''
 
-    def save(self, repository_spec, destination_info):
-
-        all_installed_files, install_datetime = extract(repository_spec,
-                                                        self.info,
-                                                        content_path=destination_info.destination_root_dir,
-                                                        extract_archive_to_dir=destination_info.extract_archive_to_dir,
-                                                        tar_file=self.tar_file,
-                                                        display_callback=self.display_callback)
-
-        install_info_ = InstallInfo.from_version_date(repository_spec.version,
-                                                      install_datetime=install_datetime)
-
-        # TODO: this save will need to be moved to a step later. after validating install?
-        install_info.save(install_info_, destination_info.install_info_path)
-
-        installation_results = InstallationResults(install_info_path=destination_info.install_info_path,
-                                                   install_info=install_info_,
-                                                   installed_to_path=destination_info.path,
-                                                   installed_datetime=install_datetime,
-                                                   installed_files=all_installed_files)
-        return installation_results
-
 
 @attr.s()
 class TraditionalRoleRepositoryArchive(BaseRepositoryArchive):
@@ -244,3 +222,27 @@ def load_archive(archive_path):
     log.debug('repository archive_ for %s: %s', archive_path, repository_archive_)
 
     return repository_archive_
+
+
+def install(repository_archive, repository_spec, destination_info, display_callback):
+    log.debug('saving repo archive %s to destination %s', repository_archive, destination_info)
+
+    all_installed_files, install_datetime = extract(repository_spec,
+                                                    repository_archive.info,
+                                                    content_path=destination_info.destination_root_dir,
+                                                    extract_archive_to_dir=destination_info.extract_archive_to_dir,
+                                                    tar_file=repository_archive.tar_file,
+                                                    display_callback=display_callback)
+
+    install_info_ = InstallInfo.from_version_date(repository_spec.version,
+                                                  install_datetime=install_datetime)
+
+    # TODO: this save will need to be moved to a step later. after validating install?
+    install_info.save(install_info_, destination_info.install_info_path)
+
+    installation_results = InstallationResults(install_info_path=destination_info.install_info_path,
+                                               install_info=install_info_,
+                                               installed_to_path=destination_info.path,
+                                               installed_datetime=install_datetime,
+                                               installed_files=all_installed_files)
+    return installation_results

--- a/ansible_galaxy/repository_archive.py
+++ b/ansible_galaxy/repository_archive.py
@@ -183,8 +183,7 @@ class TraditionalRoleRepositoryArchive(BaseRepositoryArchive):
 
 @attr.s()
 class CollectionRepositoryArchive(BaseRepositoryArchive):
-    # TODO: should we create a meta/ for a collection just for .galaxy_install_info?
-    META_INSTALL = os.path.join('meta', '.galaxy_install_info')
+    pass
 
 
 def detect_repository_archive_type(archive_path, archive_members):


### PR DESCRIPTION
##### SUMMARY
Some reworking of ansible_galaxy.repository_archive.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.2.1
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.12-100.fc27.x86_64, #1 SMP Thu Oct 4 16:22:17 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3-2/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3-2/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

