### PR TITLE
Use semver.VersionInfo type, reorg install action, fix circular dep cases, faster installed db lookups

### DIFF
--- a/ansible_galaxy/actions/install.py
+++ b/ansible_galaxy/actions/install.py
@@ -148,7 +148,7 @@ def install_repository_specs_loop(galaxy_context,
 
         for req in requirements_list:
             if req.repository_spec:
-                msg = 'Installing requirement %s as needed by %s' % (req.requirement_spec.label, req.repository_spec.label)
+                msg = 'Installing requirement %s (required by %s)' % (req.requirement_spec.label, req.repository_spec.label)
             else:
                 msg = 'Installing requirement %s' % req.requirement_spec.label
             display_callback(msg, level='info')

--- a/ansible_galaxy/actions/install.py
+++ b/ansible_galaxy/actions/install.py
@@ -235,7 +235,9 @@ def install_repository(galaxy_context,
     # repositories_matching_spec_that_are_already_installed = already_installed_generator
     already_installed_iter = irdb.by_repository_spec(repository_spec_to_install)
     already_installed = sorted(list(already_installed_iter))
+
     log.debug('already_installed: %s', already_installed)
+
     if already_installed:
         for already_installed_repository in already_installed:
             display_callback('%s is already installed at %s' % (already_installed_repository.repository_spec.label,

--- a/ansible_galaxy/actions/install.py
+++ b/ansible_galaxy/actions/install.py
@@ -390,66 +390,6 @@ def install_repository(galaxy_context,
     return installed_repositories
 
 
-# def FIXME():
-#     log.debug('installed: %s', pprint.pformat(installed_repositories))
-
-#     if no_deps:
-#         log.warning('- %s was installed but any deps will not be installed because of no_deps',
-#                     fetched_repository_spec.label)
-
-#     # TODO?: update the install receipt for 'installed' if succesull?
-
-#     # oh dear god, a dep solver...
-
-#     if no_deps:
-#         return dep_requirements
-
-#     # FIXME: Just return the single item list installed_repositories here
-#     deps_and_reqs_set = set()
-
-#     # install dependencies, if we want them
-#     for installed_repository in installed_repositories:
-#         log.debug('installed_repository: %s', installed_repository)
-
-#         # convert deps/reqs to sets. Losing any ordering, but avoids dupes
-#         reqs_set = set(installed_repository.requirements)
-#         deps_set = set(installed_repository.dependencies)
-
-#         # deps_and_reqs_set = deps_set.union(reqs_set)
-#         deps_and_reqs_set.update(deps_set, reqs_set)
-#         for dep_req in sorted(deps_and_reqs_set):
-#             log.debug('deps_and_reqs_set_item: %s', dep_req)
-
-#     deps_and_reqs_list = sorted(list(deps_and_reqs_set))
-
-#     log.debug('deps_and_reqs_list: %s', pprint.pformat(deps_and_reqs_list))
-
-#     return deps_and_reqs_list
-
-# def role_install_post_check():
-#    if False:
-#        dep_role = GalaxyContent(galaxy_context, **dep_info)
-#
-#        if '.' not in dep_role.name and '.' not in dep_role.src and dep_role.scm is None:
-#            # we know we can skip this, as it's not going to
-#            # be found on galaxy.ansible.com
-#            continue
-#        if dep_role.install_info is None:
-#            if dep_role not in requested_contents:
-#                display_callback('- adding dependency: %s' % str(dep_role))
-#                requested_contents.append(dep_role)
-#            else:
-#                display_callback('- dependency %s already pending installation.' % dep_role.name)
-#        else:
-#            if dep_role.install_info['version'] != dep_role.version:
-#                log.warning('- dependency %s from role %s differs from already installed version (%s), skipping',
-#                            str(dep_role), installed_content.name, dep_role.install_info['version'])
-#            else:
-#                display_callback('- dependency %s is already installed, skipping.' % dep_role.name)
-
-    # TODO: Need some sort of ContentTransaction for encapsulating pairs of remove and install
-
-
 # FIXME: do we need this? archive.extract_files() may do this for us now
 def stuff_for_updating(content, display_callback, force_overwrite=False):
 

--- a/ansible_galaxy/actions/list.py
+++ b/ansible_galaxy/actions/list.py
@@ -51,7 +51,6 @@ def _list(galaxy_context,
             content_items[content_item_type].append(content_dict)
             # content_item_list.append(content_dict)
 
-        log.debug('content_items: %s', content_items)
         repo_dict = {'content_items': content_items,
                      'installed_repository': installed_repository}
         repo_list.append(repo_dict)

--- a/ansible_galaxy/collection_info.py
+++ b/ansible_galaxy/collection_info.py
@@ -1,6 +1,4 @@
-
 import logging
-import prettyprinter as pprint
 
 import yaml
 
@@ -9,7 +7,6 @@ from ansible_galaxy.models.collection_info import \
 from ansible_galaxy import exceptions
 
 log = logging.getLogger(__name__)
-pf = pprint.pformat
 
 # DEFAULT_FILENAME = "collection_info.yml"
 COLLECTION_INFO_FILENAME = "galaxy.yml"
@@ -18,9 +15,6 @@ COLLECTION_INFO_FILENAME = "galaxy.yml"
 # TODO: replace with a generic version for cases
 #       where SomeClass(**dict_from_yaml) works
 def load(data_or_file_object, klass=None):
-    log.debug('loading collection info from %s',
-              pf(data_or_file_object))
-
     data_dict = yaml.safe_load(data_or_file_object)
 
     # log.debug('data: %s', pf(data_dict))

--- a/ansible_galaxy/collection_info.py
+++ b/ansible_galaxy/collection_info.py
@@ -1,6 +1,6 @@
 
 import logging
-import pprint
+import prettyprinter as pprint
 
 import yaml
 
@@ -23,7 +23,7 @@ def load(data_or_file_object, klass=None):
 
     data_dict = yaml.safe_load(data_or_file_object)
 
-    log.debug('data: %s', pf(data_dict))
+    # log.debug('data: %s', pf(data_dict))
 
     try:
         collection_info = CollectionInfo(**data_dict)
@@ -31,7 +31,5 @@ def load(data_or_file_object, klass=None):
         raise
     except Exception as exc:
         raise exceptions.GalaxyClientError("Error parsing collection metadata: %s" % str(exc))
-
-    log.debug('artifact_manifest from_kwargs: %s', collection_info)
 
     return collection_info

--- a/ansible_galaxy/fetch/galaxy_url.py
+++ b/ansible_galaxy/fetch/galaxy_url.py
@@ -5,6 +5,7 @@ import logging
 from ansible_galaxy import exceptions
 from ansible_galaxy import download
 from ansible_galaxy.fetch import base
+from ansible_galaxy.models.repository_spec import RepositorySpec
 from ansible_galaxy.rest_api import GalaxyAPI
 from ansible_galaxy import repository_version
 
@@ -119,6 +120,15 @@ class GalaxyUrlFetch(base.BaseFetch):
         if not external_url:
             raise exceptions.GalaxyError('no external_url info on the Repository object from %s' % self.repository_spec.label)
 
+        # The repo spec of the install candidate with potentially a different version
+        potential_repository_spec = RepositorySpec(namespace=namespace,
+                                                   name=repo_name,
+                                                   version=_repoversion['version'],
+                                                   fetch_method=self.repository_spec.fetch_method,
+                                                   scm=self.repository_spec.scm,
+                                                   spec_string=self.repository_spec.spec_string,
+                                                   src=self.repository_spec.src)
+
         results = {'content': {'galaxy_namespace': namespace,
                                'repo_name': repo_name},
                    'specified_content_version': self.repository_spec.version,
@@ -129,7 +139,8 @@ class GalaxyUrlFetch(base.BaseFetch):
                               'related': related,
                               'repo_data': repo_data,
                               'repo_versions_url': repo_versions_url,
-                              'repoversion': _repoversion},
+                              'repoversion': _repoversion,
+                              'potential_repository_spec': potential_repository_spec},
                    }
 
         return results

--- a/ansible_galaxy/install.py
+++ b/ansible_galaxy/install.py
@@ -3,9 +3,9 @@
 # import datetime
 import logging
 import os
-import pprint
 
 import attr
+import prettyprinter as pprint
 
 from ansible_galaxy import repository_archive
 from ansible_galaxy import exceptions

--- a/ansible_galaxy/install.py
+++ b/ansible_galaxy/install.py
@@ -5,7 +5,7 @@ import logging
 import os
 
 import attr
-import prettyprinter as pprint
+import pprint
 
 from ansible_galaxy import repository_archive
 from ansible_galaxy import exceptions

--- a/ansible_galaxy/install_info.py
+++ b/ansible_galaxy/install_info.py
@@ -3,8 +3,6 @@ import os
 
 import yaml
 
-import attr
-
 from ansible_galaxy.models.install_info import InstallInfo
 
 log = logging.getLogger(__name__)
@@ -14,6 +12,10 @@ def load(data_or_file_object):
     log.debug('loading content install info from %s', data_or_file_object)
 
     info_dict = yaml.safe_load(data_or_file_object)
+
+    # an empty .galaxy_install_info
+    if info_dict is None:
+        return None
 
     # log.debug('info_dict: %s', info_dict)
     install_info = InstallInfo(version=info_dict.get('version', None),
@@ -39,7 +41,7 @@ def load_from_filename(filename):
         f.close()
 
 
-def save(install_info, filename):
+def save(install_info_dict, filename):
     log.debug('saving install info to %s', filename)
     if not os.path.exists(os.path.dirname(filename)):
         os.makedirs(os.path.dirname(filename))
@@ -48,9 +50,9 @@ def save(install_info, filename):
         # FIXME: just return the install_info dict (or better, build it elsewhere and pass in)
         # FIXME: stop minging self state
         try:
-            install_info_ = yaml.safe_dump(attr.asdict(install_info), f, default_flow_style=False)
+            yaml.safe_dump(install_info_dict, f, default_flow_style=False)
         except Exception as e:
-            log.warn('unable to serialize .galaxy_install_info to filename=%s for data=%s', filename, install_info_)
+            log.warn('unable to serialize .galaxy_install_info to filename=%s for data=%s', filename, install_info_dict)
             log.exception(e)
             return False
 

--- a/ansible_galaxy/installed_content_item_db.py
+++ b/ansible_galaxy/installed_content_item_db.py
@@ -41,10 +41,10 @@ def plugin_content_item_types(repository):
     plugins_dir = os.path.join(repository.path, 'plugins')
     try:
         res = [x for x in os.listdir(plugins_dir) if is_plugin_dir(os.path.join(plugins_dir, x))]
-        log.debug('plugin_content_item_types: %s', res)
+        # log.debug('plugin_content_item_types: %s', res)
         return res
-    except (OSError, IOError) as e:
-        log.warning(e)
+    except (OSError, IOError):
+        # log.warning(e)
         return []
 
 

--- a/ansible_galaxy/installed_repository_db.py
+++ b/ansible_galaxy/installed_repository_db.py
@@ -52,7 +52,7 @@ def installed_repository_iterator(galaxy_context,
                                                    name=repository_path,
                                                    installed=True)
 
-            log.debug('candidate installed repo (pre filter): %s', repository_)
+            # log.debug('candidate installed repo (pre filter): %s', repository_)
 
             if repository_match_filter(repository_):
                 log.debug('Found repository "%s" in namespace "%s"', repository_path, namespace.namespace)
@@ -80,7 +80,22 @@ class InstalledRepositoryDatabase(object):
     def by_repository_spec(self, repository_spec):
         namespace_match_filter = matchers.MatchNamespace([repository_spec.namespace])
 
-        repository_match_filter = matchers.MatchRepositorySpecsNamespaceNameVersion([repository_spec])
+        repository_match_filter = matchers.MatchRepositorySpecNamespaceNameVersion([repository_spec])
+
+        return self.select(namespace_match_filter=namespace_match_filter,
+                           repository_match_filter=repository_match_filter)
+
+    def by_requirement(self, requirement):
+        required_spec = requirement.requirement_spec
+        log.debug('required_spec: %s', required_spec)
+
+        namespace_match_filter = matchers.MatchNamespace([required_spec.namespace])
+
+        # no version specified
+        if required_spec.version is None:
+            repository_match_filter = matchers.MatchRepositorySpecNamespaceName([required_spec])
+        else:
+            repository_match_filter = matchers.MatchRepositorySpecNamespaceNameVersion([required_spec])
 
         return self.select(namespace_match_filter=namespace_match_filter,
                            repository_match_filter=repository_match_filter)

--- a/ansible_galaxy/matchers.py
+++ b/ansible_galaxy/matchers.py
@@ -50,36 +50,41 @@ class MatchRepositorySpec(Match):
         return res
 
 
-class MatchRepositorySpecsNamespaceNameVersion(Match):
+class MatchRepositorySpecNamespaceName(Match):
+    def __init__(self, repository_specs):
+        self.namespaces_names = [(x.namespace, x.name) for x in repository_specs] or []
+
+    def match(self, other):
+        ns_n_match_res = False
+        other_ns_n = (other.repository_spec.namespace, other.repository_spec.name)
+        ns_n_match_res = other_ns_n in self.namespaces_names
+
+        log.debug('%s (ns_n): does %s match %s?',
+                  ns_n_match_res,
+                  other_ns_n,
+                  self.namespaces_names)
+
+        return ns_n_match_res
+
+
+class MatchRepositorySpecNamespaceNameVersion(Match):
     def __init__(self, repository_specs):
         self.namespaces_names_versions = [(x.namespace, x.name, x.version) for x in repository_specs] or []
         self.namespaces_names = [(x.namespace, x.name) for x in repository_specs] or []
 
     def match(self, other):
-        ns_n_match_res = False
         ns_n_v_match_res = False
 
         other_ns_n_v = (other.repository_spec.namespace, other.repository_spec.name, other.repository_spec.version)
 
         ns_n_v_match_res = other_ns_n_v in self.namespaces_names_versions
 
-        log.debug('%s: is %s in %s',
+        log.debug('%s (ns_n_v) : does %s match %s ?',
                   ns_n_v_match_res,
                   other_ns_n_v,
                   self.namespaces_names_versions)
 
-        # If the version field is None, consider that a 'match any namespace.name'
-        if other.repository_spec.version is None:
-            log.debug('checking for just a  namespace.name match')
-            other_ns_n = (other.repository_spec.namespace, other.repository_spec.name)
-            ns_n_match_res = other_ns_n in self.namespaces_names
-
-            log.debug('%s: is %s in %s',
-                      ns_n_match_res,
-                      other_ns_n,
-                      self.namespaces_names)
-
-        return ns_n_v_match_res or ns_n_match_res
+        return ns_n_v_match_res
 
 
 class MatchNamespace(Match):
@@ -88,8 +93,9 @@ class MatchNamespace(Match):
         self.log = logging.getLogger('%s.%s' % (__name__, self.__class__.__name__))
 
     def match(self, other):
-        self.log.debug('is %s in %s', other.namespace, self.namespaces_to_match)
-        return other.namespace in self.namespaces_to_match
+        res = other.namespace in self.namespaces_to_match
+        self.log.debug('%s: (ns) %s matches %s', res, other.namespace, self.namespaces_to_match)
+        return res
 
 
 class MatchNamespacesOrLabels(Match):

--- a/ansible_galaxy/matchers.py
+++ b/ansible_galaxy/matchers.py
@@ -5,6 +5,10 @@ log = logging.getLogger(__name__)
 
 # TODO: abc?
 class Match(object):
+    '''A callable condition/match
+
+    self.match(other) should return a bool'''
+
     def __call__(self, other):
         return self.match(other)
 

--- a/ansible_galaxy/matchers.py
+++ b/ansible_galaxy/matchers.py
@@ -53,14 +53,33 @@ class MatchRepositorySpec(Match):
 class MatchRepositorySpecsNamespaceNameVersion(Match):
     def __init__(self, repository_specs):
         self.namespaces_names_versions = [(x.namespace, x.name, x.version) for x in repository_specs] or []
+        self.namespaces_names = [(x.namespace, x.name) for x in repository_specs] or []
 
     def match(self, other):
-        res = (other.repository_spec.namespace, other.repository_spec.name, other.repository_spec.version) in self.namespaces_names_versions
+        ns_n_match_res = False
+        ns_n_v_match_res = False
+
+        other_ns_n_v = (other.repository_spec.namespace, other.repository_spec.name, other.repository_spec.version)
+
+        ns_n_v_match_res = other_ns_n_v in self.namespaces_names_versions
+
         log.debug('%s: is %s in %s',
-                  res,
-                  (other.repository_spec.namespace, other.repository_spec.name, other.repository_spec.version),
+                  ns_n_v_match_res,
+                  other_ns_n_v,
                   self.namespaces_names_versions)
-        return res
+
+        # If the version field is None, consider that a 'match any namespace.name'
+        if other.repository_spec.version is None:
+            log.debug('checking for just a  namespace.name match')
+            other_ns_n = (other.repository_spec.namespace, other.repository_spec.name)
+            ns_n_match_res = other_ns_n in self.namespaces_names
+
+            log.debug('%s: is %s in %s',
+                      ns_n_match_res,
+                      other_ns_n,
+                      self.namespaces_names)
+
+        return ns_n_v_match_res or ns_n_match_res
 
 
 class MatchNamespace(Match):

--- a/ansible_galaxy/models/install_info.py
+++ b/ansible_galaxy/models/install_info.py
@@ -1,7 +1,10 @@
+import datetime
 import logging
 
 import attr
+import semver
 
+from ansible_galaxy.utils.version import convert_string_to_semver
 
 log = logging.getLogger(__name__)
 
@@ -10,8 +13,10 @@ log = logging.getLogger(__name__)
 class InstallInfo(object):
     '''The info that is saved into the .galaxy_install_info file'''
     install_date = attr.ib()
-    install_date_iso = attr.ib()
-    version = attr.ib()
+    install_date_iso = attr.ib(type=datetime.datetime)
+
+    version = attr.ib(type=semver.VersionInfo, default=None,
+                      converter=convert_string_to_semver)
 
     @classmethod
     def from_version_date(cls, version, install_datetime):
@@ -19,3 +24,12 @@ class InstallInfo(object):
                    install_date_iso=install_datetime,
                    install_date=install_datetime.strftime('%c'))
         return inst
+
+    def to_dict_version_strings(self):
+        data = attr.asdict(self)
+
+        # semver.VersionInfo isnt yaml-able, so build a dict with
+        # the VersionInfo replaced with a str version
+        data['version'] = str(data['version'])
+
+        return data

--- a/ansible_galaxy/models/repository.py
+++ b/ansible_galaxy/models/repository.py
@@ -14,10 +14,10 @@ class Repository(object):
     installed = attr.ib(default=False, type=bool, cmp=False)
 
     # ie, a role-as-collections-meta-main-deps
-    dependencies = attr.ib(factory=list)
+    dependencies = attr.ib(factory=tuple)
 
     # ie, a collection or role-as-collections-requirement.yml
-    requirements = attr.ib(factory=list)
+    requirements = attr.ib(factory=tuple)
 
     # The data normally found in meta/main.yml for roles
     # meta_main = attr.ib(default=None, type=RoleMetadata)
@@ -25,3 +25,6 @@ class Repository(object):
     @property
     def label(self):
         return self.repository_spec.label
+
+    def __str__(self):
+        return '{repo_spec}[{path}]'.format(repo_spec=self.repository_spec, path=self.path)

--- a/ansible_galaxy/models/repository_spec.py
+++ b/ansible_galaxy/models/repository_spec.py
@@ -1,4 +1,10 @@
+import logging
+
 import attr
+import semver
+
+from ansible_galaxy.utils.version import convert_string_to_semver
+log = logging.getLogger(__name__)
 
 
 @attr.s(frozen=True)
@@ -11,7 +17,8 @@ class RepositorySpec(object):
     namespace = attr.ib()
     name = attr.ib()
     # TODO: would it be worthwhile to make this a Semver type?
-    version = attr.ib(default=None)
+    version = attr.ib(type=semver.VersionInfo, default=None,
+                      converter=convert_string_to_semver)
 
     # only namespace/name/version are used for eq checks currently
 

--- a/ansible_galaxy/models/repository_spec.py
+++ b/ansible_galaxy/models/repository_spec.py
@@ -48,3 +48,6 @@ class RepositorySpec(object):
                        src=data.get('src', None),
                        )
         return instance
+
+    def __str__(self):
+        return '{label}-{version}'.format(label=self.label, version=self.version)

--- a/ansible_galaxy/models/requirement.py
+++ b/ansible_galaxy/models/requirement.py
@@ -96,3 +96,14 @@ class Requirement(object):
     # do we need to resolve the dep at install time ('requirements') or
     # could we defer until runtime (like role dependencies)
     scope = attr.ib(default=RequirementScopes.INSTALL)
+
+    def __str__(self):
+        return '{repo_spec}->{req_spec_label}{op}{req_spec_version}'.format(repo_spec=str(self.repository_spec),
+                                                                            req_spec_label=str(self.requirement_spec.label),
+                                                                            op=self.op,
+                                                                            req_spec_version=str(self.requirement_spec.version),
+                                                                            )
+
+    # FIXME: just for debugging
+    def __repr__(self):
+        return str(self)

--- a/ansible_galaxy/repository.py
+++ b/ansible_galaxy/repository.py
@@ -39,9 +39,9 @@ def load_from_dir(content_dir, namespace, name, installed=True):
     #       Maybe:
     #       if more than one role in roles/ -> collection
 
-    # if not os.path.isdir(path_name):
-    #    log.debug('No collection found at %s', path_name)
-    #    return None
+    if not os.path.isdir(path_name):
+        log.debug('FAILURE of load of %s to a Repository', path_name)
+        return None
 
     # Now look for any install_info for the repository
     install_info_data = None

--- a/ansible_galaxy/repository.py
+++ b/ansible_galaxy/repository.py
@@ -30,7 +30,7 @@ def load_from_dir(content_dir, namespace, name, installed=True):
     # TODO: or artifact
 
     path_name = os.path.join(content_dir, namespace, name)
-
+    log.debug('START of load of %s to a Repository', path_name)
     # TODO: add trad role or collection detection rules here
     #       Or possibly earlier so we could call 'collection' loading
     #       code/class or trad-role-as-collection loading code/class
@@ -113,7 +113,7 @@ def load_from_dir(content_dir, namespace, name, installed=True):
                             requirements=requirements_list,
                             dependencies=role_dependency_specs)
 
-    log.debug('repository: %s', repository)
+    log.debug('FINISH of load of repository %s: %s', path_name, repository)
 
     return repository
 

--- a/ansible_galaxy/repository.py
+++ b/ansible_galaxy/repository.py
@@ -2,7 +2,6 @@ import logging
 import os
 import shutil
 
-import prettyprinter as pprint
 import yaml
 
 from ansible_galaxy import collection_info
@@ -125,7 +124,6 @@ def load_from_dir(content_dir, namespace, name, installed=True):
                             dependencies=role_dependency_specs)
 
     log.debug('FINISH of load of repository %s: %s', path_name, repository.repository_spec.label)
-    # log.debug('repository: %s', pprint.pformat(repository))
 
     return repository
 

--- a/ansible_galaxy/repository.py
+++ b/ansible_galaxy/repository.py
@@ -2,6 +2,7 @@ import logging
 import os
 import shutil
 
+import prettyprinter as pprint
 import yaml
 
 from ansible_galaxy import collection_info
@@ -53,7 +54,7 @@ def load_from_dir(content_dir, namespace, name, installed=True):
         log.warning('No galaxy.yml found for collection %s.%s: %s', namespace, name, e)
         # log.exception(e)
 
-    log.debug('collection_info_data: %s', collection_info_data)
+    # log.debug('collection_info_data: %s', collection_info_data)
 
     requirements_filename = os.path.join(path_name, 'requirements.yml')
     requirements_list = []
@@ -65,7 +66,7 @@ def load_from_dir(content_dir, namespace, name, installed=True):
     except EnvironmentError as e:
         log.warning('No requirements.yml found for collection %s.%s: %s', namespace, name, e)
 
-    log.debug('requirements_list: %s', requirements_list)
+    # log.debug('requirements_list: %s', requirements_list)
 
     # Now try the repository as a role-as-collection
     # FIXME: For a repository with one role that matches the collection name and doesn't
@@ -85,8 +86,8 @@ def load_from_dir(content_dir, namespace, name, installed=True):
     #       to load them and combine them with role_depenency_specs
     role_dependency_specs = []
     if role_meta_main:
-        log.debug('role_meta_main: %s', role_meta_main)
-        log.debug('role_meta_main_deps: %s', role_meta_main.dependencies)
+        # log.debug('role_meta_main: %s', role_meta_main)
+        # log.debug('role_meta_main_deps: %s', role_meta_main.dependencies)
         role_dependency_specs = role_meta_main.dependencies
 
     # Now look for any install_info for the repository
@@ -100,7 +101,7 @@ def load_from_dir(content_dir, namespace, name, installed=True):
 
     # TODO: figure out what to do if the version from install_info conflicts with version
     #       from galaxy.yml etc.
-    log.debug('install_info: %s', install_info_data)
+    # log.debug('install_info: %s', install_info_data)
     install_info_version = getattr(install_info_data, 'version', None)
 
     repository_spec = RepositorySpec(namespace=namespace,
@@ -113,7 +114,8 @@ def load_from_dir(content_dir, namespace, name, installed=True):
                             requirements=requirements_list,
                             dependencies=role_dependency_specs)
 
-    log.debug('FINISH of load of repository %s: %s', path_name, repository)
+    log.debug('FINISH of load of repository %s: %s', path_name, repository.repository_spec.label)
+    # log.debug('repository: %s', pprint.pformat(repository))
 
     return repository
 

--- a/ansible_galaxy/repository_archive.py
+++ b/ansible_galaxy/repository_archive.py
@@ -196,7 +196,9 @@ def install(repository_archive, repository_spec, destination_info, display_callb
                                                   install_datetime=install_datetime)
 
     # TODO: this save will need to be moved to a step later. after validating install?
-    install_info.save(install_info_, destination_info.install_info_path)
+    # The to_dict_version_strings is to convert the un-yaml-able semver.VersionInfo to a string
+    install_info.save(install_info_.to_dict_version_strings(),
+                      destination_info.install_info_path)
 
     installation_results = InstallationResults(install_info_path=destination_info.install_info_path,
                                                install_info=install_info_,

--- a/ansible_galaxy/repository_archive.py
+++ b/ansible_galaxy/repository_archive.py
@@ -126,8 +126,8 @@ def detect_repository_archive_type(archive_path, archive_members):
         if member.name in type_dir_targets:
             return 'multi-content'
 
-    # TODO: exception
-    return None
+    # otherwise, assume it is a collection / multi-content repo archive
+    return 'multi-content'
 
 
 def load_archive_info(archive_path):

--- a/ansible_galaxy/repository_archive.py
+++ b/ansible_galaxy/repository_archive.py
@@ -108,7 +108,7 @@ def detect_repository_archive_type(archive_path, archive_members):
 
     top_dir = archive_members[0].name
 
-    log.debug('top_dir of %s: %s', archive_path, top_dir)
+    # log.debug('top_dir of %s: %s', archive_path, top_dir)
 
     meta_main_target = os.path.join(top_dir, 'meta/main.yml')
 
@@ -116,7 +116,7 @@ def detect_repository_archive_type(archive_path, archive_members):
     # log.debug('type_dirs: %s', type_dirs)
 
     type_dir_targets = set([os.path.join(top_dir, x) for x in type_dirs])
-    log.debug('type_dir_targets: %s', type_dir_targets)
+    # log.debug('type_dir_targets: %s', type_dir_targets)
 
     for member in archive_members:
         if member.name == meta_main_target:
@@ -147,8 +147,8 @@ def load_archive_info(archive_path):
 
     archive_type = detect_repository_archive_type(archive_path, members)
 
-    log.debug('archive_type of %s: %s', archive_path, archive_type)
-    log.debug("archive_parent_dir of %s: %s", archive_path, archive_parent_dir)
+    # log.debug('archive_type of %s: %s', archive_path, archive_type)
+    # log.debug("archive_parent_dir of %s: %s", archive_path, archive_parent_dir)
 
     # looks like we are a role, update the default content_type from all -> role
     if archive_type == 'role':
@@ -159,7 +159,7 @@ def load_archive_info(archive_path):
                                          archive_type=archive_type,
                                          archive_path=archive_path)
 
-    log.debug('role archive_info for %s: %s', archive_path, archive_info)
+    # log.debug('role archive_info for %s: %s', archive_path, archive_info)
 
     return archive_info, repository_tar_file
 
@@ -183,7 +183,7 @@ def load_archive(archive_path):
 
 
 def install(repository_archive, repository_spec, destination_info, display_callback):
-    log.debug('saving repo archive %s to destination %s', repository_archive, destination_info)
+    log.debug('installing/extracting repo archive %s to destination %s', repository_archive, destination_info)
 
     all_installed_files, install_datetime = extract(repository_spec,
                                                     repository_archive.info,

--- a/ansible_galaxy/repository_spec.py
+++ b/ansible_galaxy/repository_spec.py
@@ -1,8 +1,6 @@
 import logging
 import os
 
-import semver
-
 from ansible_galaxy import galaxy_repository_spec
 from ansible_galaxy import repository_spec_parse
 from ansible_galaxy import exceptions
@@ -118,10 +116,6 @@ def repository_spec_from_string(repository_spec_string, namespace_override=None,
     spec_data = spec_data_from_string(repository_spec_string, namespace_override=None, editable=editable)
 
     log.debug('spec_data: %s', spec_data)
-
-    #version = None
-    #if spec_data.get('version'):
-    #    version = semver.parse_version_info(spec_data.get('version')),
 
     return RepositorySpec(name=spec_data.get('name'),
                           namespace=spec_data.get('namespace'),

--- a/ansible_galaxy/repository_spec.py
+++ b/ansible_galaxy/repository_spec.py
@@ -1,6 +1,8 @@
 import logging
 import os
 
+import semver
+
 from ansible_galaxy import galaxy_repository_spec
 from ansible_galaxy import repository_spec_parse
 from ansible_galaxy import exceptions
@@ -117,9 +119,14 @@ def repository_spec_from_string(repository_spec_string, namespace_override=None,
 
     log.debug('spec_data: %s', spec_data)
 
+    #version = None
+    #if spec_data.get('version'):
+    #    version = semver.parse_version_info(spec_data.get('version')),
+
     return RepositorySpec(name=spec_data.get('name'),
                           namespace=spec_data.get('namespace'),
                           version=spec_data.get('version'),
+                          # version=version,
                           scm=spec_data.get('scm'),
                           spec_string=spec_data.get('spec_string'),
                           fetch_method=spec_data.get('fetch_method'),

--- a/ansible_galaxy/repository_spec_parse.py
+++ b/ansible_galaxy/repository_spec_parse.py
@@ -166,9 +166,12 @@ def spec_data_from_string(repository_spec_string, resolver=None):
         if fetch_method == FetchMethods.GALAXY_URL:
             resolver = galaxy_repository_spec.resolve
 
-    log.debug('resolver: %s', resolver)
+    # log.debug('resolver: %s', resolver)
+
     resolved_name = resolver(spec_data)
+
     log.debug('resolved_name: %s', resolved_name)
+
     spec_data.update(resolved_name)
 
     return spec_data

--- a/ansible_galaxy/repository_spec_parse.py
+++ b/ansible_galaxy/repository_spec_parse.py
@@ -103,7 +103,7 @@ class FetchMethods(object):
 
 
 def chose_repository_fetch_method(repository_spec_string):
-    log.debug('repository_spec_string: %s', repository_spec_string)
+    # log.debug('repository_spec_string: %s', repository_spec_string)
 
     if is_scm(repository_spec_string):
         # create tar file from scm url
@@ -152,12 +152,12 @@ def resolve(data):
 def spec_data_from_string(repository_spec_string, resolver=None):
     fetch_method = chose_repository_fetch_method(repository_spec_string)
 
-#    log.debug('fetch_method: %s', fetch_method)
+    # log.debug('fetch_method: %s', fetch_method)
 
     spec_data = parse_string(repository_spec_string)
     spec_data['fetch_method'] = fetch_method
 
-#    log.debug('spec_data: %s', spec_data)
+    # log.debug('spec_data: %s', spec_data)
 
     # use passed in resolver if provided, otherwise assume 'resolve' is correct
     # but override if it looks like a galaxy requests
@@ -170,7 +170,7 @@ def spec_data_from_string(repository_spec_string, resolver=None):
 
     resolved_name = resolver(spec_data)
 
-    log.debug('resolved_name: %s', resolved_name)
+    # log.debug('resolved_name: %s', resolved_name)
 
     spec_data.update(resolved_name)
 

--- a/ansible_galaxy/repository_version.py
+++ b/ansible_galaxy/repository_version.py
@@ -75,15 +75,15 @@ def validate_versions(content_versions):
 
 
 def get_repository_version(repository_data, version, repository_versions, content_content_name):
-    '''find and compare repository version found in content_data dict
+    '''find and compare repository version found in repository_data dict
 
-    repository_data is a dict based on /api/v1/content/13 for ex
+    repository_data is a dict based on /api/v1/repositories/13 for ex
     content_content_data is the name of the content specified by user?
     version is the version string asked for by user
     content_versions is a list of version strings in order
     '''
 
-    log.debug('%s want ver: %s', content_content_name, version)
+    log.debug('%s wants ver: %s type: %s', content_content_name, version, type(version))
 #    log.debug('%s vers avail: %s',
 #              content_content_name, json.dumps(content_versions, indent=2))
 
@@ -94,6 +94,11 @@ def get_repository_version(repository_data, version, repository_versions, conten
     # in the sort
     available_versions, dummy = \
         validate_versions(available_normalized_versions)
+
+    # FIXME: support direct semver usage all the way through
+    # str or semver to string, but leave None alone
+    if version:
+        version = str(version)
 
     normalized_version = normalize_version_string(version)
 

--- a/ansible_galaxy/requirements.py
+++ b/ansible_galaxy/requirements.py
@@ -10,7 +10,7 @@ from ansible_galaxy.utils import yaml_parse
 log = logging.getLogger(__name__)
 
 
-def load(data_or_file_object):
+def load(data_or_file_object, repository_spec=None):
     log.debug('START of load of requirements %s', data_or_file_object.name)
 
     requirements_data = yaml.safe_load(data_or_file_object)
@@ -34,7 +34,7 @@ def load(data_or_file_object):
 
         # log.debug('req_spec: %s', req_spec)
 
-        req = Requirement(repository_spec=None, op=RequirementOps.EQ, requirement_spec=req_spec)
+        req = Requirement(repository_spec=repository_spec, op=RequirementOps.EQ, requirement_spec=req_spec)
 
         # log.debug('req: %s', req)
 

--- a/ansible_galaxy/requirements.py
+++ b/ansible_galaxy/requirements.py
@@ -12,6 +12,8 @@ log = logging.getLogger(__name__)
 
 
 def load(data_or_file_object):
+    log.debug('START of load of requirements %s', data_or_file_object)
+
     requirements_data = yaml.safe_load(data_or_file_object)
 
     log.debug('requirements_data: %s', pprint.pformat(requirements_data))
@@ -19,11 +21,11 @@ def load(data_or_file_object):
     requirements_list = []
 
     for req_data_item in requirements_data:
-        log.debug('req_data_item: %s', req_data_item)
-        log.debug('type(req_data_item): %s', type(req_data_item))
+        # log.debug('req_data_item: %s', req_data_item)
+        # log.debug('type(req_data_item): %s', type(req_data_item))
 
         req_spec_data = yaml_parse.yaml_parse(req_data_item)
-        log.debug('req_spec_data: %s', req_spec_data)
+        # log.debug('req_spec_data: %s', req_spec_data)
 
         # name_info = content_name.parse_content_name(data_name)
         # log.debug('data_name (after): %s', data_name)
@@ -31,7 +33,7 @@ def load(data_or_file_object):
 
         req_spec = RepositorySpec.from_dict(req_spec_data)
 
-        log.debug('req_spec: %s', req_spec)
+        # log.debug('req_spec: %s', req_spec)
 
         req = Requirement(repository_spec=None, op=RequirementOps.EQ, requirement_spec=req_spec)
 
@@ -39,7 +41,7 @@ def load(data_or_file_object):
 
         requirements_list.append(req)
 
-    log.debug('requirements_list: %s', requirements_list)
+    log.debug('FINISH of load of requirements: %s: %s', data_or_file_object, requirements_list)
     return requirements_list
 
 

--- a/ansible_galaxy/requirements.py
+++ b/ansible_galaxy/requirements.py
@@ -1,5 +1,4 @@
 import logging
-import pprint
 
 import yaml
 
@@ -12,11 +11,11 @@ log = logging.getLogger(__name__)
 
 
 def load(data_or_file_object):
-    log.debug('START of load of requirements %s', data_or_file_object)
+    log.debug('START of load of requirements %s', data_or_file_object.name)
 
     requirements_data = yaml.safe_load(data_or_file_object)
 
-    log.debug('requirements_data: %s', pprint.pformat(requirements_data))
+    # log.debug('requirements_data: %s', pprint.pformat(requirements_data))
 
     requirements_list = []
 
@@ -37,11 +36,11 @@ def load(data_or_file_object):
 
         req = Requirement(repository_spec=None, op=RequirementOps.EQ, requirement_spec=req_spec)
 
-        log.debug('req: %s', req)
+        # log.debug('req: %s', req)
 
         requirements_list.append(req)
 
-    log.debug('FINISH of load of requirements: %s: %s', data_or_file_object, requirements_list)
+    log.debug('FINISH of load of requirements: %s: %s', data_or_file_object.name, requirements_list)
     return requirements_list
 
 

--- a/ansible_galaxy/utils/version.py
+++ b/ansible_galaxy/utils/version.py
@@ -1,10 +1,24 @@
 import logging
 import re
 
+import semver
+
 log = logging.getLogger(__name__)
 
 VERSION_WITH_LEADING_V_MATCH_RE = re.compile(r'^[vV]\d+\.')
 VERSION_WITH_LEADING_V_SUB_RE = re.compile(r'(^[vV])')
+
+
+def convert_string_to_semver(version):
+    # log.debug('vs: %s type: %s', version, type(version))
+
+    if not version:
+        return None
+
+    if isinstance(version, semver.VersionInfo):
+        return version
+
+    return semver.parse_version_info(version)
 
 
 def normalize_version_string(version_string):

--- a/ansible_galaxy/utils/yaml_parse.py
+++ b/ansible_galaxy/utils/yaml_parse.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 import six
 
@@ -30,17 +29,17 @@ def yaml_parse(content, resolver=None):
     if isinstance(content, six.string_types):
         log.debug('parsing content="%s" as a string', content)
 
-        orig_content = copy.deepcopy(content)
+        # orig_content = copy.deepcopy(content)
         res = repository_spec_parse.spec_data_from_string(content, resolver=resolver)
 
         log.debug('parsed spec="%s" -> %s', content, res)
 
         return res
 
-    log.debug('content="%s" is not a string (it is a %s) so we are assuming it is a dict',
-              content, type(content))
+    # log.debug('content="%s" is not a string (it is a %s) so we are assuming it is a dict',
+    #          content, type(content))
 
-    orig_content = copy.deepcopy(content)
+    # orig_content = copy.deepcopy(content)
 
     # Not sure what will/should happen if content is not a Mapping or a string
     # FIXME: if content is not a string or a dict/map, throw a reasonable error.
@@ -61,13 +60,13 @@ def yaml_parse(content, resolver=None):
             del content['role']
             content['name'] = name
     else:
-        log.debug('content="%s" does not appear to be a role', content)
+        # log.debug('content="%s" does not appear to be a role', content)
 
         # FIXME: just use a new name already
         # FIXME: this fails for objects with no dict attribute, like a list
         content_copy = content.copy()
 
-        log.debug('content_copy: %s', content_copy)
+        # log.debug('content_copy: %s', content_copy)
 
         data = {'src': None, 'version': None, 'name': None, 'scm': None}
         data.update(content_copy)
@@ -77,7 +76,7 @@ def yaml_parse(content, resolver=None):
             # valid_kw = ('src', 'version', 'name', 'scm')
             new_data = repository_spec_parse.spec_data_from_string(data['src'])
 
-            log.debug('new_data: %s', new_data)
+            # log.debug('new_data: %s', new_data)
 
             for key in new_data:
                 if not data.get(key, None):
@@ -96,10 +95,10 @@ def yaml_parse(content, resolver=None):
     for key in list(content.keys()):
         # sub_name doesnt mean anything to role spec
         if key not in VALID_ROLE_SPEC_KEYS and key not in ('sub_name', 'namespace', 'fetch_method'):
-            log.debug('removing invalid key: %s', key)
+            # log.debug('removing invalid key: %s', key)
 
             content.pop(key)
 
-    log.debug('"parsed" content="%s" into: %s', orig_content, content)
+    # log.debug('"parsed" content="%s" into: %s', orig_content, content)
 
     return content

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -27,6 +27,7 @@ import logging
 import os
 import sys
 
+import prettyprinter
 
 from ansible_galaxy.actions import build
 from ansible_galaxy.actions import info
@@ -49,6 +50,9 @@ from ansible_galaxy_cli import __version__ as galaxy_cli_version
 from ansible_galaxy_cli import exceptions as cli_exceptions
 
 log = logging.getLogger(__name__)
+
+# https://prettyprinter.readthedocs.io/en/latest/api_reference.html#prettyprinter.install_extras
+prettyprinter.install_extras(exclude=['ipython_repr_pretty', 'ipython', 'dataclasses', 'django'])
 
 
 def exit_without_ignore(ignore_errors, msg=None, rc=1):

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -27,8 +27,6 @@ import logging
 import os
 import sys
 
-import prettyprinter
-
 from ansible_galaxy.actions import build
 from ansible_galaxy.actions import info
 from ansible_galaxy.actions import install
@@ -50,9 +48,6 @@ from ansible_galaxy_cli import __version__ as galaxy_cli_version
 from ansible_galaxy_cli import exceptions as cli_exceptions
 
 log = logging.getLogger(__name__)
-
-# https://prettyprinter.readthedocs.io/en/latest/api_reference.html#prettyprinter.install_extras
-prettyprinter.install_extras(exclude=['ipython_repr_pretty', 'ipython', 'dataclasses', 'django'])
 
 
 def exit_without_ignore(ignore_errors, msg=None, rc=1):

--- a/tests/ansible_galaxy/actions/test_list.py
+++ b/tests/ansible_galaxy/actions/test_list.py
@@ -1,11 +1,8 @@
 import logging
 import os
-import pprint
 
 from ansible_galaxy import exceptions
 from ansible_galaxy.actions import list as list_action
-from ansible_galaxy.models.repository import Repository
-from ansible_galaxy.models.repository_spec import RepositorySpec
 
 log = logging.getLogger(__name__)
 

--- a/tests/ansible_galaxy/actions/test_list.py
+++ b/tests/ansible_galaxy/actions/test_list.py
@@ -4,6 +4,8 @@ import pprint
 
 from ansible_galaxy import exceptions
 from ansible_galaxy.actions import list as list_action
+from ansible_galaxy.models.repository import Repository
+from ansible_galaxy.models.repository_spec import RepositorySpec
 
 log = logging.getLogger(__name__)
 
@@ -21,6 +23,9 @@ def test__list(galaxy_context, mocker):
     mocker.patch('ansible_galaxy.installed_repository_db.get_repository_paths',
                  return_value=iter(['n_bar', 'n_baz']))
 
+    mocker.patch('ansible_galaxy.repository.os.path.isdir',
+                 return_value=True)
+
     mocker.patch('ansible_galaxy.installed_content_item_db.glob_content_path_iterator',
                  return_value=iter(['/dev/null/content/ns_foo/n_bar/roles/role-1',
                                     '/dev/null/content/ns_blip/n_bar/roles/role-3',
@@ -29,7 +34,7 @@ def test__list(galaxy_context, mocker):
     res = list_action._list(galaxy_context,
                             display_callback=display_callback)
 
-    log.debug('res: %s', pprint.pformat(res))
+    # log.debug('res: %s', pprint.pformat(res))
 
     assert isinstance(res, list)
     assert 'ns_blip.n_bar' in [x['installed_repository'].repository_spec.label for x in res]

--- a/tests/ansible_galaxy/test_install_info.py
+++ b/tests/ansible_galaxy/test_install_info.py
@@ -26,7 +26,7 @@ def test_load():
 
     assert isinstance(install_info_, InstallInfo)
 
-    assert install_info_.version == '0.1.0'
+    assert str(install_info_.version) == '0.1.0'
     assert isinstance(install_info_.install_date_iso, datetime.datetime)
     assert isinstance(install_info_.install_date, string_types)
 
@@ -38,7 +38,7 @@ def test_load_string():
 
     assert isinstance(install_info_, InstallInfo)
 
-    assert install_info_.version == '0.1.0'
+    assert str(install_info_.version) == '0.1.0'
     assert isinstance(install_info_.install_date_iso, datetime.datetime)
     assert isinstance(install_info_.install_date, string_types)
 
@@ -56,7 +56,7 @@ def test_load_from_filename(tmpdir):
 
     assert isinstance(install_info_, InstallInfo)
 
-    assert install_info_.version == '0.1.0'
+    assert str(install_info_.version) == '0.1.0'
     assert isinstance(install_info_.install_date_iso, datetime.datetime)
     assert isinstance(install_info_.install_date, string_types)
 
@@ -69,7 +69,8 @@ def test_save(tmpdir):
 
     temp_dir = tmpdir.mkdir('mazer_content_install_info_unit_test')
     temp_file = temp_dir.join('.galaxy_install_info')
-    install_info.save(install_info_, temp_file.strpath)
+    install_info.save(install_info_.to_dict_version_strings(),
+                      temp_file.strpath)
 
     log.debug('tmpfile: %s', temp_file)
 

--- a/tests/ansible_galaxy/test_installed_content_item_db.py
+++ b/tests/ansible_galaxy/test_installed_content_item_db.py
@@ -47,6 +47,8 @@ class MatchContentItemNamesFnmatch(object):
 def test_installed_content_item_iterator_empty(galaxy_context, mocker):
     mocker.patch('ansible_galaxy.installed_namespaces_db.get_namespace_paths',
                  return_value=iter(['foo', 'blip']))
+    mocker.patch('ansible_galaxy.repository.os.path.isdir',
+                 return_value=True)
     mocker.patch('ansible_galaxy.installed_repository_db.get_repository_paths',
                  return_value=iter(['bar', 'baz']))
 


### PR DESCRIPTION
##### SUMMARY
Various fixes to improve how installing collections and roles with dependencies works.

Most of this is related to variations of 'do the right thing when asked to install something that is already installed'. Either directly, or as a requirement.

- Make RepositorySpec class used a semver.VersionInfo object directly instead of just a string.
- drive action.install breadth first instead of depth first (ie, build up info for the stuff to be installed, install it, accumulate results of all of them, then check for new deps for all new installs, repeat)
- Add 'db' methods to installed_repository_db for accessing a repo "directly" by specifying a full RepositorySpec instead of a set of constraints to match it. This reduced the number of dirs/files we have to check to answer questions like 'is namespace.name installed?'. Also reduced the number of 
Repository() objects that need to be loaded from disk.
- Fix up display output.
- Some str() for objects that need them (RepositorySpec, Requirement). The current ones are kind of ugly but it is a start.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.2.1
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.12-100.fc27.x86_64, #1 SMP Thu Oct 4 16:22:17 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3-2/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3-2/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

