### PR TITLE
Updating remaning log.warn() use to log.warning()

### DIFF
--- a/ansible_galaxy/actions/install.py
+++ b/ansible_galaxy/actions/install.py
@@ -409,8 +409,8 @@ def stuff_for_updating(content, display_callback, force_overwrite=False):
                     content.remove()
                 else:
                     # eventually need to build a results object here
-                    log.warn('- %s (%s) is already installed - use --force to change version to %s',
-                             content.name, content.install_info['version'], content.version or "unspecified")
+                    log.warning('- %s (%s) is already installed - use --force to change version to %s',
+                                content.name, content.install_info['version'], content.version or "unspecified")
                     # continue
                     return None
             else:

--- a/ansible_galaxy/config/config_file.py
+++ b/ansible_galaxy/config/config_file.py
@@ -20,7 +20,7 @@ def load(full_file_path):
         # TODO: add a py2/py3 compat raise_from method for exception chaining
         raise exceptions.GalaxyConfigFileError(e, config_file_path=full_file_path)
 
-    log.warn('No config data was loaded from file (%s), returning None instead', full_file_path)
+    log.warning('No config data was loaded from file (%s), returning None instead', full_file_path)
     # TODO: empty dict instead?
     return None
 

--- a/ansible_galaxy/fetch/base.py
+++ b/ansible_galaxy/fetch/base.py
@@ -31,4 +31,4 @@ class BaseFetch(object):
         try:
             os.unlink(self.local_path)
         except (OSError, IOError) as e:
-            log.warn('Unable to remove tmp file (%s): %s' % (self.local_path, str(e)))
+            log.warning('Unable to remove tmp file (%s): %s' % (self.local_path, str(e)))

--- a/ansible_galaxy/install_info.py
+++ b/ansible_galaxy/install_info.py
@@ -53,7 +53,7 @@ def save(install_info_dict, filename):
         try:
             yaml.safe_dump(install_info_dict, f, default_flow_style=False)
         except Exception as e:
-            log.warn('unable to serialize .galaxy_install_info to filename=%s for data=%s', filename, install_info_dict)
+            log.warning('unable to serialize .galaxy_install_info to filename=%s for data=%s', filename, install_info_dict)
             log.exception(e)
             return False
 

--- a/ansible_galaxy/installed_namespaces_db.py
+++ b/ansible_galaxy/installed_namespaces_db.py
@@ -20,8 +20,8 @@ def get_namespace_paths(content_path):
         namespace_paths = os.listdir(content_path)
     except OSError as e:
         log.exception(e)
-        log.warn('The content path %s did not exist so no content or repositories were found.',
-                 content_path)
+        log.warning('The content path %s did not exist so no content or repositories were found.',
+                    content_path)
         namespace_paths = []
 
     return namespace_paths

--- a/ansible_galaxy/installed_repository_db.py
+++ b/ansible_galaxy/installed_repository_db.py
@@ -22,8 +22,8 @@ def get_repository_paths(namespace_path):
         repository_paths = os.listdir(namespace_path)
     except OSError as e:
         log.exception(e)
-        log.warn('The namespace path %s did not exist so no repositories were found.',
-                 namespace_path)
+        log.warning('The namespace path %s did not exist so no repositories were found.',
+                    namespace_path)
         repository_paths = []
 
     return repository_paths

--- a/ansible_galaxy/repository.py
+++ b/ansible_galaxy/repository.py
@@ -154,9 +154,9 @@ def remove(installed_repository):
         shutil.rmtree(installed_repository.path)
         return True
     except EnvironmentError as e:
-        log.warn('Unable to rm the directory "%s" while removing installed repo "%s": %s',
-                 installed_repository.path,
-                 installed_repository.label,
-                 e)
+        log.warning('Unable to rm the directory "%s" while removing installed repo "%s": %s',
+                    installed_repository.path,
+                    installed_repository.label,
+                    e)
         log.exception(e)
         raise

--- a/ansible_galaxy/utils/version.py
+++ b/ansible_galaxy/utils/version.py
@@ -41,7 +41,7 @@ def normalize_version_string(version_string):
 
     new_versions_string = VERSION_WITH_LEADING_V_SUB_RE.sub('', version_string, 1)
 
-    log.warn('Stripping leading "v" or "V" from version string "%s", new version string is  "%s"',
-             version_string, new_versions_string)
+    log.warning('Stripping leading "v" or "V" from version string "%s", new version string is  "%s"',
+                version_string, new_versions_string)
 
     return new_versions_string

--- a/ansible_galaxy/yaml_persist.py
+++ b/ansible_galaxy/yaml_persist.py
@@ -33,7 +33,7 @@ def save(data, filename):
         try:
             install_info_ = yaml.safe_dump(attr.asdict(data), f, default_flow_style=False)
         except Exception as e:
-            log.warn('unable to serialize data to filename=%s for data=%s', filename, install_info_)
+            log.warning('unable to serialize data to filename=%s for data=%s', filename, install_info_)
             log.exception(e)
             return False
 


### PR DESCRIPTION
##### SUMMARY
Updating remaning log.warn() use to log.warning()

Avoid potential "DeprecationWarning: The 'warn' method
is deprecated, use 'warning' instead" warnings.

Because there is nothing as useful as showing an
additional and pointless warning when you are trying
to show a hopefully useful warning.


<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.3.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.12-100.fc27.x86_64, #1 SMP Thu Oct 4 16:22:17 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3-2/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3-2/bin/python


```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

