### PR TITLE
Stop shadowing mod scope 'fetcher' in ag.install

### DIFF
--- a/ansible_galaxy/actions/install.py
+++ b/ansible_galaxy/actions/install.py
@@ -7,6 +7,7 @@ from ansible_galaxy import install
 from ansible_galaxy import installed_repository_db
 from ansible_galaxy import matchers
 from ansible_galaxy import requirements
+from ansible_galaxy.fetch import fetch_factory
 
 log = logging.getLogger(__name__)
 
@@ -301,7 +302,9 @@ def install_repository(galaxy_context,
 
         return None
 
-    fetcher = install.fetcher(galaxy_context, repository_spec=repository_spec_to_install)
+    fetcher = fetch_factory.get(galaxy_context=galaxy_context,
+                                repository_spec=repository_spec_to_install)
+
     # if we fail to get a fetcher here, then to... FIND_FETCHER_FAILURE ?
     # could also move some of the logic in fetcher_factory to be driven from here
     # and make the steps of mapping repository spec -> fetcher method part of the

--- a/ansible_galaxy/fetch/fetch_factory.py
+++ b/ansible_galaxy/fetch/fetch_factory.py
@@ -21,10 +21,6 @@ def get(galaxy_context, repository_spec):
     # does not really imply that the repo archive download should ignore certs as well
     # (galaxy api server vs cdn) but for now, we use the value for both
 
-    log.debug('repository_spec: %r', repository_spec)
-    log.debug('repository_spec.fetch_method %s dir(fetchMethods): %s',
-              repository_spec.fetch_method, dir(FetchMethods))
-
     if repository_spec.fetch_method == FetchMethods.EDITABLE:
         fetcher = editable.EditableFetch(repository_spec=repository_spec,
                                          galaxy_context=galaxy_context)
@@ -43,4 +39,7 @@ def get(galaxy_context, repository_spec):
     else:
         raise exceptions.GalaxyError('No approriate content fetcher found for %s %s',
                                      repository_spec.scm, repository_spec.src)
+
+    log.debug('Using fetcher: %s for repository_spec: %r', fetcher, repository_spec)
+
     return fetcher

--- a/ansible_galaxy/install.py
+++ b/ansible_galaxy/install.py
@@ -2,14 +2,13 @@
 #  fetch it's artifact, validate/verify it, install/extract it, update install dbs, etc)
 import logging
 import os
+import pprint
 
 import attr
-import pprint
 
 from ansible_galaxy import repository_archive
 from ansible_galaxy import exceptions
 from ansible_galaxy import installed_repository_db
-from ansible_galaxy.fetch import fetch_factory
 from ansible_galaxy.models.install_destination import InstallDestinationInfo
 from ansible_galaxy.repository_spec import FetchMethods
 
@@ -17,17 +16,6 @@ log = logging.getLogger(__name__)
 
 # This should probably be a state machine for stepping through the install states
 # See actions.install.install_collection for a sketch of the states
-
-
-def fetcher(galaxy_context, repository_spec):
-    log.debug('Attempting to get fetcher for repository_spec=%s', repository_spec)
-
-    fetcher = fetch_factory.get(galaxy_context=galaxy_context,
-                                repository_spec=repository_spec)
-
-    log.debug('Using fetcher: %s for repository_spec: %s', fetcher, repository_spec)
-
-    return fetcher
 
 
 def find(fetcher):


### PR DESCRIPTION
##### SUMMARY

Stop shadowing mod scope 'fetcher' in ag.install

ansible_galaxy.install had an unneeded fetcher() defined
at module scope and then shadowed that in methods and method
args.

Ditch the unneeded fetcher and call fetch_factory direct.


