### PR TITLE
Load requirements from galaxy.yml as well

### DIFF
--- a/ansible_galaxy/models/collection_info.py
+++ b/ansible_galaxy/models/collection_info.py
@@ -23,6 +23,9 @@ class CollectionInfo(object):
     description = attr.ib(default=None)
     keywords = attr.ib(default=[])
     readme = attr.ib(default='README.md')
+
+    # Note galaxy.yml 'dependencies' field is what mazer and ansible
+    # consider 'requirements'. ie, install time requirements.
     dependencies = attr.ib(default=[])
 
     @property

--- a/ansible_galaxy/requirements.py
+++ b/ansible_galaxy/requirements.py
@@ -44,21 +44,16 @@ def load(data_or_file_object, repository_spec=None):
     return requirements_list
 
 
-def from_requirement_spec_strings(requirement_spec_strings, namespace_override=None, editable=False):
+def from_requirement_spec_strings(requirement_spec_strings, namespace_override=None, editable=False, repository_spec=None):
     reqs = []
     for requirement_spec_string in requirement_spec_strings:
         req_spec_data = spec_data_from_string(requirement_spec_string,
                                               namespace_override=namespace_override,
                                               editable=editable)
 
-        log.debug('req_spec_data: %s', req_spec_data)
-
         req_spec = RepositorySpec.from_dict(req_spec_data)
-        log.debug('req_spec: %s', req_spec)
 
-        req = Requirement(repository_spec=None, op=RequirementOps.EQ, requirement_spec=req_spec)
-
-        log.debug('req: %s', req)
+        req = Requirement(repository_spec=repository_spec, op=RequirementOps.EQ, requirement_spec=req_spec)
 
         reqs.append(req)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Load requirements from galaxy.yml as well, in addition to requirements.yml.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.2.1
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.12-100.fc27.x86_64, #1 SMP Thu Oct 4 16:22:17 UTC 2018, x86_64
executable_location = /home/adrian/venvs/mazer-py3-test2/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/mazer-py3-test2/bin/python

```



