### PR TITLE
Add info about editable mode to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,23 +108,26 @@ This will install the geerlingguy.nginx role to ~/my-ansible-content/geerlingguy
 ### Installing collections in 'editable' mode for development
 
 To enable development of collections, it is possible to install a
-local checkout of a collection in 'editable' mode. Instead of
-copying a collection into ~/.ansible/content, this mode will
+local checkout of a collection in 'editable' mode.
+
+Instead of copying a collection into ~/.ansible/content, this mode will
 create a symlink from ~/.ansible/content/my_namespace/my_colllection
-to a dir where the under development collection lives.
+to the directory where the collection being worked on lives.
 
 ie, if ~/src/collections/my_new_collection is being worked on, to install
-it in editable mode under the namespace 'my_namespace' :
+the collection in editable mode under the namespace 'my_namespace':
 
 ```
 $ mazer install --namespace my_namespace --editable ~/src/collections/my_new_collection
 ```
 
-The above command will symlink ~/.ansble/content/my_namespace/my_new_collection ->
+This will result in 'my_namespace.my_new_collection' being "installed".
+The above command symlinks ~/.ansble/content/my_namespace/my_new_collection to
 ~/src/collections/my_new_collection.
 
-The install option '--editable' or the short '-e' can be used.
-Note that '--namespace' option is required.
+The install option **'--editable'** or the short **'-e'** can be used.
+
+Note that **'--namespace'** option is required.
 
 
 ### Using mazer installed roles in a playbook (requires 'mazer_role_loader' ansible branch)

--- a/README.md
+++ b/README.md
@@ -107,6 +107,25 @@ This will install the geerlingguy.nginx role to ~/my-ansible-content/geerlingguy
 
 ### Installing collections in 'editable' mode for development
 
+To enable development of collections, it is possible to install a
+local checkout of a collection in 'editable' mode. Instead of
+copying a collection into ~/.ansible/content, this mode will
+create a symlink from ~/.ansible/content/my_namespace/my_colllection
+to a dir where the under development collection lives.
+
+ie, if ~/src/collections/my_new_collection is being worked on, to install
+it in editable mode under the namespace 'my_namespace' :
+
+```
+$ mazer install --namespace my_namespace --editable ~/src/collections/my_new_collection
+```
+
+The above command will symlink ~/.ansble/content/my_namespace/my_new_collection ->
+~/src/collections/my_new_collection.
+
+The install option '--editable' or the short '-e' can be used.
+Note that '--namespace' option is required.
+
 
 ### Using mazer installed roles in a playbook (requires 'mazer_role_loader' ansible branch)
 


### PR DESCRIPTION

### Installing collections in 'editable' mode for development

To enable development of collections, it is possible to install a
local checkout of a collection in 'editable' mode. Instead of
copying a collection into _~/.ansible/content_, this mode will
create a symlink from _~/.ansible/content/my_namespace/my_colllection_
to a dir where the under development collection lives.

ie, if _~/src/collections/my_new_collection_ is being worked on, to install
it in editable mode under the namespace 'my_namespace' :

```
$ mazer install --namespace my_namespace --editable _~/src/collections/my_new_collection_
```

The above command will symlink _~/.ansble/content/my_namespace/my_new_collection_ ->
_~/src/collections/my_new_collection._

The install option '--editable' or the short '-e' can be used.
Note that '--namespace' option is required.




##### ISSUE TYPE
 - Docs Pull Request



