### PR TITLE
Fix 'install -e' after requirements solving changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,26 @@ Example playbook using mazer install roles, using fully qualified role names and
     #
 
 ```
+
+### Building ansible content collection artifacts with 'mazer build'
+
+In the future, galaxy will support importing and ansible content collection
+artifacts. The artifacts are collection archives with the addition of
+a MANIFEST.json providing a manifest of the content (files) in the archive
+as well as additional metadata.
+
+For example, to build the test 'hello' collection included in mazer
+source code in tests/ansible_galaxy/collection_examples/hello/
+
+```
+$ # From a source tree checkout of mazer
+$ cd tests/ansible_galaxy/collection_examples/hello/
+$ mazer build
+```
+
+The above command will create an ansible content collection artifact
+at tests/ansible_galaxy/collection_examples/hello/releases/v11.11.11.tar.gz
+
 ## Configuration
 mazer is configured by a 'mazer.yml' config file in ~/.ansible.
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ $ mazer install --content-path ~/my-ansible-content geerlingguy.nginx
 
 This will install the geerlingguy.nginx role to ~/my-ansible-content/geerlingguy/nginx/roles/nginx
 
+### Installing collections in 'editable' mode for development
+
+
 ### Using mazer installed roles in a playbook (requires 'mazer_role_loader' ansible branch)
 
 Before running this example, install the roles required via mazer. Use '--force' if some of the roles are already installed by mazer.

--- a/ansible_galaxy/archive.py
+++ b/ansible_galaxy/archive.py
@@ -28,8 +28,8 @@ def extract_file(tar_file, file_to_extract):
 
     # TODO: raise from up a level in the stack?
     dest_path = os.path.join(dest_dir, dest_filename)
-    log.debug('dest_dir: %s, dest_filename: %s, dest_path: %s orig_name: %s',
-              dest_dir, dest_filename, dest_path, orig_name)
+    # log.debug('dest_dir: %s, dest_filename: %s, dest_path: %s orig_name: %s',
+    #          dest_dir, dest_filename, dest_path, orig_name)
     if os.path.exists(dest_path):
         if not force_overwrite:
             message = "The Galaxy content %s appears to already exist." % dest_path

--- a/ansible_galaxy/collection_members.py
+++ b/ansible_galaxy/collection_members.py
@@ -66,11 +66,11 @@ class FileWalker(object):
             # NOTE: This modifies dirnames while it is being walked over
             for dirname in dirnames:
                 if dirname in self.ignore_dirs:
-                    log.debug('ignoring dir: %s', dirname)
+                    # log.debug('ignoring dir: %s', dirname)
                     dirnames.remove(dirname)
                 else:
                     dir_full_path = os.path.join(dirpath, dirname)
-                    log.debug('yield dir_full_path: %s', dir_full_path)
+                    # log.debug('yield dir_full_path: %s', dir_full_path)
                     yield dir_full_path
 
             for filename in filenames:
@@ -86,7 +86,7 @@ class FileWalker(object):
                 if file_is_excluded(full_path, self.exclude_patterns):
                     continue
 
-                log.debug('yield (fn full_path)%s', full_path)
+                # log.debug('yield (fn full_path)%s', full_path)
                 yield full_path
                 # yield collection_relative_path
                 # yield CollectionMember(src_full_path=full_path, dest_relative_path=collection_relative_path)

--- a/ansible_galaxy/fetch/editable.py
+++ b/ansible_galaxy/fetch/editable.py
@@ -1,0 +1,68 @@
+import logging
+import os
+
+from ansible_galaxy import exceptions
+
+log = logging.getLogger(__name__)
+
+
+class EditableFetch(object):
+    fetch_method = 'editable'
+
+    def __init__(self, galaxy_context, repository_spec):
+        self.galaxy_context = galaxy_context
+        self.repository_spec = repository_spec
+        self.local_path = self.repository_spec.src
+
+    def find(self):
+        real_path = os.path.abspath(self.repository_spec.src)
+
+        log.debug('Searching for a repository to link to as an editable install at %s', real_path)
+
+        if not os.path.isdir(real_path):
+            log.warning("%s needs to be a local directory for an editable install" % self.repository.src)
+            raise exceptions.GalaxyClientError('Error finding an editable install of %s because %s is not a directory', self.repository_spec.src, real_path)
+
+        results = {'content': {'galaxy_namespace': self.repository_spec.namespace,
+                               'repo_name': self.repository_spec.name},
+                   'specified_content_version': self.repository_spec.version,
+                   'specified_repository_spec': self.repository_spec.scm,
+                   'custom': {'real_path': self.repository_spec.src}
+                   }
+        return results
+
+    def fetch(self, find_results=None):
+        find_results = find_results or {}
+
+        real_path = find_results.get('custom', {}).get('real_path', None)
+        if not real_path:
+            raise exceptions.GalaxyClientError('Error fetching an editable install of %s because no "real_path" was found in find_results',
+                                               self.repository_spec.src, real_path)
+
+        dst_ns_root = os.path.join(self.galaxy_context.content_path, self.repository_spec.namespace)
+        dst_repo_root = os.path.join(dst_ns_root,
+                                     self.repository_spec.name)
+
+        if not os.path.exists(dst_ns_root):
+            os.makedirs(dst_ns_root)
+
+        if not os.path.exists(dst_repo_root):
+            os.symlink(real_path, dst_repo_root)
+
+        repository_archive_path = self.local_path
+
+        log.debug('repository_archive_path=%s (inplace) synlink to %s',
+                  repository_archive_path,
+                  real_path)
+
+        results = {'archive_path': repository_archive_path,
+                   'fetch_method': self.fetch_method}
+
+        results['custom'] = {'local_path': self.local_path,
+                             'real_path': real_path}
+        results['content'] = find_results['content']
+
+        return results
+
+    def cleanup(self):
+        return None

--- a/ansible_galaxy/fetch/fetch_factory.py
+++ b/ansible_galaxy/fetch/fetch_factory.py
@@ -6,6 +6,7 @@ from ansible_galaxy.fetch import galaxy_url
 from ansible_galaxy.fetch import local_file
 from ansible_galaxy.fetch import remote_url
 from ansible_galaxy.fetch import scm_url
+from ansible_galaxy.fetch import editable
 
 log = logging.getLogger(__name__)
 
@@ -20,11 +21,14 @@ def get(galaxy_context, repository_spec):
     # does not really imply that the repo archive download should ignore certs as well
     # (galaxy api server vs cdn) but for now, we use the value for both
 
-    log.debug('repository_spec: %s', repository_spec)
+    log.debug('repository_spec: %r', repository_spec)
     log.debug('repository_spec.fetch_method %s dir(fetchMethods): %s',
               repository_spec.fetch_method, dir(FetchMethods))
 
-    if repository_spec.fetch_method == FetchMethods.SCM_URL:
+    if repository_spec.fetch_method == FetchMethods.EDITABLE:
+        fetcher = editable.EditableFetch(repository_spec=repository_spec,
+                                         galaxy_context=galaxy_context)
+    elif repository_spec.fetch_method == FetchMethods.SCM_URL:
         fetcher = scm_url.ScmUrlFetch(repository_spec=repository_spec)
     elif repository_spec.fetch_method == FetchMethods.LOCAL_FILE:
         # the file is a tar, so open it that way and extract it

--- a/ansible_galaxy/install.py
+++ b/ansible_galaxy/install.py
@@ -1,6 +1,5 @@
 # strategy for installing a Collection (name resolve it, find it,
 #  fetch it's artifact, validate/verify it, install/extract it, update install dbs, etc)
-# import datetime
 import logging
 import os
 
@@ -10,8 +9,9 @@ import pprint
 from ansible_galaxy import repository_archive
 from ansible_galaxy import exceptions
 from ansible_galaxy import installed_repository_db
-from ansible_galaxy.models.install_destination import InstallDestinationInfo
 from ansible_galaxy.fetch import fetch_factory
+from ansible_galaxy.models.install_destination import InstallDestinationInfo
+from ansible_galaxy.repository_spec import FetchMethods
 
 log = logging.getLogger(__name__)
 
@@ -141,7 +141,7 @@ def install(galaxy_context,
 
     # TODO: this is figuring out the archive type (multi-content collection or a trad role)
     #       could potentially pull this up a layer
-    repo_archive_ = repository_archive.load_archive(archive_path)
+    repo_archive_ = repository_archive.load_archive(archive_path, repository_spec)
 
     log.debug('repo_archive_: %s', repo_archive_)
     log.debug('repo_archive_.info: %s', repo_archive_.info)
@@ -169,12 +169,15 @@ def install(galaxy_context,
                                           namespaced_repository_path,
                                           repo_archive_.repository_dest_root_subpath(repository_spec.name))
 
+    editable = repository_spec.fetch_method == FetchMethods.EDITABLE
+
     destination_info = InstallDestinationInfo(destination_root_dir=galaxy_context.content_path,
                                               repository_spec=repository_spec,
                                               extract_archive_to_dir=extract_archive_to_dir,
                                               namespaced_repository_path=namespaced_repository_path,
                                               install_info_path=install_info_path,
-                                              force_overwrite=force_overwrite)
+                                              force_overwrite=force_overwrite,
+                                              editable=editable)
 
     # A list of InstallationResults
     res = repository_archive.install(repo_archive_,

--- a/ansible_galaxy/install_info.py
+++ b/ansible_galaxy/install_info.py
@@ -42,7 +42,8 @@ def load_from_filename(filename):
 
 
 def save(install_info_dict, filename):
-    log.debug('saving install info to %s', filename)
+    # log.debug('saving install info to %s', filename)
+
     if not os.path.exists(os.path.dirname(filename)):
         os.makedirs(os.path.dirname(filename))
 

--- a/ansible_galaxy/models/install_destination.py
+++ b/ansible_galaxy/models/install_destination.py
@@ -29,6 +29,8 @@ class InstallDestinationInfo(object):
 
     force_overwrite = attr.ib(default=False)
 
+    editable = attr.ib(default=False)
+
     @property
     def path(self):
         '''The full path to the eventually installed repository

--- a/ansible_galaxy/models/install_info.py
+++ b/ansible_galaxy/models/install_info.py
@@ -28,8 +28,13 @@ class InstallInfo(object):
     def to_dict_version_strings(self):
         data = attr.asdict(self)
 
+        if data.get('verison', '') is None:
+            del data['version']
+
         # semver.VersionInfo isnt yaml-able, so build a dict with
         # the VersionInfo replaced with a str version
-        data['version'] = str(data['version'])
+        ver = data.get('version', '')
+        if ver:
+            data['version'] = str(ver)
 
         return data

--- a/ansible_galaxy/repository.py
+++ b/ansible_galaxy/repository.py
@@ -60,12 +60,35 @@ def load_from_dir(content_dir, namespace, name, installed=True):
     galaxy_filename = os.path.join(path_name, collection_info.COLLECTION_INFO_FILENAME)
 
     collection_info_data = None
+
     try:
         with open(galaxy_filename, 'r') as gfd:
             collection_info_data = collection_info.load(gfd)
     except EnvironmentError:
         # log.debug('No galaxy.yml collection info found for collection %s.%s: %s', namespace, name, e)
         pass
+
+    # Now try the repository as a role-as-collection
+    # FIXME: For a repository with one role that matches the collection name and doesn't
+    #        have a galaxy.yml, that's indistinguishable from a role-as-collection
+    # FIXME: But in theory, if there is more than one role in roles/, we should skip this
+    role_meta_main_filename = os.path.join(path_name, 'roles', name, 'meta', 'main.yml')
+    role_meta_main = None
+    role_name = '%s.%s' % (namespace, name)
+
+    try:
+        with open(role_meta_main_filename, 'r') as rmfd:
+            role_meta_main = role_metadata.load(rmfd, role_name=role_name)
+    except EnvironmentError:
+        # log.debug('No meta/main.yml was loaded for repository %s.%s: %s', namespace, name, e)
+        pass
+
+    # Prefer version from install_info, but for a editable installed, there may be only galaxy version
+    installed_version = install_info_version
+    if collection_info_data:
+        installed_version = installed_version or collection_info_data.version
+    # if role_meta_main:
+    #    installed_version = installed_version or role_meta_main.version
 
     # TODO/FIXME: what takes precedence?
     #           - the dir names a collection lives in ~/.ansible/content/my_ns/my_name
@@ -76,7 +99,7 @@ def load_from_dir(content_dir, namespace, name, installed=True):
     # that need to know what requires something
     repository_spec = RepositorySpec(namespace=namespace,
                                      name=name,
-                                     version=install_info_version)
+                                     version=installed_version)
 
     # The current galaxy.yml 'dependencies' are actually 'requirements' in ansible/ansible terminology
     # (ie, install-time)
@@ -99,21 +122,6 @@ def load_from_dir(content_dir, namespace, name, installed=True):
         # log.debug('No requirements.yml was loaded for repository %s.%s: %s', namespace, name, e)
         pass
 
-    # Now try the repository as a role-as-collection
-    # FIXME: For a repository with one role that matches the collection name and doesn't
-    #        have a galaxy.yml, that's indistinguishable from a role-as-collection
-    # FIXME: But in theory, if there is more than one role in roles/, we should skip this
-    role_meta_main_filename = os.path.join(path_name, 'roles', name, 'meta', 'main.yml')
-    role_meta_main = None
-    role_name = '%s.%s' % (namespace, name)
-
-    try:
-        with open(role_meta_main_filename, 'r') as rmfd:
-            role_meta_main = role_metadata.load(rmfd, role_name=role_name)
-    except EnvironmentError:
-        # log.debug('No meta/main.yml was loaded for repository %s.%s: %s', namespace, name, e)
-        pass
-
     # TODO: if there are other places to load dependencies (ie, runtime deps) we will need
     #       to load them and combine them with role_depenency_specs
     role_dependency_specs = []
@@ -133,6 +141,15 @@ def load_from_dir(content_dir, namespace, name, installed=True):
 
 def remove(installed_repository):
     log.info("Removing installed repository: %s", installed_repository)
+
+    # editable installs are symlinks
+    if os.path.islink(installed_repository.path):
+        log.info('Removing the symlink at %s to %s',
+                 installed_repository.path,
+                 os.readlink(installed_repository.path))
+        os.unlink(installed_repository.path)
+        return True
+
     try:
         shutil.rmtree(installed_repository.path)
         return True

--- a/ansible_galaxy/repository_spec.py
+++ b/ansible_galaxy/repository_spec.py
@@ -79,6 +79,17 @@ def resolve(data):
     return data
 
 
+def editable_resolve(data):
+    log.debug('data: %s', data)
+
+    src = data['src']
+    if src.startswith('/'):
+        dir_name = os.path.basename(os.path.normpath(src))
+        log.debug('dir_name: %s', dir_name)
+        data['name'] = dir_name
+    return data
+
+
 def spec_data_from_string(repository_spec_string, namespace_override=None, editable=False):
     fetch_method = chose_repository_fetch_method(repository_spec_string, editable=editable)
 
@@ -92,6 +103,9 @@ def spec_data_from_string(repository_spec_string, namespace_override=None, edita
     resolver = resolve
     if fetch_method == FetchMethods.GALAXY_URL:
         resolver = galaxy_repository_spec.resolve
+
+    if fetch_method == FetchMethods.EDITABLE:
+        resolver = editable_resolve
 
     resolved_name = resolver(spec_data)
     log.debug('resolved_name: %s', resolved_name)
@@ -113,7 +127,7 @@ def spec_data_from_string(repository_spec_string, namespace_override=None, edita
 
 
 def repository_spec_from_string(repository_spec_string, namespace_override=None, editable=False):
-    spec_data = spec_data_from_string(repository_spec_string, namespace_override=None, editable=editable)
+    spec_data = spec_data_from_string(repository_spec_string, namespace_override=namespace_override, editable=editable)
 
     log.debug('spec_data: %s', spec_data)
 

--- a/ansible_galaxy/utils/version.py
+++ b/ansible_galaxy/utils/version.py
@@ -12,7 +12,7 @@ VERSION_WITH_LEADING_V_SUB_RE = re.compile(r'(^[vV])')
 def convert_string_to_semver(version):
     # log.debug('vs: %s type: %s', version, type(version))
 
-    if not version:
+    if version is None:
         return None
 
     if isinstance(version, semver.VersionInfo):

--- a/tests/ansible_galaxy/test_repository_spec.py
+++ b/tests/ansible_galaxy/test_repository_spec.py
@@ -67,9 +67,18 @@ def test_repository_spec_from_string(repository_spec_case):
 
 def test_repository_spec_editable():
     tmpdir = tempfile.mkdtemp()
-    result = repository_spec.repository_spec_from_string(tmpdir, editable=True)
+    expected = os.path.basename(tmpdir)
+    log.debug('expected: %s', expected)
+
+    result = repository_spec.repository_spec_from_string(tmpdir, namespace_override='my_namespace', editable=True)
     os.rmdir(tmpdir)
-    assert result.name == tmpdir
+
+    log.debug('result: %r', result)
+
+    assert result.name == expected
+    assert result.namespace == 'my_namespace'
+    assert result.version is None
+    assert result.src == tmpdir
     assert result.fetch_method == 'EDITABLE'
 
 


### PR DESCRIPTION
##### SUMMARY
After the changes to get the dep solving working, 'install -e' was busted.

Get 'install -e' working with deps
    
Add an 'editable' fetch method.
    
Some shenanigans to avoid writing 'None' versions
in install_info (which causes semver issues)
    
Split up repo_archive stuff so that we can skip
the extract() step.
    
Change repo archive type detection to take a list of
files instead of tarfile members, since editable repos
are just dirs (we need to know the repo role/collection
type before extracting it...)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.2.1
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.12-100.fc27.x86_64, #1 SMP Thu Oct 4 16:22:17 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py27/bin/mazer
python_version = 2.7.15 (default, Oct 15 2018, 18:36:25) [GCC 7.3.1 20180712 (Red Hat 7.3.1-6)]
python_executable = /home/adrian/venvs/galaxy-cli-py27/bin/python


```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

