### PR TITLE
Stop shadowing builtin 'attr' in arg

### DIFF
--- a/ansible_galaxy/build.py
+++ b/ansible_galaxy/build.py
@@ -68,9 +68,9 @@ class BuildResult(object):
 # is a CollectionMember/CollectionMembers object needed? CollectionFileWalker?
 
 
-def filter_artifact_file_name(attr, value):
+def filter_artifact_file_name(attribute, _value):
     '''Used by attr.asdict to remove the src_name attr when serializing'''
-    if attr.name == 'src_name':
+    if attribute.name == 'src_name':
         return False
     return True
 


### PR DESCRIPTION
##### SUMMARY

in ansible_galaxy.build.filter_artifact_file_name().
Also change 'value' arg to '_value' to avoid
unused arg warnings (method is a callback passed
to attrs.asdict())

Pylint clean ups.


<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

