### PR TITLE
Remove unused ScmFileWalker

### DIFF
--- a/ansible_galaxy/collection_members.py
+++ b/ansible_galaxy/collection_members.py
@@ -5,10 +5,6 @@ import pprint
 
 import attr
 
-# not surprisingly, setuptools_scm needs very similar file finder utils
-import setuptools_scm
-import setuptools_scm.file_finder_git
-
 log = logging.getLogger(__name__)
 
 # dirtools defaults to .git/.hg/.svn, but we need to extend that set
@@ -31,20 +27,6 @@ class CollectionMember(object):
     '''The info need to add a file to a archive (orig path, dest path, etc)'''
     src_full_path = attr.ib()
     dest_relative_path = attr.ib()
-
-
-@attr.s
-class ScmFilesWalker(object):
-    collection_path = attr.ib()
-
-    def walk(self):
-        '''recursively find members under collection_path and return a list'''
-        # just the files from scm, though this will need to change if/when we support
-        # binary modules or other 'compiled' content
-        scm_files = setuptools_scm.file_finder_git.git_find_files(self.collection_path)
-
-        for full_filename in scm_files:
-            yield full_filename
 
 
 @attr.s

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,6 @@ requirements = ['six',
                 'jinja2',
                 'semver',
                 'yamlloader',
-                # for some utils for finding right files to include from a git repo
-                'setuptools_scm',
                 # used for data classes
                 # 18.1.0 introduces the 'factory' keyword
                 'attrs>=18.1.0',

--- a/tests/ansible_galaxy/test_collection_members.py
+++ b/tests/ansible_galaxy/test_collection_members.py
@@ -12,27 +12,6 @@ pf = pprint.pformat
 hello_path = os.path.join(os.path.dirname(__file__), 'collection_examples', 'hello')
 
 
-def test_scm_walker():
-    scm_walker = collection_members.ScmFilesWalker(os.getcwd())
-
-    log.debug('scm_walker: %s', scm_walker)
-
-    members = sorted(list(scm_walker.walk()))
-
-    log.debug('members: %s', pf(members))
-
-    found_setup_py = False
-    found_install_info = False
-    for member in members:
-        if member.endswith('setup.py'):
-            found_setup_py = True
-        if member.endswith('ansible_galaxy/install_info.py'):
-            found_install_info = True
-
-    assert found_setup_py, "no setup.py found in results from walk. members: %s" % pf(members)
-    assert found_install_info, "no ansible_galaxy/install_info.py found in results from walk. members: %s" % pf(members)
-
-
 def test_file_walker_cwd():
     cwd = os.getcwd()
     git_dir = os.path.join(cwd, '.git/')
@@ -67,8 +46,8 @@ def test_file_walker_rel_path():
 def test_collection_members_init():
     # gather files from mazer src dir, not really a role
     collection_path = os.path.join(os.getcwd())
-    scm_walker = collection_members.ScmFilesWalker(collection_path)
-    coll_members = collection_members.CollectionMembers(walker=scm_walker)
+    file_walker = collection_members.FileWalker(collection_path)
+    coll_members = collection_members.CollectionMembers(walker=file_walker)
     log.debug('coll_members: %s', coll_members)
 
     members = coll_members.run()


### PR DESCRIPTION
##### SUMMARY

Remove unused ScmFileWalker
And remove the requirement on
setuptools_scm


<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.2.1
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.12-100.fc27.x86_64, #1 SMP Thu Oct 4 16:22:17 UTC 2018, x86_64
executable_location = /home/adrian/venvs/mazer-py3-0-3-1/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/mazer-py3-0-3-1/bin/python3.6

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

