### PR TITLE
Don't load and parse spdx_license.json everytime a CollectionInfo is created.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,5 +64,9 @@ dev/dist: clean ## builds source and wheel package
 	python setup.py bdist_wheel
 	ls -l dist
 
+dev/spdx-update: ## update the generated ansible_galaxy/data/spdx_licenses.py
+	curl https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json --output data/spdx_licenses.json
+	./spdx_update.py data/spdx_licenses.json > ansible_galaxy/data/spdx_licenses.json ## generate a subset of spdx license info
+
 install: clean ## install the package to the active Python's site-packages
 	python setup.py install

--- a/ansible_galaxy/data/spdx_licenses.json
+++ b/ansible_galaxy/data/spdx_licenses.json
@@ -1091,6 +1091,9 @@
     "bzip2-1.0.6":{
         "deprecated":false
     },
+    "copyleft-next-0.3.0":{
+        "deprecated":false
+    },
     "copyleft-next-0.3.1":{
         "deprecated":false
     },

--- a/ansible_galaxy/data/spdx_licenses.json
+++ b/ansible_galaxy/data/spdx_licenses.json
@@ -1,4730 +1,1145 @@
 {
-  "licenseListVersion": "v3.1-67-geb2589b",
-  "licenses": [
-    {
-      "reference": "./0BSD.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/0BSD.json",
-      "referenceNumber": "1",
-      "name": "BSD Zero Clause License",
-      "licenseId": "0BSD",
-      "seeAlso": [
-        "http://landley.net/toybox/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./AAL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/AAL.json",
-      "referenceNumber": "2",
-      "name": "Attribution Assurance License",
-      "licenseId": "AAL",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/attribution"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./ADSL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/ADSL.json",
-      "referenceNumber": "3",
-      "name": "Amazon Digital Services License",
-      "licenseId": "ADSL",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/AmazonDigitalServicesLicense"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./AFL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/AFL-1.1.json",
-      "referenceNumber": "4",
-      "name": "Academic Free License v1.1",
-      "licenseId": "AFL-1.1",
-      "seeAlso": [
-        "http://opensource.linux-mirror.org/licenses/afl-1.1.txt",
-        "http://wayback.archive.org/web/20021004124254/http://www.opensource.org/licenses/academic.php"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./AFL-1.2.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/AFL-1.2.json",
-      "referenceNumber": "5",
-      "name": "Academic Free License v1.2",
-      "licenseId": "AFL-1.2",
-      "seeAlso": [
-        "http://opensource.linux-mirror.org/licenses/afl-1.2.txt",
-        "http://wayback.archive.org/web/20021204204652/http://www.opensource.org/licenses/academic.php"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./AFL-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/AFL-2.0.json",
-      "referenceNumber": "6",
-      "name": "Academic Free License v2.0",
-      "licenseId": "AFL-2.0",
-      "seeAlso": [
-        "http://wayback.archive.org/web/20060924134533/http://www.opensource.org/licenses/afl-2.0.txt"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./AFL-2.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/AFL-2.1.json",
-      "referenceNumber": "7",
-      "name": "Academic Free License v2.1",
-      "licenseId": "AFL-2.1",
-      "seeAlso": [
-        "http://opensource.linux-mirror.org/licenses/afl-2.1.txt"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./AFL-3.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/AFL-3.0.json",
-      "referenceNumber": "8",
-      "name": "Academic Free License v3.0",
-      "licenseId": "AFL-3.0",
-      "seeAlso": [
-        "http://www.rosenlaw.com/AFL3.0.htm",
-        "http://www.opensource.org/licenses/afl-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./AGPL-1.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/AGPL-1.0-only.json",
-      "referenceNumber": "9",
-      "name": "Affero General Public License v1.0 only",
-      "licenseId": "AGPL-1.0-only",
-      "seeAlso": [
-        "http://www.affero.org/oagpl.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./AGPL-1.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/AGPL-1.0-or-later.json",
-      "referenceNumber": "10",
-      "name": "Affero General Public License v1.0 or later",
-      "licenseId": "AGPL-1.0-or-later",
-      "seeAlso": [
-        "http://www.affero.org/oagpl.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./AGPL-3.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/AGPL-3.0-only.json",
-      "referenceNumber": "11",
-      "name": "GNU Affero General Public License v3.0 only",
-      "licenseId": "AGPL-3.0-only",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/agpl.txt",
-        "http://www.opensource.org/licenses/AGPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./AGPL-3.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/AGPL-3.0-or-later.json",
-      "referenceNumber": "12",
-      "name": "GNU Affero General Public License v3.0 or later",
-      "licenseId": "AGPL-3.0-or-later",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/agpl.txt",
-        "http://www.opensource.org/licenses/AGPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./AMDPLPA.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/AMDPLPA.json",
-      "referenceNumber": "13",
-      "name": "AMD\u0027s plpa_map.c License",
-      "licenseId": "AMDPLPA",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/AMD_plpa_map_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./AML.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/AML.json",
-      "referenceNumber": "14",
-      "name": "Apple MIT License",
-      "licenseId": "AML",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Apple_MIT_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./AMPAS.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/AMPAS.json",
-      "referenceNumber": "15",
-      "name": "Academy of Motion Picture Arts and Sciences BSD",
-      "licenseId": "AMPAS",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/BSD#AMPASBSD"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./ANTLR-PD.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/ANTLR-PD.json",
-      "referenceNumber": "16",
-      "name": "ANTLR Software Rights Notice",
-      "licenseId": "ANTLR-PD",
-      "seeAlso": [
-        "http://www.antlr2.org/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./APAFML.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/APAFML.json",
-      "referenceNumber": "17",
-      "name": "Adobe Postscript AFM License",
-      "licenseId": "APAFML",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/AdobePostscriptAFM"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./APL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/APL-1.0.json",
-      "referenceNumber": "18",
-      "name": "Adaptive Public License 1.0",
-      "licenseId": "APL-1.0",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/APL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./APSL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/APSL-1.0.json",
-      "referenceNumber": "19",
-      "name": "Apple Public Source License 1.0",
-      "licenseId": "APSL-1.0",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Apple_Public_Source_License_1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./APSL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/APSL-1.1.json",
-      "referenceNumber": "20",
-      "name": "Apple Public Source License 1.1",
-      "licenseId": "APSL-1.1",
-      "seeAlso": [
-        "http://www.opensource.apple.com/source/IOSerialFamily/IOSerialFamily-7/APPLE_LICENSE"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./APSL-1.2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/APSL-1.2.json",
-      "referenceNumber": "21",
-      "name": "Apple Public Source License 1.2",
-      "licenseId": "APSL-1.2",
-      "seeAlso": [
-        "http://www.samurajdata.se/opensource/mirror/licenses/apsl.php"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./APSL-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/APSL-2.0.json",
-      "referenceNumber": "22",
-      "name": "Apple Public Source License 2.0",
-      "licenseId": "APSL-2.0",
-      "seeAlso": [
-        "http://www.opensource.apple.com/license/apsl/"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Abstyles.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Abstyles.json",
-      "referenceNumber": "23",
-      "name": "Abstyles License",
-      "licenseId": "Abstyles",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Abstyles"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Adobe-2006.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Adobe-2006.json",
-      "referenceNumber": "24",
-      "name": "Adobe Systems Incorporated Source Code License Agreement",
-      "licenseId": "Adobe-2006",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/AdobeLicense"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Adobe-Glyph.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Adobe-Glyph.json",
-      "referenceNumber": "25",
-      "name": "Adobe Glyph List License",
-      "licenseId": "Adobe-Glyph",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MIT#AdobeGlyph"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Afmparse.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Afmparse.json",
-      "referenceNumber": "26",
-      "name": "Afmparse License",
-      "licenseId": "Afmparse",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Afmparse"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Aladdin.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Aladdin.json",
-      "referenceNumber": "27",
-      "name": "Aladdin Free Public License",
-      "licenseId": "Aladdin",
-      "seeAlso": [
-        "http://pages.cs.wisc.edu/~ghost/doc/AFPL/6.01/Public.htm"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Apache-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Apache-1.0.json",
-      "referenceNumber": "28",
-      "name": "Apache License 1.0",
-      "licenseId": "Apache-1.0",
-      "seeAlso": [
-        "http://www.apache.org/licenses/LICENSE-1.0"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Apache-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Apache-1.1.json",
-      "referenceNumber": "29",
-      "name": "Apache License 1.1",
-      "licenseId": "Apache-1.1",
-      "seeAlso": [
-        "http://apache.org/licenses/LICENSE-1.1",
-        "http://opensource.org/licenses/Apache-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Apache-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Apache-2.0.json",
-      "referenceNumber": "30",
-      "name": "Apache License 2.0",
-      "licenseId": "Apache-2.0",
-      "seeAlso": [
-        "http://www.apache.org/licenses/LICENSE-2.0",
-        "http://www.opensource.org/licenses/Apache-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Artistic-1.0-Perl.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Artistic-1.0-Perl.json",
-      "referenceNumber": "31",
-      "name": "Artistic License 1.0 (Perl)",
-      "licenseId": "Artistic-1.0-Perl",
-      "seeAlso": [
-        "http://dev.perl.org/licenses/artistic.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Artistic-1.0-cl8.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Artistic-1.0-cl8.json",
-      "referenceNumber": "32",
-      "name": "Artistic License 1.0 w/clause 8",
-      "licenseId": "Artistic-1.0-cl8",
-      "seeAlso": [
-        "http://opensource.org/licenses/Artistic-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Artistic-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Artistic-1.0.json",
-      "referenceNumber": "33",
-      "name": "Artistic License 1.0",
-      "licenseId": "Artistic-1.0",
-      "seeAlso": [
-        "http://opensource.org/licenses/Artistic-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Artistic-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Artistic-2.0.json",
-      "referenceNumber": "34",
-      "name": "Artistic License 2.0",
-      "licenseId": "Artistic-2.0",
-      "seeAlso": [
-        "http://www.perlfoundation.org/artistic_license_2_0",
-        "http://www.opensource.org/licenses/artistic-license-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./BSD-1-Clause.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-1-Clause.json",
-      "referenceNumber": "35",
-      "name": "BSD 1-Clause License",
-      "licenseId": "BSD-1-Clause",
-      "seeAlso": [
-        "https://svnweb.freebsd.org/base/head/include/ifaddrs.h?revision\u003d326823"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BSD-2-Clause-FreeBSD.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-FreeBSD.json",
-      "referenceNumber": "36",
-      "name": "BSD 2-Clause FreeBSD License",
-      "licenseId": "BSD-2-Clause-FreeBSD",
-      "seeAlso": [
-        "http://www.freebsd.org/copyright/freebsd-license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BSD-2-Clause-NetBSD.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-NetBSD.json",
-      "referenceNumber": "37",
-      "name": "BSD 2-Clause NetBSD License",
-      "licenseId": "BSD-2-Clause-NetBSD",
-      "seeAlso": [
-        "http://www.netbsd.org/about/redistribution.html#default"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BSD-2-Clause-Patent.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-Patent.json",
-      "referenceNumber": "38",
-      "name": "BSD-2-Clause Plus Patent License",
-      "licenseId": "BSD-2-Clause-Patent",
-      "seeAlso": [
-        "https://opensource.org/licenses/BSDplusPatent"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./BSD-2-Clause.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause.json",
-      "referenceNumber": "39",
-      "name": "BSD 2-Clause \"Simplified\" License",
-      "licenseId": "BSD-2-Clause",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/BSD-2-Clause"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./BSD-3-Clause-Attribution.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-Attribution.json",
-      "referenceNumber": "40",
-      "name": "BSD with attribution",
-      "licenseId": "BSD-3-Clause-Attribution",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/BSD_with_Attribution"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BSD-3-Clause-Clear.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-Clear.json",
-      "referenceNumber": "41",
-      "name": "BSD 3-Clause Clear License",
-      "licenseId": "BSD-3-Clause-Clear",
-      "seeAlso": [
-        "http://labs.metacarta.com/license-explanation.html#license"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BSD-3-Clause-LBNL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-LBNL.json",
-      "referenceNumber": "42",
-      "name": "Lawrence Berkeley National Labs BSD variant license",
-      "licenseId": "BSD-3-Clause-LBNL",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/LBNLBSD"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BSD-3-Clause-No-Nuclear-License-2014.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.json",
-      "referenceNumber": "43",
-      "name": "BSD 3-Clause No Nuclear License 2014",
-      "licenseId": "BSD-3-Clause-No-Nuclear-License-2014",
-      "seeAlso": [
-        "https://java.net/projects/javaeetutorial/pages/BerkeleyLicense"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BSD-3-Clause-No-Nuclear-License.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.json",
-      "referenceNumber": "44",
-      "name": "BSD 3-Clause No Nuclear License",
-      "licenseId": "BSD-3-Clause-No-Nuclear-License",
-      "seeAlso": [
-        "http://download.oracle.com/otn-pub/java/licenses/bsd.txt?AuthParam\u003d1467140197_43d516ce1776bd08a58235a7785be1cc"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BSD-3-Clause-No-Nuclear-Warranty.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.json",
-      "referenceNumber": "45",
-      "name": "BSD 3-Clause No Nuclear Warranty",
-      "licenseId": "BSD-3-Clause-No-Nuclear-Warranty",
-      "seeAlso": [
-        "https://jogamp.org/git/?p\u003dgluegen.git;a\u003dblob_plain;f\u003dLICENSE.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BSD-3-Clause.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause.json",
-      "referenceNumber": "46",
-      "name": "BSD 3-Clause \"New\" or \"Revised\" License",
-      "licenseId": "BSD-3-Clause",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/BSD-3-Clause"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./BSD-4-Clause-UC.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-4-Clause-UC.json",
-      "referenceNumber": "47",
-      "name": "BSD-4-Clause (University of California-Specific)",
-      "licenseId": "BSD-4-Clause-UC",
-      "seeAlso": [
-        "http://www.freebsd.org/copyright/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BSD-4-Clause.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/BSD-4-Clause.json",
-      "referenceNumber": "48",
-      "name": "BSD 4-Clause \"Original\" or \"Old\" License",
-      "licenseId": "BSD-4-Clause",
-      "seeAlso": [
-        "http://directory.fsf.org/wiki/License:BSD_4Clause"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BSD-Protection.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-Protection.json",
-      "referenceNumber": "49",
-      "name": "BSD Protection License",
-      "licenseId": "BSD-Protection",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/BSD_Protection_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BSD-Source-Code.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-Source-Code.json",
-      "referenceNumber": "50",
-      "name": "BSD Source Code Attribution",
-      "licenseId": "BSD-Source-Code",
-      "seeAlso": [
-        "https://github.com/robbiehanson/CocoaHTTPServer/blob/master/LICENSE.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BSL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/BSL-1.0.json",
-      "referenceNumber": "51",
-      "name": "Boost Software License 1.0",
-      "licenseId": "BSL-1.0",
-      "seeAlso": [
-        "http://www.boost.org/LICENSE_1_0.txt",
-        "http://www.opensource.org/licenses/BSL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Bahyph.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Bahyph.json",
-      "referenceNumber": "52",
-      "name": "Bahyph License",
-      "licenseId": "Bahyph",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Bahyph"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Barr.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Barr.json",
-      "referenceNumber": "53",
-      "name": "Barr License",
-      "licenseId": "Barr",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Barr"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Beerware.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Beerware.json",
-      "referenceNumber": "54",
-      "name": "Beerware License",
-      "licenseId": "Beerware",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Beerware",
-        "https://people.freebsd.org/~phk/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BitTorrent-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BitTorrent-1.0.json",
-      "referenceNumber": "55",
-      "name": "BitTorrent Open Source License v1.0",
-      "licenseId": "BitTorrent-1.0",
-      "seeAlso": [
-        "http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/licenses/BitTorrent?r1\u003d1.1\u0026r2\u003d1.1.1.1\u0026diff_format\u003ds"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BitTorrent-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/BitTorrent-1.1.json",
-      "referenceNumber": "56",
-      "name": "BitTorrent Open Source License v1.1",
-      "licenseId": "BitTorrent-1.1",
-      "seeAlso": [
-        "http://directory.fsf.org/wiki/License:BitTorrentOSL1.1"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Borceux.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Borceux.json",
-      "referenceNumber": "57",
-      "name": "Borceux license",
-      "licenseId": "Borceux",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Borceux"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CATOSL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CATOSL-1.1.json",
-      "referenceNumber": "58",
-      "name": "Computer Associates Trusted Open Source License 1.1",
-      "licenseId": "CATOSL-1.1",
-      "seeAlso": [
-        "http://opensource.org/licenses/CATOSL-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./CC-BY-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-1.0.json",
-      "referenceNumber": "59",
-      "name": "Creative Commons Attribution 1.0 Generic",
-      "licenseId": "CC-BY-1.0",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by/1.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-2.0.json",
-      "referenceNumber": "60",
-      "name": "Creative Commons Attribution 2.0 Generic",
-      "licenseId": "CC-BY-2.0",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by/2.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-2.5.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-2.5.json",
-      "referenceNumber": "61",
-      "name": "Creative Commons Attribution 2.5 Generic",
-      "licenseId": "CC-BY-2.5",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by/2.5/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-3.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-3.0.json",
-      "referenceNumber": "62",
-      "name": "Creative Commons Attribution 3.0 Unported",
-      "licenseId": "CC-BY-3.0",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by/3.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-4.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-4.0.json",
-      "referenceNumber": "63",
-      "name": "Creative Commons Attribution 4.0 International",
-      "licenseId": "CC-BY-4.0",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by/4.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-NC-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-1.0.json",
-      "referenceNumber": "64",
-      "name": "Creative Commons Attribution Non Commercial 1.0 Generic",
-      "licenseId": "CC-BY-NC-1.0",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc/1.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-NC-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-2.0.json",
-      "referenceNumber": "65",
-      "name": "Creative Commons Attribution Non Commercial 2.0 Generic",
-      "licenseId": "CC-BY-NC-2.0",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc/2.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-NC-2.5.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-2.5.json",
-      "referenceNumber": "66",
-      "name": "Creative Commons Attribution Non Commercial 2.5 Generic",
-      "licenseId": "CC-BY-NC-2.5",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc/2.5/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-NC-3.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-3.0.json",
-      "referenceNumber": "67",
-      "name": "Creative Commons Attribution Non Commercial 3.0 Unported",
-      "licenseId": "CC-BY-NC-3.0",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc/3.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-NC-4.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-4.0.json",
-      "referenceNumber": "68",
-      "name": "Creative Commons Attribution Non Commercial 4.0 International",
-      "licenseId": "CC-BY-NC-4.0",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc/4.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-NC-ND-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-1.0.json",
-      "referenceNumber": "69",
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
-      "licenseId": "CC-BY-NC-ND-1.0",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-nd-nc/1.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-NC-ND-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-2.0.json",
-      "referenceNumber": "70",
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
-      "licenseId": "CC-BY-NC-ND-2.0",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-nd/2.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-NC-ND-2.5.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-2.5.json",
-      "referenceNumber": "71",
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
-      "licenseId": "CC-BY-NC-ND-2.5",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-nd/2.5/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-NC-ND-3.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-3.0.json",
-      "referenceNumber": "72",
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
-      "licenseId": "CC-BY-NC-ND-3.0",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-NC-ND-4.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-4.0.json",
-      "referenceNumber": "73",
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
-      "licenseId": "CC-BY-NC-ND-4.0",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-nd/4.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-NC-SA-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-1.0.json",
-      "referenceNumber": "74",
-      "name": "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
-      "licenseId": "CC-BY-NC-SA-1.0",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-sa/1.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-NC-SA-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-2.0.json",
-      "referenceNumber": "75",
-      "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
-      "licenseId": "CC-BY-NC-SA-2.0",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-sa/2.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-NC-SA-2.5.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-2.5.json",
-      "referenceNumber": "76",
-      "name": "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
-      "licenseId": "CC-BY-NC-SA-2.5",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-sa/2.5/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-NC-SA-3.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-3.0.json",
-      "referenceNumber": "77",
-      "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported",
-      "licenseId": "CC-BY-NC-SA-3.0",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-sa/3.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-NC-SA-4.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-4.0.json",
-      "referenceNumber": "78",
-      "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
-      "licenseId": "CC-BY-NC-SA-4.0",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-sa/4.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-ND-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-1.0.json",
-      "referenceNumber": "79",
-      "name": "Creative Commons Attribution No Derivatives 1.0 Generic",
-      "licenseId": "CC-BY-ND-1.0",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-nd/1.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-ND-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-2.0.json",
-      "referenceNumber": "80",
-      "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
-      "licenseId": "CC-BY-ND-2.0",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nd/2.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-ND-2.5.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-2.5.json",
-      "referenceNumber": "81",
-      "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
-      "licenseId": "CC-BY-ND-2.5",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-nd/2.5/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-ND-3.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-3.0.json",
-      "referenceNumber": "82",
-      "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
-      "licenseId": "CC-BY-ND-3.0",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-nd/3.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-ND-4.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-4.0.json",
-      "referenceNumber": "83",
-      "name": "Creative Commons Attribution No Derivatives 4.0 International",
-      "licenseId": "CC-BY-ND-4.0",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-nd/4.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-SA-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-1.0.json",
-      "referenceNumber": "84",
-      "name": "Creative Commons Attribution Share Alike 1.0 Generic",
-      "licenseId": "CC-BY-SA-1.0",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-sa/1.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-SA-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-2.0.json",
-      "referenceNumber": "85",
-      "name": "Creative Commons Attribution Share Alike 2.0 Generic",
-      "licenseId": "CC-BY-SA-2.0",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-sa/2.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-SA-2.5.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-2.5.json",
-      "referenceNumber": "86",
-      "name": "Creative Commons Attribution Share Alike 2.5 Generic",
-      "licenseId": "CC-BY-SA-2.5",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-sa/2.5/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-SA-3.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-3.0.json",
-      "referenceNumber": "87",
-      "name": "Creative Commons Attribution Share Alike 3.0 Unported",
-      "licenseId": "CC-BY-SA-3.0",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-sa/3.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC-BY-SA-4.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-4.0.json",
-      "referenceNumber": "88",
-      "name": "Creative Commons Attribution Share Alike 4.0 International",
-      "licenseId": "CC-BY-SA-4.0",
-      "seeAlso": [
-        "http://creativecommons.org/licenses/by-sa/4.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CC0-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/CC0-1.0.json",
-      "referenceNumber": "89",
-      "name": "Creative Commons Zero v1.0 Universal",
-      "licenseId": "CC0-1.0",
-      "seeAlso": [
-        "http://creativecommons.org/publicdomain/zero/1.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CDDL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/CDDL-1.0.json",
-      "referenceNumber": "90",
-      "name": "Common Development and Distribution License 1.0",
-      "licenseId": "CDDL-1.0",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/cddl1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./CDDL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CDDL-1.1.json",
-      "referenceNumber": "91",
-      "name": "Common Development and Distribution License 1.1",
-      "licenseId": "CDDL-1.1",
-      "seeAlso": [
-        "http://glassfish.java.net/public/CDDL+GPL_1_1.html",
-        "https://javaee.github.io/glassfish/LICENSE"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CDLA-Permissive-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CDLA-Permissive-1.0.json",
-      "referenceNumber": "92",
-      "name": "Community Data License Agreement Permissive 1.0",
-      "licenseId": "CDLA-Permissive-1.0",
-      "seeAlso": [
-        "https://cdla.io/permissive-1-0"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CDLA-Sharing-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CDLA-Sharing-1.0.json",
-      "referenceNumber": "93",
-      "name": "Community Data License Agreement Sharing 1.0",
-      "licenseId": "CDLA-Sharing-1.0",
-      "seeAlso": [
-        "https://cdla.io/sharing-1-0"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CECILL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CECILL-1.0.json",
-      "referenceNumber": "94",
-      "name": "CeCILL Free Software License Agreement v1.0",
-      "licenseId": "CECILL-1.0",
-      "seeAlso": [
-        "http://www.cecill.info/licences/Licence_CeCILL_V1-fr.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CECILL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CECILL-1.1.json",
-      "referenceNumber": "95",
-      "name": "CeCILL Free Software License Agreement v1.1",
-      "licenseId": "CECILL-1.1",
-      "seeAlso": [
-        "http://www.cecill.info/licences/Licence_CeCILL_V1.1-US.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CECILL-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/CECILL-2.0.json",
-      "referenceNumber": "96",
-      "name": "CeCILL Free Software License Agreement v2.0",
-      "licenseId": "CECILL-2.0",
-      "seeAlso": [
-        "http://www.cecill.info/licences/Licence_CeCILL_V2-en.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CECILL-2.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CECILL-2.1.json",
-      "referenceNumber": "97",
-      "name": "CeCILL Free Software License Agreement v2.1",
-      "licenseId": "CECILL-2.1",
-      "seeAlso": [
-        "http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./CECILL-B.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/CECILL-B.json",
-      "referenceNumber": "98",
-      "name": "CeCILL-B Free Software License Agreement",
-      "licenseId": "CECILL-B",
-      "seeAlso": [
-        "http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CECILL-C.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/CECILL-C.json",
-      "referenceNumber": "99",
-      "name": "CeCILL-C Free Software License Agreement",
-      "licenseId": "CECILL-C",
-      "seeAlso": [
-        "http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.html\n    "
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CNRI-Jython.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CNRI-Jython.json",
-      "referenceNumber": "100",
-      "name": "CNRI Jython License",
-      "licenseId": "CNRI-Jython",
-      "seeAlso": [
-        "http://www.jython.org/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CNRI-Python-GPL-Compatible.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CNRI-Python-GPL-Compatible.json",
-      "referenceNumber": "101",
-      "name": "CNRI Python Open Source GPL Compatible License Agreement",
-      "licenseId": "CNRI-Python-GPL-Compatible",
-      "seeAlso": [
-        "http://www.python.org/download/releases/1.6.1/download_win/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CNRI-Python.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CNRI-Python.json",
-      "referenceNumber": "102",
-      "name": "CNRI Python License",
-      "licenseId": "CNRI-Python",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/CNRI-Python"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./CPAL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/CPAL-1.0.json",
-      "referenceNumber": "103",
-      "name": "Common Public Attribution License 1.0",
-      "licenseId": "CPAL-1.0",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/CPAL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./CPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/CPL-1.0.json",
-      "referenceNumber": "104",
-      "name": "Common Public License 1.0",
-      "licenseId": "CPL-1.0",
-      "seeAlso": [
-        "http://opensource.org/licenses/CPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./CPOL-1.02.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CPOL-1.02.json",
-      "referenceNumber": "105",
-      "name": "Code Project Open License 1.02",
-      "licenseId": "CPOL-1.02",
-      "seeAlso": [
-        "http://www.codeproject.com/info/cpol10.aspx"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CUA-OPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CUA-OPL-1.0.json",
-      "referenceNumber": "106",
-      "name": "CUA Office Public License v1.0",
-      "licenseId": "CUA-OPL-1.0",
-      "seeAlso": [
-        "http://opensource.org/licenses/CUA-OPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Caldera.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Caldera.json",
-      "referenceNumber": "107",
-      "name": "Caldera License",
-      "licenseId": "Caldera",
-      "seeAlso": [
-        "http://www.lemis.com/grog/UNIX/ancient-source-all.pdf"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./ClArtistic.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/ClArtistic.json",
-      "referenceNumber": "108",
-      "name": "Clarified Artistic License",
-      "licenseId": "ClArtistic",
-      "seeAlso": [
-        "http://gianluca.dellavedova.org/2011/01/03/clarified-artistic-license/",
-        "http://www.ncftp.com/ncftp/doc/LICENSE.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Condor-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Condor-1.1.json",
-      "referenceNumber": "109",
-      "name": "Condor Public License v1.1",
-      "licenseId": "Condor-1.1",
-      "seeAlso": [
-        "http://research.cs.wisc.edu/condor/license.html#condor",
-        "http://web.archive.org/web/20111123062036/http://research.cs.wisc.edu/condor/license.html#condor"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Crossword.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Crossword.json",
-      "referenceNumber": "110",
-      "name": "Crossword License",
-      "licenseId": "Crossword",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Crossword"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CrystalStacker.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CrystalStacker.json",
-      "referenceNumber": "111",
-      "name": "CrystalStacker License",
-      "licenseId": "CrystalStacker",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing:CrystalStacker?rd\u003dLicensing/CrystalStacker"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Cube.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Cube.json",
-      "referenceNumber": "112",
-      "name": "Cube License",
-      "licenseId": "Cube",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Cube"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./D-FSL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/D-FSL-1.0.json",
-      "referenceNumber": "113",
-      "name": "Deutsche Freie Software Lizenz",
-      "licenseId": "D-FSL-1.0",
-      "seeAlso": [
-        "http://www.dipp.nrw.de/d-fsl/lizenzen/",
-        "http://www.dipp.nrw.de/d-fsl/index_html/lizenzen/de/D-FSL-1_0_de.txt",
-        "http://www.dipp.nrw.de/d-fsl/index_html/lizenzen/en/D-FSL-1_0_en.txt",
-        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl",
-        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl/deutsche-freie-software-lizenz",
-        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl/german-free-software-license",
-        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl/D-FSL-1_0_de.txt/at_download/file",
-        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl/D-FSL-1_0_en.txt/at_download/file"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./DOC.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/DOC.json",
-      "referenceNumber": "114",
-      "name": "DOC License",
-      "licenseId": "DOC",
-      "seeAlso": [
-        "http://www.cs.wustl.edu/~schmidt/ACE-copying.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./DSDP.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/DSDP.json",
-      "referenceNumber": "115",
-      "name": "DSDP License",
-      "licenseId": "DSDP",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/DSDP"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Dotseqn.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Dotseqn.json",
-      "referenceNumber": "116",
-      "name": "Dotseqn License",
-      "licenseId": "Dotseqn",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Dotseqn"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./ECL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/ECL-1.0.json",
-      "referenceNumber": "117",
-      "name": "Educational Community License v1.0",
-      "licenseId": "ECL-1.0",
-      "seeAlso": [
-        "http://opensource.org/licenses/ECL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./ECL-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/ECL-2.0.json",
-      "referenceNumber": "118",
-      "name": "Educational Community License v2.0",
-      "licenseId": "ECL-2.0",
-      "seeAlso": [
-        "http://opensource.org/licenses/ECL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./EFL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/EFL-1.0.json",
-      "referenceNumber": "119",
-      "name": "Eiffel Forum License v1.0",
-      "licenseId": "EFL-1.0",
-      "seeAlso": [
-        "http://www.eiffel-nice.org/license/forum.txt",
-        "http://opensource.org/licenses/EFL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./EFL-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/EFL-2.0.json",
-      "referenceNumber": "120",
-      "name": "Eiffel Forum License v2.0",
-      "licenseId": "EFL-2.0",
-      "seeAlso": [
-        "http://www.eiffel-nice.org/license/eiffel-forum-license-2.html",
-        "http://opensource.org/licenses/EFL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./EPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/EPL-1.0.json",
-      "referenceNumber": "121",
-      "name": "Eclipse Public License 1.0",
-      "licenseId": "EPL-1.0",
-      "seeAlso": [
-        "http://www.eclipse.org/legal/epl-v10.html",
-        "http://www.opensource.org/licenses/EPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./EPL-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/EPL-2.0.json",
-      "referenceNumber": "122",
-      "name": "Eclipse Public License 2.0",
-      "licenseId": "EPL-2.0",
-      "seeAlso": [
-        "https://www.eclipse.org/legal/epl-2.0",
-        "https://www.opensource.org/licenses/EPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./EUDatagrid.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/EUDatagrid.json",
-      "referenceNumber": "123",
-      "name": "EU DataGrid Software License",
-      "licenseId": "EUDatagrid",
-      "seeAlso": [
-        "http://eu-datagrid.web.cern.ch/eu-datagrid/license.html",
-        "http://www.opensource.org/licenses/EUDatagrid"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./EUPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/EUPL-1.0.json",
-      "referenceNumber": "124",
-      "name": "European Union Public License 1.0",
-      "licenseId": "EUPL-1.0",
-      "seeAlso": [
-        "http://ec.europa.eu/idabc/en/document/7330.html",
-        "http://ec.europa.eu/idabc/servlets/Doc027f.pdf?id\u003d31096"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./EUPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/EUPL-1.1.json",
-      "referenceNumber": "125",
-      "name": "European Union Public License 1.1",
-      "licenseId": "EUPL-1.1",
-      "seeAlso": [
-        "https://joinup.ec.europa.eu/software/page/eupl/licence-eupl",
-        "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl1.1.-licence-en_0.pdf",
-        "http://www.opensource.org/licenses/EUPL-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./EUPL-1.2.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/EUPL-1.2.json",
-      "referenceNumber": "126",
-      "name": "European Union Public License 1.2",
-      "licenseId": "EUPL-1.2",
-      "seeAlso": [
-        "https://joinup.ec.europa.eu/page/eupl-text-11-12",
-        "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl_v1.2_en.pdf",
-        "https://joinup.ec.europa.eu/sites/default/files/inline-files/EUPL%20v1_2%20EN(1).txt",
-        "http://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri\u003dCELEX:32017D0863",
-        "http://www.opensource.org/licenses/EUPL-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Entessa.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Entessa.json",
-      "referenceNumber": "127",
-      "name": "Entessa Public License v1.0",
-      "licenseId": "Entessa",
-      "seeAlso": [
-        "http://opensource.org/licenses/Entessa"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./ErlPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/ErlPL-1.1.json",
-      "referenceNumber": "128",
-      "name": "Erlang Public License v1.1",
-      "licenseId": "ErlPL-1.1",
-      "seeAlso": [
-        "http://www.erlang.org/EPLICENSE"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Eurosym.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Eurosym.json",
-      "referenceNumber": "129",
-      "name": "Eurosym License",
-      "licenseId": "Eurosym",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Eurosym"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./FSFAP.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/FSFAP.json",
-      "referenceNumber": "130",
-      "name": "FSF All Permissive License",
-      "licenseId": "FSFAP",
-      "seeAlso": [
-        "http://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./FSFUL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/FSFUL.json",
-      "referenceNumber": "131",
-      "name": "FSF Unlimited License",
-      "licenseId": "FSFUL",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./FSFULLR.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/FSFULLR.json",
-      "referenceNumber": "132",
-      "name": "FSF Unlimited License (with License Retention)",
-      "licenseId": "FSFULLR",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License#License_Retention_Variant"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./FTL.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/FTL.json",
-      "referenceNumber": "133",
-      "name": "Freetype Project License",
-      "licenseId": "FTL",
-      "seeAlso": [
-        "http://freetype.fis.uniroma2.it/FTL.TXT",
-        "http://git.savannah.gnu.org/cgit/freetype/freetype2.git/tree/docs/FTL.TXT"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Fair.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Fair.json",
-      "referenceNumber": "134",
-      "name": "Fair License",
-      "licenseId": "Fair",
-      "seeAlso": [
-        "http://fairlicense.org/",
-        "http://www.opensource.org/licenses/Fair"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Frameworx-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Frameworx-1.0.json",
-      "referenceNumber": "135",
-      "name": "Frameworx Open License 1.0",
-      "licenseId": "Frameworx-1.0",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/Frameworx-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./FreeImage.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/FreeImage.json",
-      "referenceNumber": "136",
-      "name": "FreeImage Public License v1.0",
-      "licenseId": "FreeImage",
-      "seeAlso": [
-        "http://freeimage.sourceforge.net/freeimage-license.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GFDL-1.1-only.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-only.json",
-      "referenceNumber": "137",
-      "name": "GNU Free Documentation License v1.1 only",
-      "licenseId": "GFDL-1.1-only",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GFDL-1.1-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-or-later.json",
-      "referenceNumber": "138",
-      "name": "GNU Free Documentation License v1.1 or later",
-      "licenseId": "GFDL-1.1-or-later",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GFDL-1.2-only.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-only.json",
-      "referenceNumber": "139",
-      "name": "GNU Free Documentation License v1.2 only",
-      "licenseId": "GFDL-1.2-only",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GFDL-1.2-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-or-later.json",
-      "referenceNumber": "140",
-      "name": "GNU Free Documentation License v1.2 or later",
-      "licenseId": "GFDL-1.2-or-later",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GFDL-1.3-only.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-only.json",
-      "referenceNumber": "141",
-      "name": "GNU Free Documentation License v1.3 only",
-      "licenseId": "GFDL-1.3-only",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/fdl-1.3.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GFDL-1.3-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-or-later.json",
-      "referenceNumber": "142",
-      "name": "GNU Free Documentation License v1.3 or later",
-      "licenseId": "GFDL-1.3-or-later",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/fdl-1.3.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GL2PS.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/GL2PS.json",
-      "referenceNumber": "143",
-      "name": "GL2PS License",
-      "licenseId": "GL2PS",
-      "seeAlso": [
-        "http://www.geuz.org/gl2ps/COPYING.GL2PS"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-1.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/GPL-1.0-only.json",
-      "referenceNumber": "144",
-      "name": "GNU General Public License v1.0 only",
-      "licenseId": "GPL-1.0-only",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-1.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/GPL-1.0-or-later.json",
-      "referenceNumber": "145",
-      "name": "GNU General Public License v1.0 or later",
-      "licenseId": "GPL-1.0-or-later",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-2.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-only.json",
-      "referenceNumber": "146",
-      "name": "GNU General Public License v2.0 only",
-      "licenseId": "GPL-2.0-only",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-2.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-or-later.json",
-      "referenceNumber": "147",
-      "name": "GNU General Public License v2.0 or later",
-      "licenseId": "GPL-2.0-or-later",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-3.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-only.json",
-      "referenceNumber": "148",
-      "name": "GNU General Public License v3.0 only",
-      "licenseId": "GPL-3.0-only",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-3.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-or-later.json",
-      "referenceNumber": "149",
-      "name": "GNU General Public License v3.0 or later",
-      "licenseId": "GPL-3.0-or-later",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Giftware.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Giftware.json",
-      "referenceNumber": "150",
-      "name": "Giftware License",
-      "licenseId": "Giftware",
-      "seeAlso": [
-        "http://liballeg.org/license.html#allegro-4-the-giftware-license"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Glide.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Glide.json",
-      "referenceNumber": "151",
-      "name": "3dfx Glide License",
-      "licenseId": "Glide",
-      "seeAlso": [
-        "http://www.users.on.net/~triforce/glidexp/COPYING.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Glulxe.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Glulxe.json",
-      "referenceNumber": "152",
-      "name": "Glulxe License",
-      "licenseId": "Glulxe",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Glulxe"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./HPND.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/HPND.json",
-      "referenceNumber": "153",
-      "name": "Historical Permission Notice and Disclaimer",
-      "licenseId": "HPND",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/HPND"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./HaskellReport.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/HaskellReport.json",
-      "referenceNumber": "154",
-      "name": "Haskell Language Report License",
-      "licenseId": "HaskellReport",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Haskell_Language_Report_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./IBM-pibs.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/IBM-pibs.json",
-      "referenceNumber": "155",
-      "name": "IBM PowerPC Initialization and Boot Software",
-      "licenseId": "IBM-pibs",
-      "seeAlso": [
-        "http://git.denx.de/?p\u003du-boot.git;a\u003dblob;f\u003darch/powerpc/cpu/ppc4xx/miiphy.c;h\u003d297155fdafa064b955e53e9832de93bfb0cfb85b;hb\u003d9fab4bf4cc077c21e43941866f3f2c196f28670d"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./ICU.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/ICU.json",
-      "referenceNumber": "156",
-      "name": "ICU License",
-      "licenseId": "ICU",
-      "seeAlso": [
-        "http://source.icu-project.org/repos/icu/icu/trunk/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./IJG.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/IJG.json",
-      "referenceNumber": "157",
-      "name": "Independent JPEG Group License",
-      "licenseId": "IJG",
-      "seeAlso": [
-        "http://dev.w3.org/cvsweb/Amaya/libjpeg/Attic/README?rev\u003d1.2"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./IPA.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/IPA.json",
-      "referenceNumber": "158",
-      "name": "IPA Font License",
-      "licenseId": "IPA",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/IPA"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./IPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/IPL-1.0.json",
-      "referenceNumber": "159",
-      "name": "IBM Public License v1.0",
-      "licenseId": "IPL-1.0",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/IPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./ISC.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/ISC.json",
-      "referenceNumber": "160",
-      "name": "ISC License",
-      "licenseId": "ISC",
-      "seeAlso": [
-        "https://www.isc.org/downloads/software-support-policy/isc-license/",
-        "http://www.opensource.org/licenses/ISC"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./ImageMagick.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/ImageMagick.json",
-      "referenceNumber": "161",
-      "name": "ImageMagick License",
-      "licenseId": "ImageMagick",
-      "seeAlso": [
-        "http://www.imagemagick.org/script/license.php"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Imlib2.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Imlib2.json",
-      "referenceNumber": "162",
-      "name": "Imlib2 License",
-      "licenseId": "Imlib2",
-      "seeAlso": [
-        "http://trac.enlightenment.org/e/browser/trunk/imlib2/COPYING",
-        "https://git.enlightenment.org/legacy/imlib2.git/tree/COPYING"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Info-ZIP.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Info-ZIP.json",
-      "referenceNumber": "163",
-      "name": "Info-ZIP License",
-      "licenseId": "Info-ZIP",
-      "seeAlso": [
-        "http://www.info-zip.org/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Intel-ACPI.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Intel-ACPI.json",
-      "referenceNumber": "164",
-      "name": "Intel ACPI Software License Agreement",
-      "licenseId": "Intel-ACPI",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Intel_ACPI_Software_License_Agreement"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Intel.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Intel.json",
-      "referenceNumber": "165",
-      "name": "Intel Open Source License",
-      "licenseId": "Intel",
-      "seeAlso": [
-        "http://opensource.org/licenses/Intel"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Interbase-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Interbase-1.0.json",
-      "referenceNumber": "166",
-      "name": "Interbase Public License v1.0",
-      "licenseId": "Interbase-1.0",
-      "seeAlso": [
-        "https://web.archive.org/web/20060319014854/http://info.borland.com/devsupport/interbase/opensource/IPL.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./JSON.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/JSON.json",
-      "referenceNumber": "167",
-      "name": "JSON License",
-      "licenseId": "JSON",
-      "seeAlso": [
-        "http://www.json.org/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./JasPer-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/JasPer-2.0.json",
-      "referenceNumber": "168",
-      "name": "JasPer License",
-      "licenseId": "JasPer-2.0",
-      "seeAlso": [
-        "http://www.ece.uvic.ca/~mdadams/jasper/LICENSE"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LAL-1.2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LAL-1.2.json",
-      "referenceNumber": "169",
-      "name": "Licence Art Libre 1.2",
-      "licenseId": "LAL-1.2",
-      "seeAlso": [
-        "http://artlibre.org/licence/lal/licence-art-libre-12/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LAL-1.3.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LAL-1.3.json",
-      "referenceNumber": "170",
-      "name": "Licence Art Libre 1.3",
-      "licenseId": "LAL-1.3",
-      "seeAlso": [
-        "http://artlibre.org/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LGPL-2.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.0-only.json",
-      "referenceNumber": "171",
-      "name": "GNU Library General Public License v2 only",
-      "licenseId": "LGPL-2.0-only",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-2.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.0-or-later.json",
-      "referenceNumber": "172",
-      "name": "GNU Library General Public License v2 or later",
-      "licenseId": "LGPL-2.0-or-later",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-2.1-only.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.1-only.json",
-      "referenceNumber": "173",
-      "name": "GNU Lesser General Public License v2.1 only",
-      "licenseId": "LGPL-2.1-only",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-2.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-2.1-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.1-or-later.json",
-      "referenceNumber": "174",
-      "name": "GNU Lesser General Public License v2.1 or later",
-      "licenseId": "LGPL-2.1-or-later",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-2.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-3.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-3.0-only.json",
-      "referenceNumber": "175",
-      "name": "GNU Lesser General Public License v3.0 only",
-      "licenseId": "LGPL-3.0-only",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-3.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-3.0-or-later.json",
-      "referenceNumber": "176",
-      "name": "GNU Lesser General Public License v3.0 or later",
-      "licenseId": "LGPL-3.0-or-later",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPLLR.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LGPLLR.json",
-      "referenceNumber": "177",
-      "name": "Lesser General Public License For Linguistic Resources",
-      "licenseId": "LGPLLR",
-      "seeAlso": [
-        "http://www-igm.univ-mlv.fr/~unitex/lgpllr.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LPL-1.0.json",
-      "referenceNumber": "178",
-      "name": "Lucent Public License Version 1.0",
-      "licenseId": "LPL-1.0",
-      "seeAlso": [
-        "http://opensource.org/licenses/LPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LPL-1.02.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LPL-1.02.json",
-      "referenceNumber": "179",
-      "name": "Lucent Public License v1.02",
-      "licenseId": "LPL-1.02",
-      "seeAlso": [
-        "http://plan9.bell-labs.com/plan9/license.html",
-        "http://www.opensource.org/licenses/LPL-1.02"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LPPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LPPL-1.0.json",
-      "referenceNumber": "180",
-      "name": "LaTeX Project Public License v1.0",
-      "licenseId": "LPPL-1.0",
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-0.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LPPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LPPL-1.1.json",
-      "referenceNumber": "181",
-      "name": "LaTeX Project Public License v1.1",
-      "licenseId": "LPPL-1.1",
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-1.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LPPL-1.2.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LPPL-1.2.json",
-      "referenceNumber": "182",
-      "name": "LaTeX Project Public License v1.2",
-      "licenseId": "LPPL-1.2",
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-2.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LPPL-1.3a.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LPPL-1.3a.json",
-      "referenceNumber": "183",
-      "name": "LaTeX Project Public License v1.3a",
-      "licenseId": "LPPL-1.3a",
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-3a.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LPPL-1.3c.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LPPL-1.3c.json",
-      "referenceNumber": "184",
-      "name": "LaTeX Project Public License v1.3c",
-      "licenseId": "LPPL-1.3c",
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-3c.txt",
-        "http://www.opensource.org/licenses/LPPL-1.3c"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Latex2e.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Latex2e.json",
-      "referenceNumber": "185",
-      "name": "Latex2e License",
-      "licenseId": "Latex2e",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Latex2e"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Leptonica.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Leptonica.json",
-      "referenceNumber": "186",
-      "name": "Leptonica License",
-      "licenseId": "Leptonica",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Leptonica"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LiLiQ-P-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LiLiQ-P-1.1.json",
-      "referenceNumber": "187",
-      "name": "Licence Libre du Québec – Permissive version 1.1",
-      "licenseId": "LiLiQ-P-1.1",
-      "seeAlso": [
-        "https://forge.gouv.qc.ca/licence/fr/liliq-v1-1/",
-        "http://opensource.org/licenses/LiLiQ-P-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LiLiQ-R-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LiLiQ-R-1.1.json",
-      "referenceNumber": "188",
-      "name": "Licence Libre du Québec – Réciprocité version 1.1",
-      "licenseId": "LiLiQ-R-1.1",
-      "seeAlso": [
-        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-liliq-r-v1-1/",
-        "http://opensource.org/licenses/LiLiQ-R-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LiLiQ-Rplus-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LiLiQ-Rplus-1.1.json",
-      "referenceNumber": "189",
-      "name": "Licence Libre du Québec – Réciprocité forte version 1.1",
-      "licenseId": "LiLiQ-Rplus-1.1",
-      "seeAlso": [
-        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-forte-liliq-r-v1-1/",
-        "http://opensource.org/licenses/LiLiQ-Rplus-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Libpng.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Libpng.json",
-      "referenceNumber": "190",
-      "name": "libpng License",
-      "licenseId": "Libpng",
-      "seeAlso": [
-        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Linux-OpenIB.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Linux-OpenIB.json",
-      "referenceNumber": "191",
-      "name": "Linux Kernel Variant of OpenIB.org license",
-      "licenseId": "Linux-OpenIB",
-      "seeAlso": [
-        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/infiniband/core/sa.h"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./MIT-0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MIT-0.json",
-      "referenceNumber": "192",
-      "name": "MIT No Attribution",
-      "licenseId": "MIT-0",
-      "seeAlso": [
-        "https://github.com/aws/mit-0",
-        "https://romanrm.net/mit-zero",
-        "https://github.com/awsdocs/aws-cloud9-user-guide/blob/master/LICENSE-SAMPLECODE"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./MIT-CMU.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MIT-CMU.json",
-      "referenceNumber": "193",
-      "name": "CMU License",
-      "licenseId": "MIT-CMU",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing:MIT?rd\u003dLicensing/MIT#CMU_Style"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./MIT-advertising.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MIT-advertising.json",
-      "referenceNumber": "194",
-      "name": "Enlightenment License (e16)",
-      "licenseId": "MIT-advertising",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MIT_With_Advertising"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./MIT-enna.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MIT-enna.json",
-      "referenceNumber": "195",
-      "name": "enna License",
-      "licenseId": "MIT-enna",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MIT#enna"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./MIT-feh.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MIT-feh.json",
-      "referenceNumber": "196",
-      "name": "feh License",
-      "licenseId": "MIT-feh",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MIT#feh"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./MIT.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/MIT.json",
-      "referenceNumber": "197",
-      "name": "MIT License",
-      "licenseId": "MIT",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/MIT"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./MITNFA.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MITNFA.json",
-      "referenceNumber": "198",
-      "name": "MIT +no-false-attribs license",
-      "licenseId": "MITNFA",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MITNFA"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./MPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MPL-1.0.json",
-      "referenceNumber": "199",
-      "name": "Mozilla Public License 1.0",
-      "licenseId": "MPL-1.0",
-      "seeAlso": [
-        "http://www.mozilla.org/MPL/MPL-1.0.html",
-        "http://opensource.org/licenses/MPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./MPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/MPL-1.1.json",
-      "referenceNumber": "200",
-      "name": "Mozilla Public License 1.1",
-      "licenseId": "MPL-1.1",
-      "seeAlso": [
-        "http://www.mozilla.org/MPL/MPL-1.1.html",
-        "http://www.opensource.org/licenses/MPL-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./MPL-2.0-no-copyleft-exception.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MPL-2.0-no-copyleft-exception.json",
-      "referenceNumber": "201",
-      "name": "Mozilla Public License 2.0 (no copyleft exception)",
-      "licenseId": "MPL-2.0-no-copyleft-exception",
-      "seeAlso": [
-        "http://www.mozilla.org/MPL/2.0/",
-        "http://opensource.org/licenses/MPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./MPL-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/MPL-2.0.json",
-      "referenceNumber": "202",
-      "name": "Mozilla Public License 2.0",
-      "licenseId": "MPL-2.0",
-      "seeAlso": [
-        "http://www.mozilla.org/MPL/2.0/",
-        "http://opensource.org/licenses/MPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./MS-PL.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/MS-PL.json",
-      "referenceNumber": "203",
-      "name": "Microsoft Public License",
-      "licenseId": "MS-PL",
-      "seeAlso": [
-        "http://www.microsoft.com/opensource/licenses.mspx",
-        "http://www.opensource.org/licenses/MS-PL"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./MS-RL.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/MS-RL.json",
-      "referenceNumber": "204",
-      "name": "Microsoft Reciprocal License",
-      "licenseId": "MS-RL",
-      "seeAlso": [
-        "http://www.microsoft.com/opensource/licenses.mspx",
-        "http://www.opensource.org/licenses/MS-RL"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./MTLL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MTLL.json",
-      "referenceNumber": "205",
-      "name": "Matrix Template Library License",
-      "licenseId": "MTLL",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Matrix_Template_Library_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./MakeIndex.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MakeIndex.json",
-      "referenceNumber": "206",
-      "name": "MakeIndex License",
-      "licenseId": "MakeIndex",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MakeIndex"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./MirOS.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MirOS.json",
-      "referenceNumber": "207",
-      "name": "MirOS License",
-      "licenseId": "MirOS",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/MirOS"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Motosoto.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Motosoto.json",
-      "referenceNumber": "208",
-      "name": "Motosoto License",
-      "licenseId": "Motosoto",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/Motosoto"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Multics.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Multics.json",
-      "referenceNumber": "209",
-      "name": "Multics License",
-      "licenseId": "Multics",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/Multics"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Mup.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Mup.json",
-      "referenceNumber": "210",
-      "name": "Mup License",
-      "licenseId": "Mup",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Mup"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NASA-1.3.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NASA-1.3.json",
-      "referenceNumber": "211",
-      "name": "NASA Open Source Agreement 1.3",
-      "licenseId": "NASA-1.3",
-      "seeAlso": [
-        "http://ti.arc.nasa.gov/opensource/nosa/",
-        "http://www.opensource.org/licenses/NASA-1.3"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./NBPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NBPL-1.0.json",
-      "referenceNumber": "212",
-      "name": "Net Boolean Public License v1",
-      "licenseId": "NBPL-1.0",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d37b4b3f6cc4bf34e1d3dec61e69914b9819d8894"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NCSA.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/NCSA.json",
-      "referenceNumber": "213",
-      "name": "University of Illinois/NCSA Open Source License",
-      "licenseId": "NCSA",
-      "seeAlso": [
-        "http://otm.illinois.edu/uiuc_openSource",
-        "http://www.opensource.org/licenses/NCSA"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./NGPL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NGPL.json",
-      "referenceNumber": "214",
-      "name": "Nethack General Public License",
-      "licenseId": "NGPL",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/NGPL"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./NLOD-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NLOD-1.0.json",
-      "referenceNumber": "215",
-      "name": "Norwegian Licence for Open Government Data",
-      "licenseId": "NLOD-1.0",
-      "seeAlso": [
-        "http://data.norge.no/nlod/en/1.0"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NLPL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NLPL.json",
-      "referenceNumber": "216",
-      "name": "No Limit Public License",
-      "licenseId": "NLPL",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/NLPL"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NOSL.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/NOSL.json",
-      "referenceNumber": "217",
-      "name": "Netizen Open Source License",
-      "licenseId": "NOSL",
-      "seeAlso": [
-        "http://bits.netizen.com.au/licenses/NOSL/nosl.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/NPL-1.0.json",
-      "referenceNumber": "218",
-      "name": "Netscape Public License v1.0",
-      "licenseId": "NPL-1.0",
-      "seeAlso": [
-        "http://www.mozilla.org/MPL/NPL/1.0/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/NPL-1.1.json",
-      "referenceNumber": "219",
-      "name": "Netscape Public License v1.1",
-      "licenseId": "NPL-1.1",
-      "seeAlso": [
-        "http://www.mozilla.org/MPL/NPL/1.1/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NPOSL-3.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NPOSL-3.0.json",
-      "referenceNumber": "220",
-      "name": "Non-Profit Open Software License 3.0",
-      "licenseId": "NPOSL-3.0",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/NOSL3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./NRL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NRL.json",
-      "referenceNumber": "221",
-      "name": "NRL License",
-      "licenseId": "NRL",
-      "seeAlso": [
-        "http://web.mit.edu/network/isakmp/nrllicense.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NTP.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NTP.json",
-      "referenceNumber": "222",
-      "name": "NTP License",
-      "licenseId": "NTP",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/NTP"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Naumen.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Naumen.json",
-      "referenceNumber": "223",
-      "name": "Naumen Public License",
-      "licenseId": "Naumen",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/Naumen"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Net-SNMP.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Net-SNMP.json",
-      "referenceNumber": "224",
-      "name": "Net-SNMP License",
-      "licenseId": "Net-SNMP",
-      "seeAlso": [
-        "http://net-snmp.sourceforge.net/about/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NetCDF.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NetCDF.json",
-      "referenceNumber": "225",
-      "name": "NetCDF license",
-      "licenseId": "NetCDF",
-      "seeAlso": [
-        "http://www.unidata.ucar.edu/software/netcdf/copyright.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Newsletr.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Newsletr.json",
-      "referenceNumber": "226",
-      "name": "Newsletr License",
-      "licenseId": "Newsletr",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Newsletr"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Nokia.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Nokia.json",
-      "referenceNumber": "227",
-      "name": "Nokia Open Source License",
-      "licenseId": "Nokia",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/nokia"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Noweb.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Noweb.json",
-      "referenceNumber": "228",
-      "name": "Noweb License",
-      "licenseId": "Noweb",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Noweb"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OCCT-PL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OCCT-PL.json",
-      "referenceNumber": "229",
-      "name": "Open CASCADE Technology Public License",
-      "licenseId": "OCCT-PL",
-      "seeAlso": [
-        "http://www.opencascade.com/content/occt-public-license"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OCLC-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OCLC-2.0.json",
-      "referenceNumber": "230",
-      "name": "OCLC Research Public License 2.0",
-      "licenseId": "OCLC-2.0",
-      "seeAlso": [
-        "http://www.oclc.org/research/activities/software/license/v2final.htm",
-        "http://www.opensource.org/licenses/OCLC-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./ODC-By-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/ODC-By-1.0.json",
-      "referenceNumber": "231",
-      "name": "Open Data Commons Attribution License v1.0",
-      "licenseId": "ODC-By-1.0",
-      "seeAlso": [
-        "https://opendatacommons.org/licenses/by/1.0/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./ODbL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/ODbL-1.0.json",
-      "referenceNumber": "232",
-      "name": "ODC Open Database License v1.0",
-      "licenseId": "ODbL-1.0",
-      "seeAlso": [
-        "http://www.opendatacommons.org/licenses/odbl/1.0/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OFL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OFL-1.0.json",
-      "referenceNumber": "233",
-      "name": "SIL Open Font License 1.0",
-      "licenseId": "OFL-1.0",
-      "seeAlso": [
-        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL10_web"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OFL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OFL-1.1.json",
-      "referenceNumber": "234",
-      "name": "SIL Open Font License 1.1",
-      "licenseId": "OFL-1.1",
-      "seeAlso": [
-        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL_web",
-        "http://www.opensource.org/licenses/OFL-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./OGTSL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OGTSL.json",
-      "referenceNumber": "235",
-      "name": "Open Group Test Suite License",
-      "licenseId": "OGTSL",
-      "seeAlso": [
-        "http://www.opengroup.org/testing/downloads/The_Open_Group_TSL.txt",
-        "http://www.opensource.org/licenses/OGTSL"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./OLDAP-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-1.1.json",
-      "referenceNumber": "236",
-      "name": "Open LDAP Public License v1.1",
-      "licenseId": "OLDAP-1.1",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d806557a5ad59804ef3a44d5abfbe91d706b0791f"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-1.2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-1.2.json",
-      "referenceNumber": "237",
-      "name": "Open LDAP Public License v1.2",
-      "licenseId": "OLDAP-1.2",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d42b0383c50c299977b5893ee695cf4e486fb0dc7"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-1.3.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-1.3.json",
-      "referenceNumber": "238",
-      "name": "Open LDAP Public License v1.3",
-      "licenseId": "OLDAP-1.3",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003de5f8117f0ce088d0bd7a8e18ddf37eaa40eb09b1"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-1.4.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-1.4.json",
-      "referenceNumber": "239",
-      "name": "Open LDAP Public License v1.4",
-      "licenseId": "OLDAP-1.4",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dc9f95c2f3f2ffb5e0ae55fe7388af75547660941"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.0.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.0.1.json",
-      "referenceNumber": "240",
-      "name": "Open LDAP Public License v2.0.1",
-      "licenseId": "OLDAP-2.0.1",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003db6d68acd14e51ca3aab4428bf26522aa74873f0e"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.0.json",
-      "referenceNumber": "241",
-      "name": "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
-      "licenseId": "OLDAP-2.0",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dcbf50f4e1185a21abd4c0a54d3f4341fe28f36ea"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.1.json",
-      "referenceNumber": "242",
-      "name": "Open LDAP Public License v2.1",
-      "licenseId": "OLDAP-2.1",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003db0d176738e96a0d3b9f85cb51e140a86f21be715"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.2.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.1.json",
-      "referenceNumber": "243",
-      "name": "Open LDAP Public License v2.2.1",
-      "licenseId": "OLDAP-2.2.1",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d4bc786f34b50aa301be6f5600f58a980070f481e"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.2.2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.2.json",
-      "referenceNumber": "244",
-      "name": "Open LDAP Public License 2.2.2",
-      "licenseId": "OLDAP-2.2.2",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003ddf2cc1e21eb7c160695f5b7cffd6296c151ba188"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.json",
-      "referenceNumber": "245",
-      "name": "Open LDAP Public License v2.2",
-      "licenseId": "OLDAP-2.2",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d470b0c18ec67621c85881b2733057fecf4a1acc3"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.3.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.3.json",
-      "referenceNumber": "246",
-      "name": "Open LDAP Public License v2.3",
-      "licenseId": "OLDAP-2.3",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dd32cf54a32d581ab475d23c810b0a7fbaf8d63c3"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.4.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.4.json",
-      "referenceNumber": "247",
-      "name": "Open LDAP Public License v2.4",
-      "licenseId": "OLDAP-2.4",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dcd1284c4a91a8a380d904eee68d1583f989ed386"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.5.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.5.json",
-      "referenceNumber": "248",
-      "name": "Open LDAP Public License v2.5",
-      "licenseId": "OLDAP-2.5",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d6852b9d90022e8593c98205413380536b1b5a7cf"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.6.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.6.json",
-      "referenceNumber": "249",
-      "name": "Open LDAP Public License v2.6",
-      "licenseId": "OLDAP-2.6",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d1cae062821881f41b73012ba816434897abf4205"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.7.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.7.json",
-      "referenceNumber": "250",
-      "name": "Open LDAP Public License v2.7",
-      "licenseId": "OLDAP-2.7",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d47c2415c1df81556eeb39be6cad458ef87c534a2"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.8.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.8.json",
-      "referenceNumber": "251",
-      "name": "Open LDAP Public License v2.8",
-      "licenseId": "OLDAP-2.8",
-      "seeAlso": [
-        "http://www.openldap.org/software/release/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OML.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OML.json",
-      "referenceNumber": "252",
-      "name": "Open Market License",
-      "licenseId": "OML",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Open_Market_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OPL-1.0.json",
-      "referenceNumber": "253",
-      "name": "Open Public License v1.0",
-      "licenseId": "OPL-1.0",
-      "seeAlso": [
-        "http://old.koalateam.com/jackaroo/OPL_1_0.TXT",
-        "https://fedoraproject.org/wiki/Licensing/Open_Public_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OSET-PL-2.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OSET-PL-2.1.json",
-      "referenceNumber": "254",
-      "name": "OSET Public License version 2.1",
-      "licenseId": "OSET-PL-2.1",
-      "seeAlso": [
-        "http://www.osetfoundation.org/public-license",
-        "http://opensource.org/licenses/OPL-2.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./OSL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OSL-1.0.json",
-      "referenceNumber": "255",
-      "name": "Open Software License 1.0",
-      "licenseId": "OSL-1.0",
-      "seeAlso": [
-        "http://opensource.org/licenses/OSL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./OSL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OSL-1.1.json",
-      "referenceNumber": "256",
-      "name": "Open Software License 1.1",
-      "licenseId": "OSL-1.1",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/OSL1.1"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OSL-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OSL-2.0.json",
-      "referenceNumber": "257",
-      "name": "Open Software License 2.0",
-      "licenseId": "OSL-2.0",
-      "seeAlso": [
-        "http://web.archive.org/web/20041020171434/http://www.rosenlaw.com/osl2.0.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./OSL-2.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OSL-2.1.json",
-      "referenceNumber": "258",
-      "name": "Open Software License 2.1",
-      "licenseId": "OSL-2.1",
-      "seeAlso": [
-        "http://web.archive.org/web/20050212003940/http://www.rosenlaw.com/osl21.htm",
-        "http://opensource.org/licenses/OSL-2.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./OSL-3.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OSL-3.0.json",
-      "referenceNumber": "259",
-      "name": "Open Software License 3.0",
-      "licenseId": "OSL-3.0",
-      "seeAlso": [
-        "http://www.rosenlaw.com/OSL3.0.htm",
-        "http://www.opensource.org/licenses/OSL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./OpenSSL.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OpenSSL.json",
-      "referenceNumber": "260",
-      "name": "OpenSSL License",
-      "licenseId": "OpenSSL",
-      "seeAlso": [
-        "http://www.openssl.org/source/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./PDDL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/PDDL-1.0.json",
-      "referenceNumber": "261",
-      "name": "ODC Public Domain Dedication \u0026 License 1.0",
-      "licenseId": "PDDL-1.0",
-      "seeAlso": [
-        "http://opendatacommons.org/licenses/pddl/1.0/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./PHP-3.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/PHP-3.0.json",
-      "referenceNumber": "262",
-      "name": "PHP License v3.0",
-      "licenseId": "PHP-3.0",
-      "seeAlso": [
-        "http://www.php.net/license/3_0.txt",
-        "http://www.opensource.org/licenses/PHP-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./PHP-3.01.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/PHP-3.01.json",
-      "referenceNumber": "263",
-      "name": "PHP License v3.01",
-      "licenseId": "PHP-3.01",
-      "seeAlso": [
-        "http://www.php.net/license/3_01.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Plexus.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Plexus.json",
-      "referenceNumber": "264",
-      "name": "Plexus Classworlds License",
-      "licenseId": "Plexus",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Plexus_Classworlds_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./PostgreSQL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/PostgreSQL.json",
-      "referenceNumber": "265",
-      "name": "PostgreSQL License",
-      "licenseId": "PostgreSQL",
-      "seeAlso": [
-        "http://www.postgresql.org/about/licence",
-        "http://www.opensource.org/licenses/PostgreSQL"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Python-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Python-2.0.json",
-      "referenceNumber": "266",
-      "name": "Python License 2.0",
-      "licenseId": "Python-2.0",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/Python-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./QPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/QPL-1.0.json",
-      "referenceNumber": "267",
-      "name": "Q Public License 1.0",
-      "licenseId": "QPL-1.0",
-      "seeAlso": [
-        "http://doc.qt.nokia.com/3.3/license.html",
-        "http://www.opensource.org/licenses/QPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Qhull.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Qhull.json",
-      "referenceNumber": "268",
-      "name": "Qhull License",
-      "licenseId": "Qhull",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Qhull"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./RHeCos-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/RHeCos-1.1.json",
-      "referenceNumber": "269",
-      "name": "Red Hat eCos Public License v1.1",
-      "licenseId": "RHeCos-1.1",
-      "seeAlso": [
-        "http://ecos.sourceware.org/old-license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./RPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/RPL-1.1.json",
-      "referenceNumber": "270",
-      "name": "Reciprocal Public License 1.1",
-      "licenseId": "RPL-1.1",
-      "seeAlso": [
-        "http://opensource.org/licenses/RPL-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./RPL-1.5.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/RPL-1.5.json",
-      "referenceNumber": "271",
-      "name": "Reciprocal Public License 1.5",
-      "licenseId": "RPL-1.5",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/RPL-1.5"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./RPSL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/RPSL-1.0.json",
-      "referenceNumber": "272",
-      "name": "RealNetworks Public Source License v1.0",
-      "licenseId": "RPSL-1.0",
-      "seeAlso": [
-        "https://helixcommunity.org/content/rpsl",
-        "http://www.opensource.org/licenses/RPSL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./RSA-MD.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/RSA-MD.json",
-      "referenceNumber": "273",
-      "name": "RSA Message-Digest License ",
-      "licenseId": "RSA-MD",
-      "seeAlso": [
-        "http://www.faqs.org/rfcs/rfc1321.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./RSCPL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/RSCPL.json",
-      "referenceNumber": "274",
-      "name": "Ricoh Source Code Public License",
-      "licenseId": "RSCPL",
-      "seeAlso": [
-        "http://wayback.archive.org/web/20060715140826/http://www.risource.org/RPL/RPL-1.0A.shtml",
-        "http://www.opensource.org/licenses/RSCPL"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Rdisc.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Rdisc.json",
-      "referenceNumber": "275",
-      "name": "Rdisc License",
-      "licenseId": "Rdisc",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Rdisc_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Ruby.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Ruby.json",
-      "referenceNumber": "276",
-      "name": "Ruby License",
-      "licenseId": "Ruby",
-      "seeAlso": [
-        "http://www.ruby-lang.org/en/LICENSE.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SAX-PD.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SAX-PD.json",
-      "referenceNumber": "277",
-      "name": "Sax Public Domain Notice",
-      "licenseId": "SAX-PD",
-      "seeAlso": [
-        "http://www.saxproject.org/copying.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SCEA.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SCEA.json",
-      "referenceNumber": "278",
-      "name": "SCEA Shared Source License",
-      "licenseId": "SCEA",
-      "seeAlso": [
-        "http://research.scea.com/scea_shared_source_license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SGI-B-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SGI-B-1.0.json",
-      "referenceNumber": "279",
-      "name": "SGI Free Software License B v1.0",
-      "licenseId": "SGI-B-1.0",
-      "seeAlso": [
-        "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.1.0.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SGI-B-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SGI-B-1.1.json",
-      "referenceNumber": "280",
-      "name": "SGI Free Software License B v1.1",
-      "licenseId": "SGI-B-1.1",
-      "seeAlso": [
-        "http://oss.sgi.com/projects/FreeB/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SGI-B-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/SGI-B-2.0.json",
-      "referenceNumber": "281",
-      "name": "SGI Free Software License B v2.0",
-      "licenseId": "SGI-B-2.0",
-      "seeAlso": [
-        "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.2.0.pdf"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SISSL-1.2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SISSL-1.2.json",
-      "referenceNumber": "282",
-      "name": "Sun Industry Standards Source License v1.2",
-      "licenseId": "SISSL-1.2",
-      "seeAlso": [
-        "http://gridscheduler.sourceforge.net/Gridengine_SISSL_license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SISSL.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/SISSL.json",
-      "referenceNumber": "283",
-      "name": "Sun Industry Standards Source License v1.1",
-      "licenseId": "SISSL",
-      "seeAlso": [
-        "http://www.openoffice.org/licenses/sissl_license.html",
-        "http://opensource.org/licenses/SISSL"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./SMLNJ.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/SMLNJ.json",
-      "referenceNumber": "284",
-      "name": "Standard ML of New Jersey License",
-      "licenseId": "SMLNJ",
-      "seeAlso": [
-        "https://www.smlnj.org/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SMPPL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SMPPL.json",
-      "referenceNumber": "285",
-      "name": "Secure Messaging Protocol Public License",
-      "licenseId": "SMPPL",
-      "seeAlso": [
-        "https://github.com/dcblake/SMP/blob/master/Documentation/License.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SNIA.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SNIA.json",
-      "referenceNumber": "286",
-      "name": "SNIA Public License 1.1",
-      "licenseId": "SNIA",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/SNIA_Public_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/SPL-1.0.json",
-      "referenceNumber": "287",
-      "name": "Sun Public License v1.0",
-      "licenseId": "SPL-1.0",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/SPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./SWL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SWL.json",
-      "referenceNumber": "288",
-      "name": "Scheme Widget Library (SWL) Software License Agreement",
-      "licenseId": "SWL",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/SWL"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Saxpath.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Saxpath.json",
-      "referenceNumber": "289",
-      "name": "Saxpath License",
-      "licenseId": "Saxpath",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Saxpath_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Sendmail.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Sendmail.json",
-      "referenceNumber": "290",
-      "name": "Sendmail License",
-      "licenseId": "Sendmail",
-      "seeAlso": [
-        "http://www.sendmail.com/pdfs/open_source/sendmail_license.pdf",
-        "https://web.archive.org/web/20160322142305/https://www.sendmail.com/pdfs/open_source/sendmail_license.pdf"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SimPL-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SimPL-2.0.json",
-      "referenceNumber": "291",
-      "name": "Simple Public License 2.0",
-      "licenseId": "SimPL-2.0",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/SimPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Sleepycat.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Sleepycat.json",
-      "referenceNumber": "292",
-      "name": "Sleepycat License",
-      "licenseId": "Sleepycat",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/Sleepycat"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Spencer-86.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Spencer-86.json",
-      "referenceNumber": "293",
-      "name": "Spencer License 86",
-      "licenseId": "Spencer-86",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Spencer-94.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Spencer-94.json",
-      "referenceNumber": "294",
-      "name": "Spencer License 94",
-      "licenseId": "Spencer-94",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Spencer-99.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Spencer-99.json",
-      "referenceNumber": "295",
-      "name": "Spencer License 99",
-      "licenseId": "Spencer-99",
-      "seeAlso": [
-        "http://www.opensource.apple.com/source/tcl/tcl-5/tcl/generic/regfronts.c"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SugarCRM-1.1.3.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SugarCRM-1.1.3.json",
-      "referenceNumber": "296",
-      "name": "SugarCRM Public License v1.1.3",
-      "licenseId": "SugarCRM-1.1.3",
-      "seeAlso": [
-        "http://www.sugarcrm.com/crm/SPL"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./TCL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/TCL.json",
-      "referenceNumber": "297",
-      "name": "TCL/TK License",
-      "licenseId": "TCL",
-      "seeAlso": [
-        "http://www.tcl.tk/software/tcltk/license.html",
-        "https://fedoraproject.org/wiki/Licensing/TCL"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./TCP-wrappers.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/TCP-wrappers.json",
-      "referenceNumber": "298",
-      "name": "TCP Wrappers License",
-      "licenseId": "TCP-wrappers",
-      "seeAlso": [
-        "http://rc.quest.com/topics/openssh/license.php#tcpwrappers"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./TMate.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/TMate.json",
-      "referenceNumber": "299",
-      "name": "TMate Open Source License",
-      "licenseId": "TMate",
-      "seeAlso": [
-        "http://svnkit.com/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./TORQUE-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/TORQUE-1.1.json",
-      "referenceNumber": "300",
-      "name": "TORQUE v2.5+ Software License v1.1",
-      "licenseId": "TORQUE-1.1",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/TORQUEv1.1"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./TOSL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/TOSL.json",
-      "referenceNumber": "301",
-      "name": "Trusster Open Source License",
-      "licenseId": "TOSL",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/TOSL"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./TU-Berlin-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/TU-Berlin-1.0.json",
-      "referenceNumber": "302",
-      "name": "Technische Universitaet Berlin License 1.0",
-      "licenseId": "TU-Berlin-1.0",
-      "seeAlso": [
-        "https://github.com/swh/ladspa/blob/7bf6f3799fdba70fda297c2d8fd9f526803d9680/gsm/COPYRIGHT"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./TU-Berlin-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/TU-Berlin-2.0.json",
-      "referenceNumber": "303",
-      "name": "Technische Universitaet Berlin License 2.0",
-      "licenseId": "TU-Berlin-2.0",
-      "seeAlso": [
-        "https://github.com/CorsixTH/deps/blob/fd339a9f526d1d9c9f01ccf39e438a015da50035/licences/libgsm.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./UPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/UPL-1.0.json",
-      "referenceNumber": "304",
-      "name": "Universal Permissive License v1.0",
-      "licenseId": "UPL-1.0",
-      "seeAlso": [
-        "http://opensource.org/licenses/UPL"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Unicode-DFS-2015.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Unicode-DFS-2015.json",
-      "referenceNumber": "305",
-      "name": "Unicode License Agreement - Data Files and Software (2015)",
-      "licenseId": "Unicode-DFS-2015",
-      "seeAlso": [
-        "https://web.archive.org/web/20151224134844/http://unicode.org/copyright.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Unicode-DFS-2016.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Unicode-DFS-2016.json",
-      "referenceNumber": "306",
-      "name": "Unicode License Agreement - Data Files and Software (2016)",
-      "licenseId": "Unicode-DFS-2016",
-      "seeAlso": [
-        "http://www.unicode.org/copyright.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Unicode-TOU.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Unicode-TOU.json",
-      "referenceNumber": "307",
-      "name": "Unicode Terms of Use",
-      "licenseId": "Unicode-TOU",
-      "seeAlso": [
-        "http://www.unicode.org/copyright.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Unlicense.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Unlicense.json",
-      "referenceNumber": "308",
-      "name": "The Unlicense",
-      "licenseId": "Unlicense",
-      "seeAlso": [
-        "http://unlicense.org/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./VOSTROM.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/VOSTROM.json",
-      "referenceNumber": "309",
-      "name": "VOSTROM Public License for Open Source",
-      "licenseId": "VOSTROM",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/VOSTROM"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./VSL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/VSL-1.0.json",
-      "referenceNumber": "310",
-      "name": "Vovida Software License v1.0",
-      "licenseId": "VSL-1.0",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/VSL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Vim.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Vim.json",
-      "referenceNumber": "311",
-      "name": "Vim License",
-      "licenseId": "Vim",
-      "seeAlso": [
-        "http://vimdoc.sourceforge.net/htmldoc/uganda.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./W3C-19980720.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/W3C-19980720.json",
-      "referenceNumber": "312",
-      "name": "W3C Software Notice and License (1998-07-20)",
-      "licenseId": "W3C-19980720",
-      "seeAlso": [
-        "http://www.w3.org/Consortium/Legal/copyright-software-19980720.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./W3C-20150513.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/W3C-20150513.json",
-      "referenceNumber": "313",
-      "name": "W3C Software Notice and Document License (2015-05-13)",
-      "licenseId": "W3C-20150513",
-      "seeAlso": [
-        "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./W3C.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/W3C.json",
-      "referenceNumber": "314",
-      "name": "W3C Software Notice and License (2002-12-31)",
-      "licenseId": "W3C",
-      "seeAlso": [
-        "http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html",
-        "http://www.opensource.org/licenses/W3C"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./WTFPL.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/WTFPL.json",
-      "referenceNumber": "315",
-      "name": "Do What The F*ck You Want To Public License",
-      "licenseId": "WTFPL",
-      "seeAlso": [
-        "http://sam.zoy.org/wtfpl/COPYING"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Watcom-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Watcom-1.0.json",
-      "referenceNumber": "316",
-      "name": "Sybase Open Watcom Public License 1.0",
-      "licenseId": "Watcom-1.0",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/Watcom-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Wsuipa.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Wsuipa.json",
-      "referenceNumber": "317",
-      "name": "Wsuipa License",
-      "licenseId": "Wsuipa",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Wsuipa"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./X11.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/X11.json",
-      "referenceNumber": "318",
-      "name": "X11 License",
-      "licenseId": "X11",
-      "seeAlso": [
-        "http://www.xfree86.org/3.3.6/COPYRIGHT2.html#3"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./XFree86-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/XFree86-1.1.json",
-      "referenceNumber": "319",
-      "name": "XFree86 License 1.1",
-      "licenseId": "XFree86-1.1",
-      "seeAlso": [
-        "http://www.xfree86.org/current/LICENSE4.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./XSkat.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/XSkat.json",
-      "referenceNumber": "320",
-      "name": "XSkat License",
-      "licenseId": "XSkat",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/XSkat_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Xerox.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Xerox.json",
-      "referenceNumber": "321",
-      "name": "Xerox License",
-      "licenseId": "Xerox",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Xerox"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Xnet.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Xnet.json",
-      "referenceNumber": "322",
-      "name": "X.Net License",
-      "licenseId": "Xnet",
-      "seeAlso": [
-        "http://opensource.org/licenses/Xnet"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./YPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/YPL-1.0.json",
-      "referenceNumber": "323",
-      "name": "Yahoo! Public License v1.0",
-      "licenseId": "YPL-1.0",
-      "seeAlso": [
-        "http://www.zimbra.com/license/yahoo_public_license_1.0.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./YPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/YPL-1.1.json",
-      "referenceNumber": "324",
-      "name": "Yahoo! Public License v1.1",
-      "licenseId": "YPL-1.1",
-      "seeAlso": [
-        "http://www.zimbra.com/license/yahoo_public_license_1.1.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./ZPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/ZPL-1.1.json",
-      "referenceNumber": "325",
-      "name": "Zope Public License 1.1",
-      "licenseId": "ZPL-1.1",
-      "seeAlso": [
-        "http://old.zope.org/Resources/License/ZPL-1.1"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./ZPL-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/ZPL-2.0.json",
-      "referenceNumber": "326",
-      "name": "Zope Public License 2.0",
-      "licenseId": "ZPL-2.0",
-      "seeAlso": [
-        "http://old.zope.org/Resources/License/ZPL-2.0",
-        "http://opensource.org/licenses/ZPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./ZPL-2.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/ZPL-2.1.json",
-      "referenceNumber": "327",
-      "name": "Zope Public License 2.1",
-      "licenseId": "ZPL-2.1",
-      "seeAlso": [
-        "http://old.zope.org/Resources/ZPL/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Zed.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Zed.json",
-      "referenceNumber": "328",
-      "name": "Zed License",
-      "licenseId": "Zed",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Zed"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Zend-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Zend-2.0.json",
-      "referenceNumber": "329",
-      "name": "Zend License v2.0",
-      "licenseId": "Zend-2.0",
-      "seeAlso": [
-        "https://web.archive.org/web/20130517195954/http://www.zend.com/license/2_00.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Zimbra-1.3.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Zimbra-1.3.json",
-      "referenceNumber": "330",
-      "name": "Zimbra Public License v1.3",
-      "licenseId": "Zimbra-1.3",
-      "seeAlso": [
-        "http://web.archive.org/web/20100302225219/http://www.zimbra.com/license/zimbra-public-license-1-3.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Zimbra-1.4.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Zimbra-1.4.json",
-      "referenceNumber": "331",
-      "name": "Zimbra Public License v1.4",
-      "licenseId": "Zimbra-1.4",
-      "seeAlso": [
-        "http://www.zimbra.com/legal/zimbra-public-license-1-4"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Zlib.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Zlib.json",
-      "referenceNumber": "332",
-      "name": "zlib License",
-      "licenseId": "Zlib",
-      "seeAlso": [
-        "http://www.zlib.net/zlib_license.html",
-        "http://www.opensource.org/licenses/Zlib"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./bzip2-1.0.5.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/bzip2-1.0.5.json",
-      "referenceNumber": "333",
-      "name": "bzip2 and libbzip2 License v1.0.5",
-      "licenseId": "bzip2-1.0.5",
-      "seeAlso": [
-        "http://bzip.org/1.0.5/bzip2-manual-1.0.5.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./bzip2-1.0.6.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/bzip2-1.0.6.json",
-      "referenceNumber": "334",
-      "name": "bzip2 and libbzip2 License v1.0.6",
-      "licenseId": "bzip2-1.0.6",
-      "seeAlso": [
-        "https://github.com/asimonov-im/bzip2/blob/master/LICENSE"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./curl.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/curl.json",
-      "referenceNumber": "335",
-      "name": "curl License",
-      "licenseId": "curl",
-      "seeAlso": [
-        "https://github.com/bagder/curl/blob/master/COPYING"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./diffmark.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/diffmark.json",
-      "referenceNumber": "336",
-      "name": "diffmark license",
-      "licenseId": "diffmark",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/diffmark"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./dvipdfm.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/dvipdfm.json",
-      "referenceNumber": "337",
-      "name": "dvipdfm License",
-      "licenseId": "dvipdfm",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/dvipdfm"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./eGenix.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/eGenix.json",
-      "referenceNumber": "338",
-      "name": "eGenix.com Public License 1.1.0",
-      "licenseId": "eGenix",
-      "seeAlso": [
-        "http://www.egenix.com/products/eGenix.com-Public-License-1.1.0.pdf",
-        "https://fedoraproject.org/wiki/Licensing/eGenix.com_Public_License_1.1.0"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./gSOAP-1.3b.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/gSOAP-1.3b.json",
-      "referenceNumber": "339",
-      "name": "gSOAP Public License v1.3b",
-      "licenseId": "gSOAP-1.3b",
-      "seeAlso": [
-        "http://www.cs.fsu.edu/~engelen/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./gnuplot.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/gnuplot.json",
-      "referenceNumber": "340",
-      "name": "gnuplot License",
-      "licenseId": "gnuplot",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Gnuplot"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./iMatix.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/iMatix.json",
-      "referenceNumber": "341",
-      "name": "iMatix Standard Function Library Agreement",
-      "licenseId": "iMatix",
-      "seeAlso": [
-        "http://legacy.imatix.com/html/sfl/sfl4.htm#license"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./libtiff.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/libtiff.json",
-      "referenceNumber": "342",
-      "name": "libtiff License",
-      "licenseId": "libtiff",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/libtiff"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./mpich2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/mpich2.json",
-      "referenceNumber": "343",
-      "name": "mpich2 License",
-      "licenseId": "mpich2",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MIT"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./psfrag.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/psfrag.json",
-      "referenceNumber": "344",
-      "name": "psfrag License",
-      "licenseId": "psfrag",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/psfrag"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./psutils.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/psutils.json",
-      "referenceNumber": "345",
-      "name": "psutils License",
-      "licenseId": "psutils",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/psutils"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./xinetd.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/xinetd.json",
-      "referenceNumber": "346",
-      "name": "xinetd License",
-      "licenseId": "xinetd",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Xinetd_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./xpp.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/xpp.json",
-      "referenceNumber": "347",
-      "name": "XPP License",
-      "licenseId": "xpp",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/xpp"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./zlib-acknowledgement.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/zlib-acknowledgement.json",
-      "referenceNumber": "348",
-      "name": "zlib/libpng License with Acknowledgement",
-      "licenseId": "zlib-acknowledgement",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/ZlibWithAcknowledgement"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./AGPL-1.0.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/AGPL-1.0.json",
-      "referenceNumber": "349",
-      "name": "Affero General Public License v1.0",
-      "licenseId": "AGPL-1.0",
-      "seeAlso": [
-        "http://www.affero.org/oagpl.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./AGPL-3.0.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/AGPL-3.0.json",
-      "referenceNumber": "350",
-      "name": "GNU Affero General Public License v3.0",
-      "licenseId": "AGPL-3.0",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/agpl.txt",
-        "http://www.opensource.org/licenses/AGPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GFDL-1.1.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.1.json",
-      "referenceNumber": "351",
-      "name": "GNU Free Documentation License v1.1",
-      "licenseId": "GFDL-1.1",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GFDL-1.2.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.2.json",
-      "referenceNumber": "352",
-      "name": "GNU Free Documentation License v1.2",
-      "licenseId": "GFDL-1.2",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GFDL-1.3.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.3.json",
-      "referenceNumber": "353",
-      "name": "GNU Free Documentation License v1.3",
-      "licenseId": "GFDL-1.3",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/fdl-1.3.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-1.0+.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-1.0+.json",
-      "referenceNumber": "354",
-      "name": "GNU General Public License v1.0 or later",
-      "licenseId": "GPL-1.0+",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-1.0.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-1.0.json",
-      "referenceNumber": "355",
-      "name": "GNU General Public License v1.0 only",
-      "licenseId": "GPL-1.0",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-2.0+.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0+.json",
-      "referenceNumber": "356",
-      "name": "GNU General Public License v2.0 or later",
-      "licenseId": "GPL-2.0+",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-2.0-with-GCC-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-GCC-exception.json",
-      "referenceNumber": "357",
-      "name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
-      "licenseId": "GPL-2.0-with-GCC-exception",
-      "seeAlso": [
-        "https://gcc.gnu.org/git/?p\u003dgcc.git;a\u003dblob;f\u003dgcc/libgcc1.c;h\u003d762f5143fc6eed57b6797c82710f3538aa52b40b;hb\u003dcb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-2.0-with-autoconf-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-autoconf-exception.json",
-      "referenceNumber": "358",
-      "name": "GNU General Public License v2.0 w/Autoconf exception",
-      "licenseId": "GPL-2.0-with-autoconf-exception",
-      "seeAlso": [
-        "http://ac-archive.sourceforge.net/doc/copyright.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-2.0-with-bison-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-bison-exception.json",
-      "referenceNumber": "359",
-      "name": "GNU General Public License v2.0 w/Bison exception",
-      "licenseId": "GPL-2.0-with-bison-exception",
-      "seeAlso": [
-        "http://git.savannah.gnu.org/cgit/bison.git/tree/data/yacc.c?id\u003d193d7c7054ba7197b0789e14965b739162319b5e#n141"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-2.0-with-classpath-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-classpath-exception.json",
-      "referenceNumber": "360",
-      "name": "GNU General Public License v2.0 w/Classpath exception",
-      "licenseId": "GPL-2.0-with-classpath-exception",
-      "seeAlso": [
-        "http://www.gnu.org/software/classpath/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-2.0-with-font-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-font-exception.json",
-      "referenceNumber": "361",
-      "name": "GNU General Public License v2.0 w/Font exception",
-      "licenseId": "GPL-2.0-with-font-exception",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/gpl-faq.html#FontException"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-2.0.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0.json",
-      "referenceNumber": "362",
-      "name": "GNU General Public License v2.0 only",
-      "licenseId": "GPL-2.0",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-3.0+.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-3.0+.json",
-      "referenceNumber": "363",
-      "name": "GNU General Public License v3.0 or later",
-      "licenseId": "GPL-3.0+",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-3.0-with-GCC-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-with-GCC-exception.json",
-      "referenceNumber": "364",
-      "name": "GNU General Public License v3.0 w/GCC Runtime Library exception",
-      "licenseId": "GPL-3.0-with-GCC-exception",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/gcc-exception-3.1.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-3.0-with-autoconf-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-with-autoconf-exception.json",
-      "referenceNumber": "365",
-      "name": "GNU General Public License v3.0 w/Autoconf exception",
-      "licenseId": "GPL-3.0-with-autoconf-exception",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/autoconf-exception-3.0.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-3.0.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-3.0.json",
-      "referenceNumber": "366",
-      "name": "GNU General Public License v3.0 only",
-      "licenseId": "GPL-3.0",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-2.0+.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.0+.json",
-      "referenceNumber": "367",
-      "name": "GNU Library General Public License v2 or later",
-      "licenseId": "LGPL-2.0+",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-2.0.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.0.json",
-      "referenceNumber": "368",
-      "name": "GNU Library General Public License v2 only",
-      "licenseId": "LGPL-2.0",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-2.1+.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.1+.json",
-      "referenceNumber": "369",
-      "name": "GNU Library General Public License v2.1 or later",
-      "licenseId": "LGPL-2.1+",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-2.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-2.1.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.1.json",
-      "referenceNumber": "370",
-      "name": "GNU Lesser General Public License v2.1 only",
-      "licenseId": "LGPL-2.1",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-2.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-3.0+.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-3.0+.json",
-      "referenceNumber": "371",
-      "name": "GNU Lesser General Public License v3.0 or later",
-      "licenseId": "LGPL-3.0+",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-3.0.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-3.0.json",
-      "referenceNumber": "372",
-      "name": "GNU Lesser General Public License v3.0 only",
-      "licenseId": "LGPL-3.0",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Nunit.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Nunit.json",
-      "referenceNumber": "373",
-      "name": "Nunit License",
-      "licenseId": "Nunit",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Nunit"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./StandardML-NJ.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/StandardML-NJ.json",
-      "referenceNumber": "374",
-      "name": "Standard ML of New Jersey License",
-      "licenseId": "StandardML-NJ",
-      "seeAlso": [
-        "http://www.smlnj.org//license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./eCos-2.0.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/eCos-2.0.json",
-      "referenceNumber": "375",
-      "name": "eCos license version 2.0",
-      "licenseId": "eCos-2.0",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/ecos-license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./wxWindows.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/wxWindows.json",
-      "referenceNumber": "376",
-      "name": "wxWindows Library License",
-      "licenseId": "wxWindows",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/WXwindows"
-      ],
-      "isOsiApproved": false
+    "0BSD":{
+        "deprecated":false
+    },
+    "AAL":{
+        "deprecated":false
+    },
+    "ADSL":{
+        "deprecated":false
+    },
+    "AFL-1.1":{
+        "deprecated":false
+    },
+    "AFL-1.2":{
+        "deprecated":false
+    },
+    "AFL-2.0":{
+        "deprecated":false
+    },
+    "AFL-2.1":{
+        "deprecated":false
+    },
+    "AFL-3.0":{
+        "deprecated":false
+    },
+    "AGPL-1.0":{
+        "deprecated":true
+    },
+    "AGPL-1.0-only":{
+        "deprecated":false
+    },
+    "AGPL-1.0-or-later":{
+        "deprecated":false
+    },
+    "AGPL-3.0":{
+        "deprecated":true
+    },
+    "AGPL-3.0-only":{
+        "deprecated":false
+    },
+    "AGPL-3.0-or-later":{
+        "deprecated":false
+    },
+    "AMDPLPA":{
+        "deprecated":false
+    },
+    "AML":{
+        "deprecated":false
+    },
+    "AMPAS":{
+        "deprecated":false
+    },
+    "ANTLR-PD":{
+        "deprecated":false
+    },
+    "APAFML":{
+        "deprecated":false
+    },
+    "APL-1.0":{
+        "deprecated":false
+    },
+    "APSL-1.0":{
+        "deprecated":false
+    },
+    "APSL-1.1":{
+        "deprecated":false
+    },
+    "APSL-1.2":{
+        "deprecated":false
+    },
+    "APSL-2.0":{
+        "deprecated":false
+    },
+    "Abstyles":{
+        "deprecated":false
+    },
+    "Adobe-2006":{
+        "deprecated":false
+    },
+    "Adobe-Glyph":{
+        "deprecated":false
+    },
+    "Afmparse":{
+        "deprecated":false
+    },
+    "Aladdin":{
+        "deprecated":false
+    },
+    "Apache-1.0":{
+        "deprecated":false
+    },
+    "Apache-1.1":{
+        "deprecated":false
+    },
+    "Apache-2.0":{
+        "deprecated":false
+    },
+    "Artistic-1.0":{
+        "deprecated":false
+    },
+    "Artistic-1.0-Perl":{
+        "deprecated":false
+    },
+    "Artistic-1.0-cl8":{
+        "deprecated":false
+    },
+    "Artistic-2.0":{
+        "deprecated":false
+    },
+    "BSD-1-Clause":{
+        "deprecated":false
+    },
+    "BSD-2-Clause":{
+        "deprecated":false
+    },
+    "BSD-2-Clause-FreeBSD":{
+        "deprecated":false
+    },
+    "BSD-2-Clause-NetBSD":{
+        "deprecated":false
+    },
+    "BSD-2-Clause-Patent":{
+        "deprecated":false
+    },
+    "BSD-3-Clause":{
+        "deprecated":false
+    },
+    "BSD-3-Clause-Attribution":{
+        "deprecated":false
+    },
+    "BSD-3-Clause-Clear":{
+        "deprecated":false
+    },
+    "BSD-3-Clause-LBNL":{
+        "deprecated":false
+    },
+    "BSD-3-Clause-No-Nuclear-License":{
+        "deprecated":false
+    },
+    "BSD-3-Clause-No-Nuclear-License-2014":{
+        "deprecated":false
+    },
+    "BSD-3-Clause-No-Nuclear-Warranty":{
+        "deprecated":false
+    },
+    "BSD-4-Clause":{
+        "deprecated":false
+    },
+    "BSD-4-Clause-UC":{
+        "deprecated":false
+    },
+    "BSD-Protection":{
+        "deprecated":false
+    },
+    "BSD-Source-Code":{
+        "deprecated":false
+    },
+    "BSL-1.0":{
+        "deprecated":false
+    },
+    "Bahyph":{
+        "deprecated":false
+    },
+    "Barr":{
+        "deprecated":false
+    },
+    "Beerware":{
+        "deprecated":false
+    },
+    "BitTorrent-1.0":{
+        "deprecated":false
+    },
+    "BitTorrent-1.1":{
+        "deprecated":false
+    },
+    "Borceux":{
+        "deprecated":false
+    },
+    "CATOSL-1.1":{
+        "deprecated":false
+    },
+    "CC-BY-1.0":{
+        "deprecated":false
+    },
+    "CC-BY-2.0":{
+        "deprecated":false
+    },
+    "CC-BY-2.5":{
+        "deprecated":false
+    },
+    "CC-BY-3.0":{
+        "deprecated":false
+    },
+    "CC-BY-4.0":{
+        "deprecated":false
+    },
+    "CC-BY-NC-1.0":{
+        "deprecated":false
+    },
+    "CC-BY-NC-2.0":{
+        "deprecated":false
+    },
+    "CC-BY-NC-2.5":{
+        "deprecated":false
+    },
+    "CC-BY-NC-3.0":{
+        "deprecated":false
+    },
+    "CC-BY-NC-4.0":{
+        "deprecated":false
+    },
+    "CC-BY-NC-ND-1.0":{
+        "deprecated":false
+    },
+    "CC-BY-NC-ND-2.0":{
+        "deprecated":false
+    },
+    "CC-BY-NC-ND-2.5":{
+        "deprecated":false
+    },
+    "CC-BY-NC-ND-3.0":{
+        "deprecated":false
+    },
+    "CC-BY-NC-ND-4.0":{
+        "deprecated":false
+    },
+    "CC-BY-NC-SA-1.0":{
+        "deprecated":false
+    },
+    "CC-BY-NC-SA-2.0":{
+        "deprecated":false
+    },
+    "CC-BY-NC-SA-2.5":{
+        "deprecated":false
+    },
+    "CC-BY-NC-SA-3.0":{
+        "deprecated":false
+    },
+    "CC-BY-NC-SA-4.0":{
+        "deprecated":false
+    },
+    "CC-BY-ND-1.0":{
+        "deprecated":false
+    },
+    "CC-BY-ND-2.0":{
+        "deprecated":false
+    },
+    "CC-BY-ND-2.5":{
+        "deprecated":false
+    },
+    "CC-BY-ND-3.0":{
+        "deprecated":false
+    },
+    "CC-BY-ND-4.0":{
+        "deprecated":false
+    },
+    "CC-BY-SA-1.0":{
+        "deprecated":false
+    },
+    "CC-BY-SA-2.0":{
+        "deprecated":false
+    },
+    "CC-BY-SA-2.5":{
+        "deprecated":false
+    },
+    "CC-BY-SA-3.0":{
+        "deprecated":false
+    },
+    "CC-BY-SA-4.0":{
+        "deprecated":false
+    },
+    "CC0-1.0":{
+        "deprecated":false
+    },
+    "CDDL-1.0":{
+        "deprecated":false
+    },
+    "CDDL-1.1":{
+        "deprecated":false
+    },
+    "CDLA-Permissive-1.0":{
+        "deprecated":false
+    },
+    "CDLA-Sharing-1.0":{
+        "deprecated":false
+    },
+    "CECILL-1.0":{
+        "deprecated":false
+    },
+    "CECILL-1.1":{
+        "deprecated":false
+    },
+    "CECILL-2.0":{
+        "deprecated":false
+    },
+    "CECILL-2.1":{
+        "deprecated":false
+    },
+    "CECILL-B":{
+        "deprecated":false
+    },
+    "CECILL-C":{
+        "deprecated":false
+    },
+    "CNRI-Jython":{
+        "deprecated":false
+    },
+    "CNRI-Python":{
+        "deprecated":false
+    },
+    "CNRI-Python-GPL-Compatible":{
+        "deprecated":false
+    },
+    "CPAL-1.0":{
+        "deprecated":false
+    },
+    "CPL-1.0":{
+        "deprecated":false
+    },
+    "CPOL-1.02":{
+        "deprecated":false
+    },
+    "CUA-OPL-1.0":{
+        "deprecated":false
+    },
+    "Caldera":{
+        "deprecated":false
+    },
+    "ClArtistic":{
+        "deprecated":false
+    },
+    "Condor-1.1":{
+        "deprecated":false
+    },
+    "Crossword":{
+        "deprecated":false
+    },
+    "CrystalStacker":{
+        "deprecated":false
+    },
+    "Cube":{
+        "deprecated":false
+    },
+    "D-FSL-1.0":{
+        "deprecated":false
+    },
+    "DOC":{
+        "deprecated":false
+    },
+    "DSDP":{
+        "deprecated":false
+    },
+    "Dotseqn":{
+        "deprecated":false
+    },
+    "ECL-1.0":{
+        "deprecated":false
+    },
+    "ECL-2.0":{
+        "deprecated":false
+    },
+    "EFL-1.0":{
+        "deprecated":false
+    },
+    "EFL-2.0":{
+        "deprecated":false
+    },
+    "EPL-1.0":{
+        "deprecated":false
+    },
+    "EPL-2.0":{
+        "deprecated":false
+    },
+    "EUDatagrid":{
+        "deprecated":false
+    },
+    "EUPL-1.0":{
+        "deprecated":false
+    },
+    "EUPL-1.1":{
+        "deprecated":false
+    },
+    "EUPL-1.2":{
+        "deprecated":false
+    },
+    "Entessa":{
+        "deprecated":false
+    },
+    "ErlPL-1.1":{
+        "deprecated":false
+    },
+    "Eurosym":{
+        "deprecated":false
+    },
+    "FSFAP":{
+        "deprecated":false
+    },
+    "FSFUL":{
+        "deprecated":false
+    },
+    "FSFULLR":{
+        "deprecated":false
+    },
+    "FTL":{
+        "deprecated":false
+    },
+    "Fair":{
+        "deprecated":false
+    },
+    "Frameworx-1.0":{
+        "deprecated":false
+    },
+    "FreeImage":{
+        "deprecated":false
+    },
+    "GFDL-1.1":{
+        "deprecated":true
+    },
+    "GFDL-1.1-only":{
+        "deprecated":false
+    },
+    "GFDL-1.1-or-later":{
+        "deprecated":false
+    },
+    "GFDL-1.2":{
+        "deprecated":true
+    },
+    "GFDL-1.2-only":{
+        "deprecated":false
+    },
+    "GFDL-1.2-or-later":{
+        "deprecated":false
+    },
+    "GFDL-1.3":{
+        "deprecated":true
+    },
+    "GFDL-1.3-only":{
+        "deprecated":false
+    },
+    "GFDL-1.3-or-later":{
+        "deprecated":false
+    },
+    "GL2PS":{
+        "deprecated":false
+    },
+    "GPL-1.0":{
+        "deprecated":true
+    },
+    "GPL-1.0+":{
+        "deprecated":true
+    },
+    "GPL-1.0-only":{
+        "deprecated":false
+    },
+    "GPL-1.0-or-later":{
+        "deprecated":false
+    },
+    "GPL-2.0":{
+        "deprecated":true
+    },
+    "GPL-2.0+":{
+        "deprecated":true
+    },
+    "GPL-2.0-only":{
+        "deprecated":false
+    },
+    "GPL-2.0-or-later":{
+        "deprecated":false
+    },
+    "GPL-2.0-with-GCC-exception":{
+        "deprecated":true
+    },
+    "GPL-2.0-with-autoconf-exception":{
+        "deprecated":true
+    },
+    "GPL-2.0-with-bison-exception":{
+        "deprecated":true
+    },
+    "GPL-2.0-with-classpath-exception":{
+        "deprecated":true
+    },
+    "GPL-2.0-with-font-exception":{
+        "deprecated":true
+    },
+    "GPL-3.0":{
+        "deprecated":true
+    },
+    "GPL-3.0+":{
+        "deprecated":true
+    },
+    "GPL-3.0-only":{
+        "deprecated":false
+    },
+    "GPL-3.0-or-later":{
+        "deprecated":false
+    },
+    "GPL-3.0-with-GCC-exception":{
+        "deprecated":true
+    },
+    "GPL-3.0-with-autoconf-exception":{
+        "deprecated":true
+    },
+    "Giftware":{
+        "deprecated":false
+    },
+    "Glide":{
+        "deprecated":false
+    },
+    "Glulxe":{
+        "deprecated":false
+    },
+    "HPND":{
+        "deprecated":false
+    },
+    "HaskellReport":{
+        "deprecated":false
+    },
+    "IBM-pibs":{
+        "deprecated":false
+    },
+    "ICU":{
+        "deprecated":false
+    },
+    "IJG":{
+        "deprecated":false
+    },
+    "IPA":{
+        "deprecated":false
+    },
+    "IPL-1.0":{
+        "deprecated":false
+    },
+    "ISC":{
+        "deprecated":false
+    },
+    "ImageMagick":{
+        "deprecated":false
+    },
+    "Imlib2":{
+        "deprecated":false
+    },
+    "Info-ZIP":{
+        "deprecated":false
+    },
+    "Intel":{
+        "deprecated":false
+    },
+    "Intel-ACPI":{
+        "deprecated":false
+    },
+    "Interbase-1.0":{
+        "deprecated":false
+    },
+    "JSON":{
+        "deprecated":false
+    },
+    "JasPer-2.0":{
+        "deprecated":false
+    },
+    "LAL-1.2":{
+        "deprecated":false
+    },
+    "LAL-1.3":{
+        "deprecated":false
+    },
+    "LGPL-2.0":{
+        "deprecated":true
+    },
+    "LGPL-2.0+":{
+        "deprecated":true
+    },
+    "LGPL-2.0-only":{
+        "deprecated":false
+    },
+    "LGPL-2.0-or-later":{
+        "deprecated":false
+    },
+    "LGPL-2.1":{
+        "deprecated":true
+    },
+    "LGPL-2.1+":{
+        "deprecated":true
+    },
+    "LGPL-2.1-only":{
+        "deprecated":false
+    },
+    "LGPL-2.1-or-later":{
+        "deprecated":false
+    },
+    "LGPL-3.0":{
+        "deprecated":true
+    },
+    "LGPL-3.0+":{
+        "deprecated":true
+    },
+    "LGPL-3.0-only":{
+        "deprecated":false
+    },
+    "LGPL-3.0-or-later":{
+        "deprecated":false
+    },
+    "LGPLLR":{
+        "deprecated":false
+    },
+    "LPL-1.0":{
+        "deprecated":false
+    },
+    "LPL-1.02":{
+        "deprecated":false
+    },
+    "LPPL-1.0":{
+        "deprecated":false
+    },
+    "LPPL-1.1":{
+        "deprecated":false
+    },
+    "LPPL-1.2":{
+        "deprecated":false
+    },
+    "LPPL-1.3a":{
+        "deprecated":false
+    },
+    "LPPL-1.3c":{
+        "deprecated":false
+    },
+    "Latex2e":{
+        "deprecated":false
+    },
+    "Leptonica":{
+        "deprecated":false
+    },
+    "LiLiQ-P-1.1":{
+        "deprecated":false
+    },
+    "LiLiQ-R-1.1":{
+        "deprecated":false
+    },
+    "LiLiQ-Rplus-1.1":{
+        "deprecated":false
+    },
+    "Libpng":{
+        "deprecated":false
+    },
+    "Linux-OpenIB":{
+        "deprecated":false
+    },
+    "MIT":{
+        "deprecated":false
+    },
+    "MIT-0":{
+        "deprecated":false
+    },
+    "MIT-CMU":{
+        "deprecated":false
+    },
+    "MIT-advertising":{
+        "deprecated":false
+    },
+    "MIT-enna":{
+        "deprecated":false
+    },
+    "MIT-feh":{
+        "deprecated":false
+    },
+    "MITNFA":{
+        "deprecated":false
+    },
+    "MPL-1.0":{
+        "deprecated":false
+    },
+    "MPL-1.1":{
+        "deprecated":false
+    },
+    "MPL-2.0":{
+        "deprecated":false
+    },
+    "MPL-2.0-no-copyleft-exception":{
+        "deprecated":false
+    },
+    "MS-PL":{
+        "deprecated":false
+    },
+    "MS-RL":{
+        "deprecated":false
+    },
+    "MTLL":{
+        "deprecated":false
+    },
+    "MakeIndex":{
+        "deprecated":false
+    },
+    "MirOS":{
+        "deprecated":false
+    },
+    "Motosoto":{
+        "deprecated":false
+    },
+    "Multics":{
+        "deprecated":false
+    },
+    "Mup":{
+        "deprecated":false
+    },
+    "NASA-1.3":{
+        "deprecated":false
+    },
+    "NBPL-1.0":{
+        "deprecated":false
+    },
+    "NCSA":{
+        "deprecated":false
+    },
+    "NGPL":{
+        "deprecated":false
+    },
+    "NLOD-1.0":{
+        "deprecated":false
+    },
+    "NLPL":{
+        "deprecated":false
+    },
+    "NOSL":{
+        "deprecated":false
+    },
+    "NPL-1.0":{
+        "deprecated":false
+    },
+    "NPL-1.1":{
+        "deprecated":false
+    },
+    "NPOSL-3.0":{
+        "deprecated":false
+    },
+    "NRL":{
+        "deprecated":false
+    },
+    "NTP":{
+        "deprecated":false
+    },
+    "Naumen":{
+        "deprecated":false
+    },
+    "Net-SNMP":{
+        "deprecated":false
+    },
+    "NetCDF":{
+        "deprecated":false
+    },
+    "Newsletr":{
+        "deprecated":false
+    },
+    "Nokia":{
+        "deprecated":false
+    },
+    "Noweb":{
+        "deprecated":false
+    },
+    "Nunit":{
+        "deprecated":true
+    },
+    "OCCT-PL":{
+        "deprecated":false
+    },
+    "OCLC-2.0":{
+        "deprecated":false
+    },
+    "ODC-By-1.0":{
+        "deprecated":false
+    },
+    "ODbL-1.0":{
+        "deprecated":false
+    },
+    "OFL-1.0":{
+        "deprecated":false
+    },
+    "OFL-1.1":{
+        "deprecated":false
+    },
+    "OGL-UK-1.0":{
+        "deprecated":false
+    },
+    "OGL-UK-2.0":{
+        "deprecated":false
+    },
+    "OGL-UK-3.0":{
+        "deprecated":false
+    },
+    "OGTSL":{
+        "deprecated":false
+    },
+    "OLDAP-1.1":{
+        "deprecated":false
+    },
+    "OLDAP-1.2":{
+        "deprecated":false
+    },
+    "OLDAP-1.3":{
+        "deprecated":false
+    },
+    "OLDAP-1.4":{
+        "deprecated":false
+    },
+    "OLDAP-2.0":{
+        "deprecated":false
+    },
+    "OLDAP-2.0.1":{
+        "deprecated":false
+    },
+    "OLDAP-2.1":{
+        "deprecated":false
+    },
+    "OLDAP-2.2":{
+        "deprecated":false
+    },
+    "OLDAP-2.2.1":{
+        "deprecated":false
+    },
+    "OLDAP-2.2.2":{
+        "deprecated":false
+    },
+    "OLDAP-2.3":{
+        "deprecated":false
+    },
+    "OLDAP-2.4":{
+        "deprecated":false
+    },
+    "OLDAP-2.5":{
+        "deprecated":false
+    },
+    "OLDAP-2.6":{
+        "deprecated":false
+    },
+    "OLDAP-2.7":{
+        "deprecated":false
+    },
+    "OLDAP-2.8":{
+        "deprecated":false
+    },
+    "OML":{
+        "deprecated":false
+    },
+    "OPL-1.0":{
+        "deprecated":false
+    },
+    "OSET-PL-2.1":{
+        "deprecated":false
+    },
+    "OSL-1.0":{
+        "deprecated":false
+    },
+    "OSL-1.1":{
+        "deprecated":false
+    },
+    "OSL-2.0":{
+        "deprecated":false
+    },
+    "OSL-2.1":{
+        "deprecated":false
+    },
+    "OSL-3.0":{
+        "deprecated":false
+    },
+    "OpenSSL":{
+        "deprecated":false
+    },
+    "PDDL-1.0":{
+        "deprecated":false
+    },
+    "PHP-3.0":{
+        "deprecated":false
+    },
+    "PHP-3.01":{
+        "deprecated":false
+    },
+    "Plexus":{
+        "deprecated":false
+    },
+    "PostgreSQL":{
+        "deprecated":false
+    },
+    "Python-2.0":{
+        "deprecated":false
+    },
+    "QPL-1.0":{
+        "deprecated":false
+    },
+    "Qhull":{
+        "deprecated":false
+    },
+    "RHeCos-1.1":{
+        "deprecated":false
+    },
+    "RPL-1.1":{
+        "deprecated":false
+    },
+    "RPL-1.5":{
+        "deprecated":false
+    },
+    "RPSL-1.0":{
+        "deprecated":false
+    },
+    "RSA-MD":{
+        "deprecated":false
+    },
+    "RSCPL":{
+        "deprecated":false
+    },
+    "Rdisc":{
+        "deprecated":false
+    },
+    "Ruby":{
+        "deprecated":false
+    },
+    "SAX-PD":{
+        "deprecated":false
+    },
+    "SCEA":{
+        "deprecated":false
+    },
+    "SGI-B-1.0":{
+        "deprecated":false
+    },
+    "SGI-B-1.1":{
+        "deprecated":false
+    },
+    "SGI-B-2.0":{
+        "deprecated":false
+    },
+    "SISSL":{
+        "deprecated":false
+    },
+    "SISSL-1.2":{
+        "deprecated":false
+    },
+    "SMLNJ":{
+        "deprecated":false
+    },
+    "SMPPL":{
+        "deprecated":false
+    },
+    "SNIA":{
+        "deprecated":false
+    },
+    "SPL-1.0":{
+        "deprecated":false
+    },
+    "SWL":{
+        "deprecated":false
+    },
+    "Saxpath":{
+        "deprecated":false
+    },
+    "Sendmail":{
+        "deprecated":false
+    },
+    "Sendmail-8.23":{
+        "deprecated":false
+    },
+    "SimPL-2.0":{
+        "deprecated":false
+    },
+    "Sleepycat":{
+        "deprecated":false
+    },
+    "Spencer-86":{
+        "deprecated":false
+    },
+    "Spencer-94":{
+        "deprecated":false
+    },
+    "Spencer-99":{
+        "deprecated":false
+    },
+    "StandardML-NJ":{
+        "deprecated":true
+    },
+    "SugarCRM-1.1.3":{
+        "deprecated":false
+    },
+    "TCL":{
+        "deprecated":false
+    },
+    "TCP-wrappers":{
+        "deprecated":false
+    },
+    "TMate":{
+        "deprecated":false
+    },
+    "TORQUE-1.1":{
+        "deprecated":false
+    },
+    "TOSL":{
+        "deprecated":false
+    },
+    "TU-Berlin-1.0":{
+        "deprecated":false
+    },
+    "TU-Berlin-2.0":{
+        "deprecated":false
+    },
+    "UPL-1.0":{
+        "deprecated":false
+    },
+    "Unicode-DFS-2015":{
+        "deprecated":false
+    },
+    "Unicode-DFS-2016":{
+        "deprecated":false
+    },
+    "Unicode-TOU":{
+        "deprecated":false
+    },
+    "Unlicense":{
+        "deprecated":false
+    },
+    "VOSTROM":{
+        "deprecated":false
+    },
+    "VSL-1.0":{
+        "deprecated":false
+    },
+    "Vim":{
+        "deprecated":false
+    },
+    "W3C":{
+        "deprecated":false
+    },
+    "W3C-19980720":{
+        "deprecated":false
+    },
+    "W3C-20150513":{
+        "deprecated":false
+    },
+    "WTFPL":{
+        "deprecated":false
+    },
+    "Watcom-1.0":{
+        "deprecated":false
+    },
+    "Wsuipa":{
+        "deprecated":false
+    },
+    "X11":{
+        "deprecated":false
+    },
+    "XFree86-1.1":{
+        "deprecated":false
+    },
+    "XSkat":{
+        "deprecated":false
+    },
+    "Xerox":{
+        "deprecated":false
+    },
+    "Xnet":{
+        "deprecated":false
+    },
+    "YPL-1.0":{
+        "deprecated":false
+    },
+    "YPL-1.1":{
+        "deprecated":false
+    },
+    "ZPL-1.1":{
+        "deprecated":false
+    },
+    "ZPL-2.0":{
+        "deprecated":false
+    },
+    "ZPL-2.1":{
+        "deprecated":false
+    },
+    "Zed":{
+        "deprecated":false
+    },
+    "Zend-2.0":{
+        "deprecated":false
+    },
+    "Zimbra-1.3":{
+        "deprecated":false
+    },
+    "Zimbra-1.4":{
+        "deprecated":false
+    },
+    "Zlib":{
+        "deprecated":false
+    },
+    "bzip2-1.0.5":{
+        "deprecated":false
+    },
+    "bzip2-1.0.6":{
+        "deprecated":false
+    },
+    "copyleft-next-0.3.1":{
+        "deprecated":false
+    },
+    "curl":{
+        "deprecated":false
+    },
+    "diffmark":{
+        "deprecated":false
+    },
+    "dvipdfm":{
+        "deprecated":false
+    },
+    "eCos-2.0":{
+        "deprecated":true
+    },
+    "eGenix":{
+        "deprecated":false
+    },
+    "gSOAP-1.3b":{
+        "deprecated":false
+    },
+    "gnuplot":{
+        "deprecated":false
+    },
+    "iMatix":{
+        "deprecated":false
+    },
+    "libtiff":{
+        "deprecated":false
+    },
+    "mpich2":{
+        "deprecated":false
+    },
+    "psfrag":{
+        "deprecated":false
+    },
+    "psutils":{
+        "deprecated":false
+    },
+    "wxWindows":{
+        "deprecated":true
+    },
+    "xinetd":{
+        "deprecated":false
+    },
+    "xpp":{
+        "deprecated":false
+    },
+    "zlib-acknowledgement":{
+        "deprecated":false
     }
-  ],
-  "releaseDate": "2018-08-23"
 }

--- a/ansible_galaxy/data/spdx_licenses.py
+++ b/ansible_galaxy/data/spdx_licenses.py
@@ -1,0 +1,31 @@
+import json
+import logging
+import os
+
+log = logging.getLogger(__name__)
+
+# use get_spdx() to ref the spdx_license info, so it
+# only loaded from disk once
+_SPDX_LICENSES = None
+
+
+def load_spdx():
+    cwd = os.path.dirname(os.path.abspath(__file__))
+    license_path = os.path.join(cwd, '..', 'data', 'spdx_licenses.json')
+    try:
+        with open(license_path, 'r') as fo:
+            return json.load(fo)
+    except EnvironmentError as exc:
+        log.warning('Unable to open %s to load the list of acceptable open source licenses: %s',
+                    license_path, exc)
+        log.exception(exc)
+        return {}
+
+
+def get_spdx():
+    global _SPDX_LICENSES
+
+    if not _SPDX_LICENSES:
+        _SPDX_LICENSES = load_spdx()
+
+    return _SPDX_LICENSES

--- a/data/spdx_licenses.json
+++ b/data/spdx_licenses.json
@@ -1,0 +1,4730 @@
+{
+  "licenseListVersion": "v3.1-67-geb2589b",
+  "licenses": [
+    {
+      "reference": "./0BSD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/0BSD.json",
+      "referenceNumber": "1",
+      "name": "BSD Zero Clause License",
+      "licenseId": "0BSD",
+      "seeAlso": [
+        "http://landley.net/toybox/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./AAL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/AAL.json",
+      "referenceNumber": "2",
+      "name": "Attribution Assurance License",
+      "licenseId": "AAL",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/attribution"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./ADSL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/ADSL.json",
+      "referenceNumber": "3",
+      "name": "Amazon Digital Services License",
+      "licenseId": "ADSL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/AmazonDigitalServicesLicense"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./AFL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/AFL-1.1.json",
+      "referenceNumber": "4",
+      "name": "Academic Free License v1.1",
+      "licenseId": "AFL-1.1",
+      "seeAlso": [
+        "http://opensource.linux-mirror.org/licenses/afl-1.1.txt",
+        "http://wayback.archive.org/web/20021004124254/http://www.opensource.org/licenses/academic.php"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./AFL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/AFL-1.2.json",
+      "referenceNumber": "5",
+      "name": "Academic Free License v1.2",
+      "licenseId": "AFL-1.2",
+      "seeAlso": [
+        "http://opensource.linux-mirror.org/licenses/afl-1.2.txt",
+        "http://wayback.archive.org/web/20021204204652/http://www.opensource.org/licenses/academic.php"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./AFL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/AFL-2.0.json",
+      "referenceNumber": "6",
+      "name": "Academic Free License v2.0",
+      "licenseId": "AFL-2.0",
+      "seeAlso": [
+        "http://wayback.archive.org/web/20060924134533/http://www.opensource.org/licenses/afl-2.0.txt"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./AFL-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/AFL-2.1.json",
+      "referenceNumber": "7",
+      "name": "Academic Free License v2.1",
+      "licenseId": "AFL-2.1",
+      "seeAlso": [
+        "http://opensource.linux-mirror.org/licenses/afl-2.1.txt"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./AFL-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/AFL-3.0.json",
+      "referenceNumber": "8",
+      "name": "Academic Free License v3.0",
+      "licenseId": "AFL-3.0",
+      "seeAlso": [
+        "http://www.rosenlaw.com/AFL3.0.htm",
+        "http://www.opensource.org/licenses/afl-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./AGPL-1.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/AGPL-1.0-only.json",
+      "referenceNumber": "9",
+      "name": "Affero General Public License v1.0 only",
+      "licenseId": "AGPL-1.0-only",
+      "seeAlso": [
+        "http://www.affero.org/oagpl.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./AGPL-1.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/AGPL-1.0-or-later.json",
+      "referenceNumber": "10",
+      "name": "Affero General Public License v1.0 or later",
+      "licenseId": "AGPL-1.0-or-later",
+      "seeAlso": [
+        "http://www.affero.org/oagpl.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./AGPL-3.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/AGPL-3.0-only.json",
+      "referenceNumber": "11",
+      "name": "GNU Affero General Public License v3.0 only",
+      "licenseId": "AGPL-3.0-only",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/agpl.txt",
+        "http://www.opensource.org/licenses/AGPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./AGPL-3.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/AGPL-3.0-or-later.json",
+      "referenceNumber": "12",
+      "name": "GNU Affero General Public License v3.0 or later",
+      "licenseId": "AGPL-3.0-or-later",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/agpl.txt",
+        "http://www.opensource.org/licenses/AGPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./AMDPLPA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/AMDPLPA.json",
+      "referenceNumber": "13",
+      "name": "AMD\u0027s plpa_map.c License",
+      "licenseId": "AMDPLPA",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/AMD_plpa_map_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./AML.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/AML.json",
+      "referenceNumber": "14",
+      "name": "Apple MIT License",
+      "licenseId": "AML",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Apple_MIT_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./AMPAS.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/AMPAS.json",
+      "referenceNumber": "15",
+      "name": "Academy of Motion Picture Arts and Sciences BSD",
+      "licenseId": "AMPAS",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/BSD#AMPASBSD"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./ANTLR-PD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/ANTLR-PD.json",
+      "referenceNumber": "16",
+      "name": "ANTLR Software Rights Notice",
+      "licenseId": "ANTLR-PD",
+      "seeAlso": [
+        "http://www.antlr2.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./APAFML.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/APAFML.json",
+      "referenceNumber": "17",
+      "name": "Adobe Postscript AFM License",
+      "licenseId": "APAFML",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/AdobePostscriptAFM"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./APL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/APL-1.0.json",
+      "referenceNumber": "18",
+      "name": "Adaptive Public License 1.0",
+      "licenseId": "APL-1.0",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/APL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./APSL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/APSL-1.0.json",
+      "referenceNumber": "19",
+      "name": "Apple Public Source License 1.0",
+      "licenseId": "APSL-1.0",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Apple_Public_Source_License_1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./APSL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/APSL-1.1.json",
+      "referenceNumber": "20",
+      "name": "Apple Public Source License 1.1",
+      "licenseId": "APSL-1.1",
+      "seeAlso": [
+        "http://www.opensource.apple.com/source/IOSerialFamily/IOSerialFamily-7/APPLE_LICENSE"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./APSL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/APSL-1.2.json",
+      "referenceNumber": "21",
+      "name": "Apple Public Source License 1.2",
+      "licenseId": "APSL-1.2",
+      "seeAlso": [
+        "http://www.samurajdata.se/opensource/mirror/licenses/apsl.php"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./APSL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/APSL-2.0.json",
+      "referenceNumber": "22",
+      "name": "Apple Public Source License 2.0",
+      "licenseId": "APSL-2.0",
+      "seeAlso": [
+        "http://www.opensource.apple.com/license/apsl/"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Abstyles.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Abstyles.json",
+      "referenceNumber": "23",
+      "name": "Abstyles License",
+      "licenseId": "Abstyles",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Abstyles"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Adobe-2006.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Adobe-2006.json",
+      "referenceNumber": "24",
+      "name": "Adobe Systems Incorporated Source Code License Agreement",
+      "licenseId": "Adobe-2006",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/AdobeLicense"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Adobe-Glyph.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Adobe-Glyph.json",
+      "referenceNumber": "25",
+      "name": "Adobe Glyph List License",
+      "licenseId": "Adobe-Glyph",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT#AdobeGlyph"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Afmparse.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Afmparse.json",
+      "referenceNumber": "26",
+      "name": "Afmparse License",
+      "licenseId": "Afmparse",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Afmparse"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Aladdin.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Aladdin.json",
+      "referenceNumber": "27",
+      "name": "Aladdin Free Public License",
+      "licenseId": "Aladdin",
+      "seeAlso": [
+        "http://pages.cs.wisc.edu/~ghost/doc/AFPL/6.01/Public.htm"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Apache-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Apache-1.0.json",
+      "referenceNumber": "28",
+      "name": "Apache License 1.0",
+      "licenseId": "Apache-1.0",
+      "seeAlso": [
+        "http://www.apache.org/licenses/LICENSE-1.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Apache-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Apache-1.1.json",
+      "referenceNumber": "29",
+      "name": "Apache License 1.1",
+      "licenseId": "Apache-1.1",
+      "seeAlso": [
+        "http://apache.org/licenses/LICENSE-1.1",
+        "http://opensource.org/licenses/Apache-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Apache-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Apache-2.0.json",
+      "referenceNumber": "30",
+      "name": "Apache License 2.0",
+      "licenseId": "Apache-2.0",
+      "seeAlso": [
+        "http://www.apache.org/licenses/LICENSE-2.0",
+        "http://www.opensource.org/licenses/Apache-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Artistic-1.0-Perl.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Artistic-1.0-Perl.json",
+      "referenceNumber": "31",
+      "name": "Artistic License 1.0 (Perl)",
+      "licenseId": "Artistic-1.0-Perl",
+      "seeAlso": [
+        "http://dev.perl.org/licenses/artistic.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Artistic-1.0-cl8.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Artistic-1.0-cl8.json",
+      "referenceNumber": "32",
+      "name": "Artistic License 1.0 w/clause 8",
+      "licenseId": "Artistic-1.0-cl8",
+      "seeAlso": [
+        "http://opensource.org/licenses/Artistic-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Artistic-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Artistic-1.0.json",
+      "referenceNumber": "33",
+      "name": "Artistic License 1.0",
+      "licenseId": "Artistic-1.0",
+      "seeAlso": [
+        "http://opensource.org/licenses/Artistic-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Artistic-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Artistic-2.0.json",
+      "referenceNumber": "34",
+      "name": "Artistic License 2.0",
+      "licenseId": "Artistic-2.0",
+      "seeAlso": [
+        "http://www.perlfoundation.org/artistic_license_2_0",
+        "http://www.opensource.org/licenses/artistic-license-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./BSD-1-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/BSD-1-Clause.json",
+      "referenceNumber": "35",
+      "name": "BSD 1-Clause License",
+      "licenseId": "BSD-1-Clause",
+      "seeAlso": [
+        "https://svnweb.freebsd.org/base/head/include/ifaddrs.h?revision\u003d326823"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-2-Clause-FreeBSD.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-FreeBSD.json",
+      "referenceNumber": "36",
+      "name": "BSD 2-Clause FreeBSD License",
+      "licenseId": "BSD-2-Clause-FreeBSD",
+      "seeAlso": [
+        "http://www.freebsd.org/copyright/freebsd-license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-2-Clause-NetBSD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-NetBSD.json",
+      "referenceNumber": "37",
+      "name": "BSD 2-Clause NetBSD License",
+      "licenseId": "BSD-2-Clause-NetBSD",
+      "seeAlso": [
+        "http://www.netbsd.org/about/redistribution.html#default"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-2-Clause-Patent.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-Patent.json",
+      "referenceNumber": "38",
+      "name": "BSD-2-Clause Plus Patent License",
+      "licenseId": "BSD-2-Clause-Patent",
+      "seeAlso": [
+        "https://opensource.org/licenses/BSDplusPatent"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./BSD-2-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause.json",
+      "referenceNumber": "39",
+      "name": "BSD 2-Clause \"Simplified\" License",
+      "licenseId": "BSD-2-Clause",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/BSD-2-Clause"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./BSD-3-Clause-Attribution.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-Attribution.json",
+      "referenceNumber": "40",
+      "name": "BSD with attribution",
+      "licenseId": "BSD-3-Clause-Attribution",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/BSD_with_Attribution"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-3-Clause-Clear.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-Clear.json",
+      "referenceNumber": "41",
+      "name": "BSD 3-Clause Clear License",
+      "licenseId": "BSD-3-Clause-Clear",
+      "seeAlso": [
+        "http://labs.metacarta.com/license-explanation.html#license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-3-Clause-LBNL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-LBNL.json",
+      "referenceNumber": "42",
+      "name": "Lawrence Berkeley National Labs BSD variant license",
+      "licenseId": "BSD-3-Clause-LBNL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/LBNLBSD"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-3-Clause-No-Nuclear-License-2014.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.json",
+      "referenceNumber": "43",
+      "name": "BSD 3-Clause No Nuclear License 2014",
+      "licenseId": "BSD-3-Clause-No-Nuclear-License-2014",
+      "seeAlso": [
+        "https://java.net/projects/javaeetutorial/pages/BerkeleyLicense"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-3-Clause-No-Nuclear-License.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.json",
+      "referenceNumber": "44",
+      "name": "BSD 3-Clause No Nuclear License",
+      "licenseId": "BSD-3-Clause-No-Nuclear-License",
+      "seeAlso": [
+        "http://download.oracle.com/otn-pub/java/licenses/bsd.txt?AuthParam\u003d1467140197_43d516ce1776bd08a58235a7785be1cc"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-3-Clause-No-Nuclear-Warranty.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.json",
+      "referenceNumber": "45",
+      "name": "BSD 3-Clause No Nuclear Warranty",
+      "licenseId": "BSD-3-Clause-No-Nuclear-Warranty",
+      "seeAlso": [
+        "https://jogamp.org/git/?p\u003dgluegen.git;a\u003dblob_plain;f\u003dLICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-3-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause.json",
+      "referenceNumber": "46",
+      "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+      "licenseId": "BSD-3-Clause",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/BSD-3-Clause"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./BSD-4-Clause-UC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/BSD-4-Clause-UC.json",
+      "referenceNumber": "47",
+      "name": "BSD-4-Clause (University of California-Specific)",
+      "licenseId": "BSD-4-Clause-UC",
+      "seeAlso": [
+        "http://www.freebsd.org/copyright/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-4-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/BSD-4-Clause.json",
+      "referenceNumber": "48",
+      "name": "BSD 4-Clause \"Original\" or \"Old\" License",
+      "licenseId": "BSD-4-Clause",
+      "seeAlso": [
+        "http://directory.fsf.org/wiki/License:BSD_4Clause"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-Protection.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/BSD-Protection.json",
+      "referenceNumber": "49",
+      "name": "BSD Protection License",
+      "licenseId": "BSD-Protection",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/BSD_Protection_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-Source-Code.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/BSD-Source-Code.json",
+      "referenceNumber": "50",
+      "name": "BSD Source Code Attribution",
+      "licenseId": "BSD-Source-Code",
+      "seeAlso": [
+        "https://github.com/robbiehanson/CocoaHTTPServer/blob/master/LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/BSL-1.0.json",
+      "referenceNumber": "51",
+      "name": "Boost Software License 1.0",
+      "licenseId": "BSL-1.0",
+      "seeAlso": [
+        "http://www.boost.org/LICENSE_1_0.txt",
+        "http://www.opensource.org/licenses/BSL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Bahyph.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Bahyph.json",
+      "referenceNumber": "52",
+      "name": "Bahyph License",
+      "licenseId": "Bahyph",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Bahyph"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Barr.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Barr.json",
+      "referenceNumber": "53",
+      "name": "Barr License",
+      "licenseId": "Barr",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Barr"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Beerware.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Beerware.json",
+      "referenceNumber": "54",
+      "name": "Beerware License",
+      "licenseId": "Beerware",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Beerware",
+        "https://people.freebsd.org/~phk/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BitTorrent-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/BitTorrent-1.0.json",
+      "referenceNumber": "55",
+      "name": "BitTorrent Open Source License v1.0",
+      "licenseId": "BitTorrent-1.0",
+      "seeAlso": [
+        "http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/licenses/BitTorrent?r1\u003d1.1\u0026r2\u003d1.1.1.1\u0026diff_format\u003ds"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BitTorrent-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/BitTorrent-1.1.json",
+      "referenceNumber": "56",
+      "name": "BitTorrent Open Source License v1.1",
+      "licenseId": "BitTorrent-1.1",
+      "seeAlso": [
+        "http://directory.fsf.org/wiki/License:BitTorrentOSL1.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Borceux.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Borceux.json",
+      "referenceNumber": "57",
+      "name": "Borceux license",
+      "licenseId": "Borceux",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Borceux"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CATOSL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CATOSL-1.1.json",
+      "referenceNumber": "58",
+      "name": "Computer Associates Trusted Open Source License 1.1",
+      "licenseId": "CATOSL-1.1",
+      "seeAlso": [
+        "http://opensource.org/licenses/CATOSL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./CC-BY-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-1.0.json",
+      "referenceNumber": "59",
+      "name": "Creative Commons Attribution 1.0 Generic",
+      "licenseId": "CC-BY-1.0",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-2.0.json",
+      "referenceNumber": "60",
+      "name": "Creative Commons Attribution 2.0 Generic",
+      "licenseId": "CC-BY-2.0",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by/2.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-2.5.json",
+      "referenceNumber": "61",
+      "name": "Creative Commons Attribution 2.5 Generic",
+      "licenseId": "CC-BY-2.5",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by/2.5/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-3.0.json",
+      "referenceNumber": "62",
+      "name": "Creative Commons Attribution 3.0 Unported",
+      "licenseId": "CC-BY-3.0",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by/3.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-4.0.json",
+      "referenceNumber": "63",
+      "name": "Creative Commons Attribution 4.0 International",
+      "licenseId": "CC-BY-4.0",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by/4.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-1.0.json",
+      "referenceNumber": "64",
+      "name": "Creative Commons Attribution Non Commercial 1.0 Generic",
+      "licenseId": "CC-BY-NC-1.0",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-nc/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-2.0.json",
+      "referenceNumber": "65",
+      "name": "Creative Commons Attribution Non Commercial 2.0 Generic",
+      "licenseId": "CC-BY-NC-2.0",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-nc/2.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-2.5.json",
+      "referenceNumber": "66",
+      "name": "Creative Commons Attribution Non Commercial 2.5 Generic",
+      "licenseId": "CC-BY-NC-2.5",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-nc/2.5/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-3.0.json",
+      "referenceNumber": "67",
+      "name": "Creative Commons Attribution Non Commercial 3.0 Unported",
+      "licenseId": "CC-BY-NC-3.0",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-nc/3.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-4.0.json",
+      "referenceNumber": "68",
+      "name": "Creative Commons Attribution Non Commercial 4.0 International",
+      "licenseId": "CC-BY-NC-4.0",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-nc/4.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-ND-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-1.0.json",
+      "referenceNumber": "69",
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
+      "licenseId": "CC-BY-NC-ND-1.0",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-nd-nc/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-ND-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-2.0.json",
+      "referenceNumber": "70",
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
+      "licenseId": "CC-BY-NC-ND-2.0",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-nc-nd/2.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-ND-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-2.5.json",
+      "referenceNumber": "71",
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
+      "licenseId": "CC-BY-NC-ND-2.5",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-nc-nd/2.5/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-ND-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-3.0.json",
+      "referenceNumber": "72",
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
+      "licenseId": "CC-BY-NC-ND-3.0",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-ND-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-4.0.json",
+      "referenceNumber": "73",
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
+      "licenseId": "CC-BY-NC-ND-4.0",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-nc-nd/4.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-SA-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-1.0.json",
+      "referenceNumber": "74",
+      "name": "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
+      "licenseId": "CC-BY-NC-SA-1.0",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-nc-sa/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-SA-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-2.0.json",
+      "referenceNumber": "75",
+      "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
+      "licenseId": "CC-BY-NC-SA-2.0",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-nc-sa/2.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-SA-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-2.5.json",
+      "referenceNumber": "76",
+      "name": "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
+      "licenseId": "CC-BY-NC-SA-2.5",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-nc-sa/2.5/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-SA-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-3.0.json",
+      "referenceNumber": "77",
+      "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported",
+      "licenseId": "CC-BY-NC-SA-3.0",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-nc-sa/3.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-SA-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-4.0.json",
+      "referenceNumber": "78",
+      "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
+      "licenseId": "CC-BY-NC-SA-4.0",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-nc-sa/4.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-ND-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-1.0.json",
+      "referenceNumber": "79",
+      "name": "Creative Commons Attribution No Derivatives 1.0 Generic",
+      "licenseId": "CC-BY-ND-1.0",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-nd/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-ND-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-2.0.json",
+      "referenceNumber": "80",
+      "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
+      "licenseId": "CC-BY-ND-2.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nd/2.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-ND-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-2.5.json",
+      "referenceNumber": "81",
+      "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
+      "licenseId": "CC-BY-ND-2.5",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-nd/2.5/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-ND-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-3.0.json",
+      "referenceNumber": "82",
+      "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
+      "licenseId": "CC-BY-ND-3.0",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-nd/3.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-ND-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-4.0.json",
+      "referenceNumber": "83",
+      "name": "Creative Commons Attribution No Derivatives 4.0 International",
+      "licenseId": "CC-BY-ND-4.0",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-nd/4.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-SA-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-1.0.json",
+      "referenceNumber": "84",
+      "name": "Creative Commons Attribution Share Alike 1.0 Generic",
+      "licenseId": "CC-BY-SA-1.0",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-sa/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-SA-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-2.0.json",
+      "referenceNumber": "85",
+      "name": "Creative Commons Attribution Share Alike 2.0 Generic",
+      "licenseId": "CC-BY-SA-2.0",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-sa/2.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-SA-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-2.5.json",
+      "referenceNumber": "86",
+      "name": "Creative Commons Attribution Share Alike 2.5 Generic",
+      "licenseId": "CC-BY-SA-2.5",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-sa/2.5/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-SA-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-3.0.json",
+      "referenceNumber": "87",
+      "name": "Creative Commons Attribution Share Alike 3.0 Unported",
+      "licenseId": "CC-BY-SA-3.0",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-sa/3.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-SA-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-4.0.json",
+      "referenceNumber": "88",
+      "name": "Creative Commons Attribution Share Alike 4.0 International",
+      "licenseId": "CC-BY-SA-4.0",
+      "seeAlso": [
+        "http://creativecommons.org/licenses/by-sa/4.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC0-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/CC0-1.0.json",
+      "referenceNumber": "89",
+      "name": "Creative Commons Zero v1.0 Universal",
+      "licenseId": "CC0-1.0",
+      "seeAlso": [
+        "http://creativecommons.org/publicdomain/zero/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CDDL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/CDDL-1.0.json",
+      "referenceNumber": "90",
+      "name": "Common Development and Distribution License 1.0",
+      "licenseId": "CDDL-1.0",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/cddl1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./CDDL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CDDL-1.1.json",
+      "referenceNumber": "91",
+      "name": "Common Development and Distribution License 1.1",
+      "licenseId": "CDDL-1.1",
+      "seeAlso": [
+        "http://glassfish.java.net/public/CDDL+GPL_1_1.html",
+        "https://javaee.github.io/glassfish/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CDLA-Permissive-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CDLA-Permissive-1.0.json",
+      "referenceNumber": "92",
+      "name": "Community Data License Agreement Permissive 1.0",
+      "licenseId": "CDLA-Permissive-1.0",
+      "seeAlso": [
+        "https://cdla.io/permissive-1-0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CDLA-Sharing-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CDLA-Sharing-1.0.json",
+      "referenceNumber": "93",
+      "name": "Community Data License Agreement Sharing 1.0",
+      "licenseId": "CDLA-Sharing-1.0",
+      "seeAlso": [
+        "https://cdla.io/sharing-1-0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CECILL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CECILL-1.0.json",
+      "referenceNumber": "94",
+      "name": "CeCILL Free Software License Agreement v1.0",
+      "licenseId": "CECILL-1.0",
+      "seeAlso": [
+        "http://www.cecill.info/licences/Licence_CeCILL_V1-fr.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CECILL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CECILL-1.1.json",
+      "referenceNumber": "95",
+      "name": "CeCILL Free Software License Agreement v1.1",
+      "licenseId": "CECILL-1.1",
+      "seeAlso": [
+        "http://www.cecill.info/licences/Licence_CeCILL_V1.1-US.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CECILL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/CECILL-2.0.json",
+      "referenceNumber": "96",
+      "name": "CeCILL Free Software License Agreement v2.0",
+      "licenseId": "CECILL-2.0",
+      "seeAlso": [
+        "http://www.cecill.info/licences/Licence_CeCILL_V2-en.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CECILL-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CECILL-2.1.json",
+      "referenceNumber": "97",
+      "name": "CeCILL Free Software License Agreement v2.1",
+      "licenseId": "CECILL-2.1",
+      "seeAlso": [
+        "http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./CECILL-B.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/CECILL-B.json",
+      "referenceNumber": "98",
+      "name": "CeCILL-B Free Software License Agreement",
+      "licenseId": "CECILL-B",
+      "seeAlso": [
+        "http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CECILL-C.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/CECILL-C.json",
+      "referenceNumber": "99",
+      "name": "CeCILL-C Free Software License Agreement",
+      "licenseId": "CECILL-C",
+      "seeAlso": [
+        "http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.html\n    "
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CNRI-Jython.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CNRI-Jython.json",
+      "referenceNumber": "100",
+      "name": "CNRI Jython License",
+      "licenseId": "CNRI-Jython",
+      "seeAlso": [
+        "http://www.jython.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CNRI-Python-GPL-Compatible.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CNRI-Python-GPL-Compatible.json",
+      "referenceNumber": "101",
+      "name": "CNRI Python Open Source GPL Compatible License Agreement",
+      "licenseId": "CNRI-Python-GPL-Compatible",
+      "seeAlso": [
+        "http://www.python.org/download/releases/1.6.1/download_win/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CNRI-Python.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CNRI-Python.json",
+      "referenceNumber": "102",
+      "name": "CNRI Python License",
+      "licenseId": "CNRI-Python",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/CNRI-Python"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./CPAL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/CPAL-1.0.json",
+      "referenceNumber": "103",
+      "name": "Common Public Attribution License 1.0",
+      "licenseId": "CPAL-1.0",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/CPAL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./CPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/CPL-1.0.json",
+      "referenceNumber": "104",
+      "name": "Common Public License 1.0",
+      "licenseId": "CPL-1.0",
+      "seeAlso": [
+        "http://opensource.org/licenses/CPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./CPOL-1.02.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CPOL-1.02.json",
+      "referenceNumber": "105",
+      "name": "Code Project Open License 1.02",
+      "licenseId": "CPOL-1.02",
+      "seeAlso": [
+        "http://www.codeproject.com/info/cpol10.aspx"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CUA-OPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CUA-OPL-1.0.json",
+      "referenceNumber": "106",
+      "name": "CUA Office Public License v1.0",
+      "licenseId": "CUA-OPL-1.0",
+      "seeAlso": [
+        "http://opensource.org/licenses/CUA-OPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Caldera.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Caldera.json",
+      "referenceNumber": "107",
+      "name": "Caldera License",
+      "licenseId": "Caldera",
+      "seeAlso": [
+        "http://www.lemis.com/grog/UNIX/ancient-source-all.pdf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./ClArtistic.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/ClArtistic.json",
+      "referenceNumber": "108",
+      "name": "Clarified Artistic License",
+      "licenseId": "ClArtistic",
+      "seeAlso": [
+        "http://gianluca.dellavedova.org/2011/01/03/clarified-artistic-license/",
+        "http://www.ncftp.com/ncftp/doc/LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Condor-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Condor-1.1.json",
+      "referenceNumber": "109",
+      "name": "Condor Public License v1.1",
+      "licenseId": "Condor-1.1",
+      "seeAlso": [
+        "http://research.cs.wisc.edu/condor/license.html#condor",
+        "http://web.archive.org/web/20111123062036/http://research.cs.wisc.edu/condor/license.html#condor"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Crossword.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Crossword.json",
+      "referenceNumber": "110",
+      "name": "Crossword License",
+      "licenseId": "Crossword",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Crossword"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CrystalStacker.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CrystalStacker.json",
+      "referenceNumber": "111",
+      "name": "CrystalStacker License",
+      "licenseId": "CrystalStacker",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:CrystalStacker?rd\u003dLicensing/CrystalStacker"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Cube.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Cube.json",
+      "referenceNumber": "112",
+      "name": "Cube License",
+      "licenseId": "Cube",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Cube"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./D-FSL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/D-FSL-1.0.json",
+      "referenceNumber": "113",
+      "name": "Deutsche Freie Software Lizenz",
+      "licenseId": "D-FSL-1.0",
+      "seeAlso": [
+        "http://www.dipp.nrw.de/d-fsl/lizenzen/",
+        "http://www.dipp.nrw.de/d-fsl/index_html/lizenzen/de/D-FSL-1_0_de.txt",
+        "http://www.dipp.nrw.de/d-fsl/index_html/lizenzen/en/D-FSL-1_0_en.txt",
+        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl",
+        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl/deutsche-freie-software-lizenz",
+        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl/german-free-software-license",
+        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl/D-FSL-1_0_de.txt/at_download/file",
+        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl/D-FSL-1_0_en.txt/at_download/file"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./DOC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/DOC.json",
+      "referenceNumber": "114",
+      "name": "DOC License",
+      "licenseId": "DOC",
+      "seeAlso": [
+        "http://www.cs.wustl.edu/~schmidt/ACE-copying.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./DSDP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/DSDP.json",
+      "referenceNumber": "115",
+      "name": "DSDP License",
+      "licenseId": "DSDP",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/DSDP"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Dotseqn.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Dotseqn.json",
+      "referenceNumber": "116",
+      "name": "Dotseqn License",
+      "licenseId": "Dotseqn",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Dotseqn"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./ECL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/ECL-1.0.json",
+      "referenceNumber": "117",
+      "name": "Educational Community License v1.0",
+      "licenseId": "ECL-1.0",
+      "seeAlso": [
+        "http://opensource.org/licenses/ECL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./ECL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/ECL-2.0.json",
+      "referenceNumber": "118",
+      "name": "Educational Community License v2.0",
+      "licenseId": "ECL-2.0",
+      "seeAlso": [
+        "http://opensource.org/licenses/ECL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./EFL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/EFL-1.0.json",
+      "referenceNumber": "119",
+      "name": "Eiffel Forum License v1.0",
+      "licenseId": "EFL-1.0",
+      "seeAlso": [
+        "http://www.eiffel-nice.org/license/forum.txt",
+        "http://opensource.org/licenses/EFL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./EFL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/EFL-2.0.json",
+      "referenceNumber": "120",
+      "name": "Eiffel Forum License v2.0",
+      "licenseId": "EFL-2.0",
+      "seeAlso": [
+        "http://www.eiffel-nice.org/license/eiffel-forum-license-2.html",
+        "http://opensource.org/licenses/EFL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./EPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/EPL-1.0.json",
+      "referenceNumber": "121",
+      "name": "Eclipse Public License 1.0",
+      "licenseId": "EPL-1.0",
+      "seeAlso": [
+        "http://www.eclipse.org/legal/epl-v10.html",
+        "http://www.opensource.org/licenses/EPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./EPL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/EPL-2.0.json",
+      "referenceNumber": "122",
+      "name": "Eclipse Public License 2.0",
+      "licenseId": "EPL-2.0",
+      "seeAlso": [
+        "https://www.eclipse.org/legal/epl-2.0",
+        "https://www.opensource.org/licenses/EPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./EUDatagrid.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/EUDatagrid.json",
+      "referenceNumber": "123",
+      "name": "EU DataGrid Software License",
+      "licenseId": "EUDatagrid",
+      "seeAlso": [
+        "http://eu-datagrid.web.cern.ch/eu-datagrid/license.html",
+        "http://www.opensource.org/licenses/EUDatagrid"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./EUPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/EUPL-1.0.json",
+      "referenceNumber": "124",
+      "name": "European Union Public License 1.0",
+      "licenseId": "EUPL-1.0",
+      "seeAlso": [
+        "http://ec.europa.eu/idabc/en/document/7330.html",
+        "http://ec.europa.eu/idabc/servlets/Doc027f.pdf?id\u003d31096"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./EUPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/EUPL-1.1.json",
+      "referenceNumber": "125",
+      "name": "European Union Public License 1.1",
+      "licenseId": "EUPL-1.1",
+      "seeAlso": [
+        "https://joinup.ec.europa.eu/software/page/eupl/licence-eupl",
+        "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl1.1.-licence-en_0.pdf",
+        "http://www.opensource.org/licenses/EUPL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./EUPL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/EUPL-1.2.json",
+      "referenceNumber": "126",
+      "name": "European Union Public License 1.2",
+      "licenseId": "EUPL-1.2",
+      "seeAlso": [
+        "https://joinup.ec.europa.eu/page/eupl-text-11-12",
+        "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl_v1.2_en.pdf",
+        "https://joinup.ec.europa.eu/sites/default/files/inline-files/EUPL%20v1_2%20EN(1).txt",
+        "http://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri\u003dCELEX:32017D0863",
+        "http://www.opensource.org/licenses/EUPL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Entessa.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Entessa.json",
+      "referenceNumber": "127",
+      "name": "Entessa Public License v1.0",
+      "licenseId": "Entessa",
+      "seeAlso": [
+        "http://opensource.org/licenses/Entessa"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./ErlPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/ErlPL-1.1.json",
+      "referenceNumber": "128",
+      "name": "Erlang Public License v1.1",
+      "licenseId": "ErlPL-1.1",
+      "seeAlso": [
+        "http://www.erlang.org/EPLICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Eurosym.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Eurosym.json",
+      "referenceNumber": "129",
+      "name": "Eurosym License",
+      "licenseId": "Eurosym",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Eurosym"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./FSFAP.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/FSFAP.json",
+      "referenceNumber": "130",
+      "name": "FSF All Permissive License",
+      "licenseId": "FSFAP",
+      "seeAlso": [
+        "http://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./FSFUL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/FSFUL.json",
+      "referenceNumber": "131",
+      "name": "FSF Unlimited License",
+      "licenseId": "FSFUL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./FSFULLR.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/FSFULLR.json",
+      "referenceNumber": "132",
+      "name": "FSF Unlimited License (with License Retention)",
+      "licenseId": "FSFULLR",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License#License_Retention_Variant"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./FTL.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/FTL.json",
+      "referenceNumber": "133",
+      "name": "Freetype Project License",
+      "licenseId": "FTL",
+      "seeAlso": [
+        "http://freetype.fis.uniroma2.it/FTL.TXT",
+        "http://git.savannah.gnu.org/cgit/freetype/freetype2.git/tree/docs/FTL.TXT"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Fair.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Fair.json",
+      "referenceNumber": "134",
+      "name": "Fair License",
+      "licenseId": "Fair",
+      "seeAlso": [
+        "http://fairlicense.org/",
+        "http://www.opensource.org/licenses/Fair"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Frameworx-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Frameworx-1.0.json",
+      "referenceNumber": "135",
+      "name": "Frameworx Open License 1.0",
+      "licenseId": "Frameworx-1.0",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/Frameworx-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./FreeImage.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/FreeImage.json",
+      "referenceNumber": "136",
+      "name": "FreeImage Public License v1.0",
+      "licenseId": "FreeImage",
+      "seeAlso": [
+        "http://freeimage.sourceforge.net/freeimage-license.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.1-only.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-only.json",
+      "referenceNumber": "137",
+      "name": "GNU Free Documentation License v1.1 only",
+      "licenseId": "GFDL-1.1-only",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.1-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-or-later.json",
+      "referenceNumber": "138",
+      "name": "GNU Free Documentation License v1.1 or later",
+      "licenseId": "GFDL-1.1-or-later",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.2-only.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-only.json",
+      "referenceNumber": "139",
+      "name": "GNU Free Documentation License v1.2 only",
+      "licenseId": "GFDL-1.2-only",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.2-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-or-later.json",
+      "referenceNumber": "140",
+      "name": "GNU Free Documentation License v1.2 or later",
+      "licenseId": "GFDL-1.2-or-later",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.3-only.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-only.json",
+      "referenceNumber": "141",
+      "name": "GNU Free Documentation License v1.3 only",
+      "licenseId": "GFDL-1.3-only",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.3-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-or-later.json",
+      "referenceNumber": "142",
+      "name": "GNU Free Documentation License v1.3 or later",
+      "licenseId": "GFDL-1.3-or-later",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GL2PS.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/GL2PS.json",
+      "referenceNumber": "143",
+      "name": "GL2PS License",
+      "licenseId": "GL2PS",
+      "seeAlso": [
+        "http://www.geuz.org/gl2ps/COPYING.GL2PS"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-1.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/GPL-1.0-only.json",
+      "referenceNumber": "144",
+      "name": "GNU General Public License v1.0 only",
+      "licenseId": "GPL-1.0-only",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-1.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/GPL-1.0-or-later.json",
+      "referenceNumber": "145",
+      "name": "GNU General Public License v1.0 or later",
+      "licenseId": "GPL-1.0-or-later",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-2.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-only.json",
+      "referenceNumber": "146",
+      "name": "GNU General Public License v2.0 only",
+      "licenseId": "GPL-2.0-only",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "http://www.opensource.org/licenses/GPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-2.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-or-later.json",
+      "referenceNumber": "147",
+      "name": "GNU General Public License v2.0 or later",
+      "licenseId": "GPL-2.0-or-later",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "http://www.opensource.org/licenses/GPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-3.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-only.json",
+      "referenceNumber": "148",
+      "name": "GNU General Public License v3.0 only",
+      "licenseId": "GPL-3.0-only",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "http://www.opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-3.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-or-later.json",
+      "referenceNumber": "149",
+      "name": "GNU General Public License v3.0 or later",
+      "licenseId": "GPL-3.0-or-later",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "http://www.opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Giftware.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Giftware.json",
+      "referenceNumber": "150",
+      "name": "Giftware License",
+      "licenseId": "Giftware",
+      "seeAlso": [
+        "http://liballeg.org/license.html#allegro-4-the-giftware-license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Glide.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Glide.json",
+      "referenceNumber": "151",
+      "name": "3dfx Glide License",
+      "licenseId": "Glide",
+      "seeAlso": [
+        "http://www.users.on.net/~triforce/glidexp/COPYING.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Glulxe.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Glulxe.json",
+      "referenceNumber": "152",
+      "name": "Glulxe License",
+      "licenseId": "Glulxe",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Glulxe"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./HPND.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/HPND.json",
+      "referenceNumber": "153",
+      "name": "Historical Permission Notice and Disclaimer",
+      "licenseId": "HPND",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/HPND"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./HaskellReport.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/HaskellReport.json",
+      "referenceNumber": "154",
+      "name": "Haskell Language Report License",
+      "licenseId": "HaskellReport",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Haskell_Language_Report_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./IBM-pibs.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/IBM-pibs.json",
+      "referenceNumber": "155",
+      "name": "IBM PowerPC Initialization and Boot Software",
+      "licenseId": "IBM-pibs",
+      "seeAlso": [
+        "http://git.denx.de/?p\u003du-boot.git;a\u003dblob;f\u003darch/powerpc/cpu/ppc4xx/miiphy.c;h\u003d297155fdafa064b955e53e9832de93bfb0cfb85b;hb\u003d9fab4bf4cc077c21e43941866f3f2c196f28670d"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./ICU.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/ICU.json",
+      "referenceNumber": "156",
+      "name": "ICU License",
+      "licenseId": "ICU",
+      "seeAlso": [
+        "http://source.icu-project.org/repos/icu/icu/trunk/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./IJG.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/IJG.json",
+      "referenceNumber": "157",
+      "name": "Independent JPEG Group License",
+      "licenseId": "IJG",
+      "seeAlso": [
+        "http://dev.w3.org/cvsweb/Amaya/libjpeg/Attic/README?rev\u003d1.2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./IPA.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/IPA.json",
+      "referenceNumber": "158",
+      "name": "IPA Font License",
+      "licenseId": "IPA",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/IPA"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./IPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/IPL-1.0.json",
+      "referenceNumber": "159",
+      "name": "IBM Public License v1.0",
+      "licenseId": "IPL-1.0",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/IPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./ISC.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/ISC.json",
+      "referenceNumber": "160",
+      "name": "ISC License",
+      "licenseId": "ISC",
+      "seeAlso": [
+        "https://www.isc.org/downloads/software-support-policy/isc-license/",
+        "http://www.opensource.org/licenses/ISC"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./ImageMagick.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/ImageMagick.json",
+      "referenceNumber": "161",
+      "name": "ImageMagick License",
+      "licenseId": "ImageMagick",
+      "seeAlso": [
+        "http://www.imagemagick.org/script/license.php"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Imlib2.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Imlib2.json",
+      "referenceNumber": "162",
+      "name": "Imlib2 License",
+      "licenseId": "Imlib2",
+      "seeAlso": [
+        "http://trac.enlightenment.org/e/browser/trunk/imlib2/COPYING",
+        "https://git.enlightenment.org/legacy/imlib2.git/tree/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Info-ZIP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Info-ZIP.json",
+      "referenceNumber": "163",
+      "name": "Info-ZIP License",
+      "licenseId": "Info-ZIP",
+      "seeAlso": [
+        "http://www.info-zip.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Intel-ACPI.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Intel-ACPI.json",
+      "referenceNumber": "164",
+      "name": "Intel ACPI Software License Agreement",
+      "licenseId": "Intel-ACPI",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Intel_ACPI_Software_License_Agreement"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Intel.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Intel.json",
+      "referenceNumber": "165",
+      "name": "Intel Open Source License",
+      "licenseId": "Intel",
+      "seeAlso": [
+        "http://opensource.org/licenses/Intel"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Interbase-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Interbase-1.0.json",
+      "referenceNumber": "166",
+      "name": "Interbase Public License v1.0",
+      "licenseId": "Interbase-1.0",
+      "seeAlso": [
+        "https://web.archive.org/web/20060319014854/http://info.borland.com/devsupport/interbase/opensource/IPL.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./JSON.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/JSON.json",
+      "referenceNumber": "167",
+      "name": "JSON License",
+      "licenseId": "JSON",
+      "seeAlso": [
+        "http://www.json.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./JasPer-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/JasPer-2.0.json",
+      "referenceNumber": "168",
+      "name": "JasPer License",
+      "licenseId": "JasPer-2.0",
+      "seeAlso": [
+        "http://www.ece.uvic.ca/~mdadams/jasper/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LAL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LAL-1.2.json",
+      "referenceNumber": "169",
+      "name": "Licence Art Libre 1.2",
+      "licenseId": "LAL-1.2",
+      "seeAlso": [
+        "http://artlibre.org/licence/lal/licence-art-libre-12/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LAL-1.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LAL-1.3.json",
+      "referenceNumber": "170",
+      "name": "Licence Art Libre 1.3",
+      "licenseId": "LAL-1.3",
+      "seeAlso": [
+        "http://artlibre.org/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LGPL-2.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-2.0-only.json",
+      "referenceNumber": "171",
+      "name": "GNU Library General Public License v2 only",
+      "licenseId": "LGPL-2.0-only",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-2.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-2.0-or-later.json",
+      "referenceNumber": "172",
+      "name": "GNU Library General Public License v2 or later",
+      "licenseId": "LGPL-2.0-or-later",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-2.1-only.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-2.1-only.json",
+      "referenceNumber": "173",
+      "name": "GNU Lesser General Public License v2.1 only",
+      "licenseId": "LGPL-2.1-only",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "http://www.opensource.org/licenses/LGPL-2.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-2.1-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-2.1-or-later.json",
+      "referenceNumber": "174",
+      "name": "GNU Lesser General Public License v2.1 or later",
+      "licenseId": "LGPL-2.1-or-later",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "http://www.opensource.org/licenses/LGPL-2.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-3.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-3.0-only.json",
+      "referenceNumber": "175",
+      "name": "GNU Lesser General Public License v3.0 only",
+      "licenseId": "LGPL-3.0-only",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "http://www.opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-3.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-3.0-or-later.json",
+      "referenceNumber": "176",
+      "name": "GNU Lesser General Public License v3.0 or later",
+      "licenseId": "LGPL-3.0-or-later",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "http://www.opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPLLR.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LGPLLR.json",
+      "referenceNumber": "177",
+      "name": "Lesser General Public License For Linguistic Resources",
+      "licenseId": "LGPLLR",
+      "seeAlso": [
+        "http://www-igm.univ-mlv.fr/~unitex/lgpllr.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LPL-1.0.json",
+      "referenceNumber": "178",
+      "name": "Lucent Public License Version 1.0",
+      "licenseId": "LPL-1.0",
+      "seeAlso": [
+        "http://opensource.org/licenses/LPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LPL-1.02.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/LPL-1.02.json",
+      "referenceNumber": "179",
+      "name": "Lucent Public License v1.02",
+      "licenseId": "LPL-1.02",
+      "seeAlso": [
+        "http://plan9.bell-labs.com/plan9/license.html",
+        "http://www.opensource.org/licenses/LPL-1.02"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LPPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LPPL-1.0.json",
+      "referenceNumber": "180",
+      "name": "LaTeX Project Public License v1.0",
+      "licenseId": "LPPL-1.0",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-0.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LPPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LPPL-1.1.json",
+      "referenceNumber": "181",
+      "name": "LaTeX Project Public License v1.1",
+      "licenseId": "LPPL-1.1",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LPPL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/LPPL-1.2.json",
+      "referenceNumber": "182",
+      "name": "LaTeX Project Public License v1.2",
+      "licenseId": "LPPL-1.2",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LPPL-1.3a.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/LPPL-1.3a.json",
+      "referenceNumber": "183",
+      "name": "LaTeX Project Public License v1.3a",
+      "licenseId": "LPPL-1.3a",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-3a.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LPPL-1.3c.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LPPL-1.3c.json",
+      "referenceNumber": "184",
+      "name": "LaTeX Project Public License v1.3c",
+      "licenseId": "LPPL-1.3c",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-3c.txt",
+        "http://www.opensource.org/licenses/LPPL-1.3c"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Latex2e.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Latex2e.json",
+      "referenceNumber": "185",
+      "name": "Latex2e License",
+      "licenseId": "Latex2e",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Latex2e"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Leptonica.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Leptonica.json",
+      "referenceNumber": "186",
+      "name": "Leptonica License",
+      "licenseId": "Leptonica",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Leptonica"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LiLiQ-P-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LiLiQ-P-1.1.json",
+      "referenceNumber": "187",
+      "name": "Licence Libre du Québec – Permissive version 1.1",
+      "licenseId": "LiLiQ-P-1.1",
+      "seeAlso": [
+        "https://forge.gouv.qc.ca/licence/fr/liliq-v1-1/",
+        "http://opensource.org/licenses/LiLiQ-P-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LiLiQ-R-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LiLiQ-R-1.1.json",
+      "referenceNumber": "188",
+      "name": "Licence Libre du Québec – Réciprocité version 1.1",
+      "licenseId": "LiLiQ-R-1.1",
+      "seeAlso": [
+        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-liliq-r-v1-1/",
+        "http://opensource.org/licenses/LiLiQ-R-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LiLiQ-Rplus-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LiLiQ-Rplus-1.1.json",
+      "referenceNumber": "189",
+      "name": "Licence Libre du Québec – Réciprocité forte version 1.1",
+      "licenseId": "LiLiQ-Rplus-1.1",
+      "seeAlso": [
+        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-forte-liliq-r-v1-1/",
+        "http://opensource.org/licenses/LiLiQ-Rplus-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Libpng.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Libpng.json",
+      "referenceNumber": "190",
+      "name": "libpng License",
+      "licenseId": "Libpng",
+      "seeAlso": [
+        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Linux-OpenIB.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Linux-OpenIB.json",
+      "referenceNumber": "191",
+      "name": "Linux Kernel Variant of OpenIB.org license",
+      "licenseId": "Linux-OpenIB",
+      "seeAlso": [
+        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/infiniband/core/sa.h"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MIT-0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MIT-0.json",
+      "referenceNumber": "192",
+      "name": "MIT No Attribution",
+      "licenseId": "MIT-0",
+      "seeAlso": [
+        "https://github.com/aws/mit-0",
+        "https://romanrm.net/mit-zero",
+        "https://github.com/awsdocs/aws-cloud9-user-guide/blob/master/LICENSE-SAMPLECODE"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MIT-CMU.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MIT-CMU.json",
+      "referenceNumber": "193",
+      "name": "CMU License",
+      "licenseId": "MIT-CMU",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:MIT?rd\u003dLicensing/MIT#CMU_Style"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MIT-advertising.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MIT-advertising.json",
+      "referenceNumber": "194",
+      "name": "Enlightenment License (e16)",
+      "licenseId": "MIT-advertising",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT_With_Advertising"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MIT-enna.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MIT-enna.json",
+      "referenceNumber": "195",
+      "name": "enna License",
+      "licenseId": "MIT-enna",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT#enna"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MIT-feh.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MIT-feh.json",
+      "referenceNumber": "196",
+      "name": "feh License",
+      "licenseId": "MIT-feh",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT#feh"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MIT.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/MIT.json",
+      "referenceNumber": "197",
+      "name": "MIT License",
+      "licenseId": "MIT",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/MIT"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MITNFA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MITNFA.json",
+      "referenceNumber": "198",
+      "name": "MIT +no-false-attribs license",
+      "licenseId": "MITNFA",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MITNFA"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MPL-1.0.json",
+      "referenceNumber": "199",
+      "name": "Mozilla Public License 1.0",
+      "licenseId": "MPL-1.0",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/MPL-1.0.html",
+        "http://opensource.org/licenses/MPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/MPL-1.1.json",
+      "referenceNumber": "200",
+      "name": "Mozilla Public License 1.1",
+      "licenseId": "MPL-1.1",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/MPL-1.1.html",
+        "http://www.opensource.org/licenses/MPL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MPL-2.0-no-copyleft-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MPL-2.0-no-copyleft-exception.json",
+      "referenceNumber": "201",
+      "name": "Mozilla Public License 2.0 (no copyleft exception)",
+      "licenseId": "MPL-2.0-no-copyleft-exception",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/2.0/",
+        "http://opensource.org/licenses/MPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MPL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/MPL-2.0.json",
+      "referenceNumber": "202",
+      "name": "Mozilla Public License 2.0",
+      "licenseId": "MPL-2.0",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/2.0/",
+        "http://opensource.org/licenses/MPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MS-PL.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/MS-PL.json",
+      "referenceNumber": "203",
+      "name": "Microsoft Public License",
+      "licenseId": "MS-PL",
+      "seeAlso": [
+        "http://www.microsoft.com/opensource/licenses.mspx",
+        "http://www.opensource.org/licenses/MS-PL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MS-RL.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/MS-RL.json",
+      "referenceNumber": "204",
+      "name": "Microsoft Reciprocal License",
+      "licenseId": "MS-RL",
+      "seeAlso": [
+        "http://www.microsoft.com/opensource/licenses.mspx",
+        "http://www.opensource.org/licenses/MS-RL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MTLL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MTLL.json",
+      "referenceNumber": "205",
+      "name": "Matrix Template Library License",
+      "licenseId": "MTLL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Matrix_Template_Library_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MakeIndex.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MakeIndex.json",
+      "referenceNumber": "206",
+      "name": "MakeIndex License",
+      "licenseId": "MakeIndex",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MakeIndex"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MirOS.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MirOS.json",
+      "referenceNumber": "207",
+      "name": "MirOS License",
+      "licenseId": "MirOS",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/MirOS"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Motosoto.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Motosoto.json",
+      "referenceNumber": "208",
+      "name": "Motosoto License",
+      "licenseId": "Motosoto",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/Motosoto"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Multics.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Multics.json",
+      "referenceNumber": "209",
+      "name": "Multics License",
+      "licenseId": "Multics",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/Multics"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Mup.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Mup.json",
+      "referenceNumber": "210",
+      "name": "Mup License",
+      "licenseId": "Mup",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Mup"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NASA-1.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/NASA-1.3.json",
+      "referenceNumber": "211",
+      "name": "NASA Open Source Agreement 1.3",
+      "licenseId": "NASA-1.3",
+      "seeAlso": [
+        "http://ti.arc.nasa.gov/opensource/nosa/",
+        "http://www.opensource.org/licenses/NASA-1.3"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./NBPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/NBPL-1.0.json",
+      "referenceNumber": "212",
+      "name": "Net Boolean Public License v1",
+      "licenseId": "NBPL-1.0",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d37b4b3f6cc4bf34e1d3dec61e69914b9819d8894"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NCSA.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/NCSA.json",
+      "referenceNumber": "213",
+      "name": "University of Illinois/NCSA Open Source License",
+      "licenseId": "NCSA",
+      "seeAlso": [
+        "http://otm.illinois.edu/uiuc_openSource",
+        "http://www.opensource.org/licenses/NCSA"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./NGPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/NGPL.json",
+      "referenceNumber": "214",
+      "name": "Nethack General Public License",
+      "licenseId": "NGPL",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/NGPL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./NLOD-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/NLOD-1.0.json",
+      "referenceNumber": "215",
+      "name": "Norwegian Licence for Open Government Data",
+      "licenseId": "NLOD-1.0",
+      "seeAlso": [
+        "http://data.norge.no/nlod/en/1.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NLPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/NLPL.json",
+      "referenceNumber": "216",
+      "name": "No Limit Public License",
+      "licenseId": "NLPL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/NLPL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NOSL.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/NOSL.json",
+      "referenceNumber": "217",
+      "name": "Netizen Open Source License",
+      "licenseId": "NOSL",
+      "seeAlso": [
+        "http://bits.netizen.com.au/licenses/NOSL/nosl.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/NPL-1.0.json",
+      "referenceNumber": "218",
+      "name": "Netscape Public License v1.0",
+      "licenseId": "NPL-1.0",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/NPL/1.0/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/NPL-1.1.json",
+      "referenceNumber": "219",
+      "name": "Netscape Public License v1.1",
+      "licenseId": "NPL-1.1",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/NPL/1.1/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NPOSL-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/NPOSL-3.0.json",
+      "referenceNumber": "220",
+      "name": "Non-Profit Open Software License 3.0",
+      "licenseId": "NPOSL-3.0",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/NOSL3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./NRL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/NRL.json",
+      "referenceNumber": "221",
+      "name": "NRL License",
+      "licenseId": "NRL",
+      "seeAlso": [
+        "http://web.mit.edu/network/isakmp/nrllicense.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NTP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/NTP.json",
+      "referenceNumber": "222",
+      "name": "NTP License",
+      "licenseId": "NTP",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/NTP"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Naumen.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Naumen.json",
+      "referenceNumber": "223",
+      "name": "Naumen Public License",
+      "licenseId": "Naumen",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/Naumen"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Net-SNMP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Net-SNMP.json",
+      "referenceNumber": "224",
+      "name": "Net-SNMP License",
+      "licenseId": "Net-SNMP",
+      "seeAlso": [
+        "http://net-snmp.sourceforge.net/about/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NetCDF.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/NetCDF.json",
+      "referenceNumber": "225",
+      "name": "NetCDF license",
+      "licenseId": "NetCDF",
+      "seeAlso": [
+        "http://www.unidata.ucar.edu/software/netcdf/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Newsletr.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Newsletr.json",
+      "referenceNumber": "226",
+      "name": "Newsletr License",
+      "licenseId": "Newsletr",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Newsletr"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Nokia.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Nokia.json",
+      "referenceNumber": "227",
+      "name": "Nokia Open Source License",
+      "licenseId": "Nokia",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/nokia"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Noweb.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Noweb.json",
+      "referenceNumber": "228",
+      "name": "Noweb License",
+      "licenseId": "Noweb",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Noweb"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OCCT-PL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OCCT-PL.json",
+      "referenceNumber": "229",
+      "name": "Open CASCADE Technology Public License",
+      "licenseId": "OCCT-PL",
+      "seeAlso": [
+        "http://www.opencascade.com/content/occt-public-license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OCLC-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OCLC-2.0.json",
+      "referenceNumber": "230",
+      "name": "OCLC Research Public License 2.0",
+      "licenseId": "OCLC-2.0",
+      "seeAlso": [
+        "http://www.oclc.org/research/activities/software/license/v2final.htm",
+        "http://www.opensource.org/licenses/OCLC-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./ODC-By-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/ODC-By-1.0.json",
+      "referenceNumber": "231",
+      "name": "Open Data Commons Attribution License v1.0",
+      "licenseId": "ODC-By-1.0",
+      "seeAlso": [
+        "https://opendatacommons.org/licenses/by/1.0/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./ODbL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/ODbL-1.0.json",
+      "referenceNumber": "232",
+      "name": "ODC Open Database License v1.0",
+      "licenseId": "ODbL-1.0",
+      "seeAlso": [
+        "http://www.opendatacommons.org/licenses/odbl/1.0/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OFL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/OFL-1.0.json",
+      "referenceNumber": "233",
+      "name": "SIL Open Font License 1.0",
+      "licenseId": "OFL-1.0",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL10_web"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OFL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/OFL-1.1.json",
+      "referenceNumber": "234",
+      "name": "SIL Open Font License 1.1",
+      "licenseId": "OFL-1.1",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL_web",
+        "http://www.opensource.org/licenses/OFL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OGTSL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OGTSL.json",
+      "referenceNumber": "235",
+      "name": "Open Group Test Suite License",
+      "licenseId": "OGTSL",
+      "seeAlso": [
+        "http://www.opengroup.org/testing/downloads/The_Open_Group_TSL.txt",
+        "http://www.opensource.org/licenses/OGTSL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OLDAP-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-1.1.json",
+      "referenceNumber": "236",
+      "name": "Open LDAP Public License v1.1",
+      "licenseId": "OLDAP-1.1",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d806557a5ad59804ef3a44d5abfbe91d706b0791f"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-1.2.json",
+      "referenceNumber": "237",
+      "name": "Open LDAP Public License v1.2",
+      "licenseId": "OLDAP-1.2",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d42b0383c50c299977b5893ee695cf4e486fb0dc7"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-1.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-1.3.json",
+      "referenceNumber": "238",
+      "name": "Open LDAP Public License v1.3",
+      "licenseId": "OLDAP-1.3",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003de5f8117f0ce088d0bd7a8e18ddf37eaa40eb09b1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-1.4.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-1.4.json",
+      "referenceNumber": "239",
+      "name": "Open LDAP Public License v1.4",
+      "licenseId": "OLDAP-1.4",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dc9f95c2f3f2ffb5e0ae55fe7388af75547660941"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.0.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.0.1.json",
+      "referenceNumber": "240",
+      "name": "Open LDAP Public License v2.0.1",
+      "licenseId": "OLDAP-2.0.1",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003db6d68acd14e51ca3aab4428bf26522aa74873f0e"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.0.json",
+      "referenceNumber": "241",
+      "name": "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
+      "licenseId": "OLDAP-2.0",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dcbf50f4e1185a21abd4c0a54d3f4341fe28f36ea"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.1.json",
+      "referenceNumber": "242",
+      "name": "Open LDAP Public License v2.1",
+      "licenseId": "OLDAP-2.1",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003db0d176738e96a0d3b9f85cb51e140a86f21be715"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.1.json",
+      "referenceNumber": "243",
+      "name": "Open LDAP Public License v2.2.1",
+      "licenseId": "OLDAP-2.2.1",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d4bc786f34b50aa301be6f5600f58a980070f481e"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.2.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.2.json",
+      "referenceNumber": "244",
+      "name": "Open LDAP Public License 2.2.2",
+      "licenseId": "OLDAP-2.2.2",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003ddf2cc1e21eb7c160695f5b7cffd6296c151ba188"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.json",
+      "referenceNumber": "245",
+      "name": "Open LDAP Public License v2.2",
+      "licenseId": "OLDAP-2.2",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d470b0c18ec67621c85881b2733057fecf4a1acc3"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.3.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.3.json",
+      "referenceNumber": "246",
+      "name": "Open LDAP Public License v2.3",
+      "licenseId": "OLDAP-2.3",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dd32cf54a32d581ab475d23c810b0a7fbaf8d63c3"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.4.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.4.json",
+      "referenceNumber": "247",
+      "name": "Open LDAP Public License v2.4",
+      "licenseId": "OLDAP-2.4",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dcd1284c4a91a8a380d904eee68d1583f989ed386"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.5.json",
+      "referenceNumber": "248",
+      "name": "Open LDAP Public License v2.5",
+      "licenseId": "OLDAP-2.5",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d6852b9d90022e8593c98205413380536b1b5a7cf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.6.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.6.json",
+      "referenceNumber": "249",
+      "name": "Open LDAP Public License v2.6",
+      "licenseId": "OLDAP-2.6",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d1cae062821881f41b73012ba816434897abf4205"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.7.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.7.json",
+      "referenceNumber": "250",
+      "name": "Open LDAP Public License v2.7",
+      "licenseId": "OLDAP-2.7",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d47c2415c1df81556eeb39be6cad458ef87c534a2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.8.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.8.json",
+      "referenceNumber": "251",
+      "name": "Open LDAP Public License v2.8",
+      "licenseId": "OLDAP-2.8",
+      "seeAlso": [
+        "http://www.openldap.org/software/release/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OML.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OML.json",
+      "referenceNumber": "252",
+      "name": "Open Market License",
+      "licenseId": "OML",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Open_Market_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OPL-1.0.json",
+      "referenceNumber": "253",
+      "name": "Open Public License v1.0",
+      "licenseId": "OPL-1.0",
+      "seeAlso": [
+        "http://old.koalateam.com/jackaroo/OPL_1_0.TXT",
+        "https://fedoraproject.org/wiki/Licensing/Open_Public_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OSET-PL-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OSET-PL-2.1.json",
+      "referenceNumber": "254",
+      "name": "OSET Public License version 2.1",
+      "licenseId": "OSET-PL-2.1",
+      "seeAlso": [
+        "http://www.osetfoundation.org/public-license",
+        "http://opensource.org/licenses/OPL-2.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OSL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/OSL-1.0.json",
+      "referenceNumber": "255",
+      "name": "Open Software License 1.0",
+      "licenseId": "OSL-1.0",
+      "seeAlso": [
+        "http://opensource.org/licenses/OSL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OSL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/OSL-1.1.json",
+      "referenceNumber": "256",
+      "name": "Open Software License 1.1",
+      "licenseId": "OSL-1.1",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/OSL1.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OSL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/OSL-2.0.json",
+      "referenceNumber": "257",
+      "name": "Open Software License 2.0",
+      "licenseId": "OSL-2.0",
+      "seeAlso": [
+        "http://web.archive.org/web/20041020171434/http://www.rosenlaw.com/osl2.0.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OSL-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/OSL-2.1.json",
+      "referenceNumber": "258",
+      "name": "Open Software License 2.1",
+      "licenseId": "OSL-2.1",
+      "seeAlso": [
+        "http://web.archive.org/web/20050212003940/http://www.rosenlaw.com/osl21.htm",
+        "http://opensource.org/licenses/OSL-2.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OSL-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/OSL-3.0.json",
+      "referenceNumber": "259",
+      "name": "Open Software License 3.0",
+      "licenseId": "OSL-3.0",
+      "seeAlso": [
+        "http://www.rosenlaw.com/OSL3.0.htm",
+        "http://www.opensource.org/licenses/OSL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OpenSSL.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/OpenSSL.json",
+      "referenceNumber": "260",
+      "name": "OpenSSL License",
+      "licenseId": "OpenSSL",
+      "seeAlso": [
+        "http://www.openssl.org/source/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./PDDL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/PDDL-1.0.json",
+      "referenceNumber": "261",
+      "name": "ODC Public Domain Dedication \u0026 License 1.0",
+      "licenseId": "PDDL-1.0",
+      "seeAlso": [
+        "http://opendatacommons.org/licenses/pddl/1.0/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./PHP-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/PHP-3.0.json",
+      "referenceNumber": "262",
+      "name": "PHP License v3.0",
+      "licenseId": "PHP-3.0",
+      "seeAlso": [
+        "http://www.php.net/license/3_0.txt",
+        "http://www.opensource.org/licenses/PHP-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./PHP-3.01.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/PHP-3.01.json",
+      "referenceNumber": "263",
+      "name": "PHP License v3.01",
+      "licenseId": "PHP-3.01",
+      "seeAlso": [
+        "http://www.php.net/license/3_01.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Plexus.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Plexus.json",
+      "referenceNumber": "264",
+      "name": "Plexus Classworlds License",
+      "licenseId": "Plexus",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Plexus_Classworlds_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./PostgreSQL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/PostgreSQL.json",
+      "referenceNumber": "265",
+      "name": "PostgreSQL License",
+      "licenseId": "PostgreSQL",
+      "seeAlso": [
+        "http://www.postgresql.org/about/licence",
+        "http://www.opensource.org/licenses/PostgreSQL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Python-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Python-2.0.json",
+      "referenceNumber": "266",
+      "name": "Python License 2.0",
+      "licenseId": "Python-2.0",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/Python-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./QPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/QPL-1.0.json",
+      "referenceNumber": "267",
+      "name": "Q Public License 1.0",
+      "licenseId": "QPL-1.0",
+      "seeAlso": [
+        "http://doc.qt.nokia.com/3.3/license.html",
+        "http://www.opensource.org/licenses/QPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Qhull.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Qhull.json",
+      "referenceNumber": "268",
+      "name": "Qhull License",
+      "licenseId": "Qhull",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Qhull"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./RHeCos-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/RHeCos-1.1.json",
+      "referenceNumber": "269",
+      "name": "Red Hat eCos Public License v1.1",
+      "licenseId": "RHeCos-1.1",
+      "seeAlso": [
+        "http://ecos.sourceware.org/old-license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./RPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/RPL-1.1.json",
+      "referenceNumber": "270",
+      "name": "Reciprocal Public License 1.1",
+      "licenseId": "RPL-1.1",
+      "seeAlso": [
+        "http://opensource.org/licenses/RPL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./RPL-1.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/RPL-1.5.json",
+      "referenceNumber": "271",
+      "name": "Reciprocal Public License 1.5",
+      "licenseId": "RPL-1.5",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/RPL-1.5"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./RPSL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/RPSL-1.0.json",
+      "referenceNumber": "272",
+      "name": "RealNetworks Public Source License v1.0",
+      "licenseId": "RPSL-1.0",
+      "seeAlso": [
+        "https://helixcommunity.org/content/rpsl",
+        "http://www.opensource.org/licenses/RPSL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./RSA-MD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/RSA-MD.json",
+      "referenceNumber": "273",
+      "name": "RSA Message-Digest License ",
+      "licenseId": "RSA-MD",
+      "seeAlso": [
+        "http://www.faqs.org/rfcs/rfc1321.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./RSCPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/RSCPL.json",
+      "referenceNumber": "274",
+      "name": "Ricoh Source Code Public License",
+      "licenseId": "RSCPL",
+      "seeAlso": [
+        "http://wayback.archive.org/web/20060715140826/http://www.risource.org/RPL/RPL-1.0A.shtml",
+        "http://www.opensource.org/licenses/RSCPL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Rdisc.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Rdisc.json",
+      "referenceNumber": "275",
+      "name": "Rdisc License",
+      "licenseId": "Rdisc",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Rdisc_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Ruby.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Ruby.json",
+      "referenceNumber": "276",
+      "name": "Ruby License",
+      "licenseId": "Ruby",
+      "seeAlso": [
+        "http://www.ruby-lang.org/en/LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SAX-PD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SAX-PD.json",
+      "referenceNumber": "277",
+      "name": "Sax Public Domain Notice",
+      "licenseId": "SAX-PD",
+      "seeAlso": [
+        "http://www.saxproject.org/copying.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SCEA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SCEA.json",
+      "referenceNumber": "278",
+      "name": "SCEA Shared Source License",
+      "licenseId": "SCEA",
+      "seeAlso": [
+        "http://research.scea.com/scea_shared_source_license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SGI-B-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SGI-B-1.0.json",
+      "referenceNumber": "279",
+      "name": "SGI Free Software License B v1.0",
+      "licenseId": "SGI-B-1.0",
+      "seeAlso": [
+        "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.1.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SGI-B-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SGI-B-1.1.json",
+      "referenceNumber": "280",
+      "name": "SGI Free Software License B v1.1",
+      "licenseId": "SGI-B-1.1",
+      "seeAlso": [
+        "http://oss.sgi.com/projects/FreeB/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SGI-B-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/SGI-B-2.0.json",
+      "referenceNumber": "281",
+      "name": "SGI Free Software License B v2.0",
+      "licenseId": "SGI-B-2.0",
+      "seeAlso": [
+        "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.2.0.pdf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SISSL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SISSL-1.2.json",
+      "referenceNumber": "282",
+      "name": "Sun Industry Standards Source License v1.2",
+      "licenseId": "SISSL-1.2",
+      "seeAlso": [
+        "http://gridscheduler.sourceforge.net/Gridengine_SISSL_license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SISSL.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/SISSL.json",
+      "referenceNumber": "283",
+      "name": "Sun Industry Standards Source License v1.1",
+      "licenseId": "SISSL",
+      "seeAlso": [
+        "http://www.openoffice.org/licenses/sissl_license.html",
+        "http://opensource.org/licenses/SISSL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./SMLNJ.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/SMLNJ.json",
+      "referenceNumber": "284",
+      "name": "Standard ML of New Jersey License",
+      "licenseId": "SMLNJ",
+      "seeAlso": [
+        "https://www.smlnj.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SMPPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SMPPL.json",
+      "referenceNumber": "285",
+      "name": "Secure Messaging Protocol Public License",
+      "licenseId": "SMPPL",
+      "seeAlso": [
+        "https://github.com/dcblake/SMP/blob/master/Documentation/License.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SNIA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SNIA.json",
+      "referenceNumber": "286",
+      "name": "SNIA Public License 1.1",
+      "licenseId": "SNIA",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/SNIA_Public_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/SPL-1.0.json",
+      "referenceNumber": "287",
+      "name": "Sun Public License v1.0",
+      "licenseId": "SPL-1.0",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/SPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./SWL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SWL.json",
+      "referenceNumber": "288",
+      "name": "Scheme Widget Library (SWL) Software License Agreement",
+      "licenseId": "SWL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/SWL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Saxpath.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Saxpath.json",
+      "referenceNumber": "289",
+      "name": "Saxpath License",
+      "licenseId": "Saxpath",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Saxpath_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Sendmail.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Sendmail.json",
+      "referenceNumber": "290",
+      "name": "Sendmail License",
+      "licenseId": "Sendmail",
+      "seeAlso": [
+        "http://www.sendmail.com/pdfs/open_source/sendmail_license.pdf",
+        "https://web.archive.org/web/20160322142305/https://www.sendmail.com/pdfs/open_source/sendmail_license.pdf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SimPL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SimPL-2.0.json",
+      "referenceNumber": "291",
+      "name": "Simple Public License 2.0",
+      "licenseId": "SimPL-2.0",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/SimPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Sleepycat.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Sleepycat.json",
+      "referenceNumber": "292",
+      "name": "Sleepycat License",
+      "licenseId": "Sleepycat",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/Sleepycat"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Spencer-86.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Spencer-86.json",
+      "referenceNumber": "293",
+      "name": "Spencer License 86",
+      "licenseId": "Spencer-86",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Spencer-94.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Spencer-94.json",
+      "referenceNumber": "294",
+      "name": "Spencer License 94",
+      "licenseId": "Spencer-94",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Spencer-99.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Spencer-99.json",
+      "referenceNumber": "295",
+      "name": "Spencer License 99",
+      "licenseId": "Spencer-99",
+      "seeAlso": [
+        "http://www.opensource.apple.com/source/tcl/tcl-5/tcl/generic/regfronts.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SugarCRM-1.1.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SugarCRM-1.1.3.json",
+      "referenceNumber": "296",
+      "name": "SugarCRM Public License v1.1.3",
+      "licenseId": "SugarCRM-1.1.3",
+      "seeAlso": [
+        "http://www.sugarcrm.com/crm/SPL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./TCL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/TCL.json",
+      "referenceNumber": "297",
+      "name": "TCL/TK License",
+      "licenseId": "TCL",
+      "seeAlso": [
+        "http://www.tcl.tk/software/tcltk/license.html",
+        "https://fedoraproject.org/wiki/Licensing/TCL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./TCP-wrappers.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/TCP-wrappers.json",
+      "referenceNumber": "298",
+      "name": "TCP Wrappers License",
+      "licenseId": "TCP-wrappers",
+      "seeAlso": [
+        "http://rc.quest.com/topics/openssh/license.php#tcpwrappers"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./TMate.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/TMate.json",
+      "referenceNumber": "299",
+      "name": "TMate Open Source License",
+      "licenseId": "TMate",
+      "seeAlso": [
+        "http://svnkit.com/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./TORQUE-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/TORQUE-1.1.json",
+      "referenceNumber": "300",
+      "name": "TORQUE v2.5+ Software License v1.1",
+      "licenseId": "TORQUE-1.1",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/TORQUEv1.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./TOSL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/TOSL.json",
+      "referenceNumber": "301",
+      "name": "Trusster Open Source License",
+      "licenseId": "TOSL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/TOSL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./TU-Berlin-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/TU-Berlin-1.0.json",
+      "referenceNumber": "302",
+      "name": "Technische Universitaet Berlin License 1.0",
+      "licenseId": "TU-Berlin-1.0",
+      "seeAlso": [
+        "https://github.com/swh/ladspa/blob/7bf6f3799fdba70fda297c2d8fd9f526803d9680/gsm/COPYRIGHT"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./TU-Berlin-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/TU-Berlin-2.0.json",
+      "referenceNumber": "303",
+      "name": "Technische Universitaet Berlin License 2.0",
+      "licenseId": "TU-Berlin-2.0",
+      "seeAlso": [
+        "https://github.com/CorsixTH/deps/blob/fd339a9f526d1d9c9f01ccf39e438a015da50035/licences/libgsm.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./UPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/UPL-1.0.json",
+      "referenceNumber": "304",
+      "name": "Universal Permissive License v1.0",
+      "licenseId": "UPL-1.0",
+      "seeAlso": [
+        "http://opensource.org/licenses/UPL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Unicode-DFS-2015.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Unicode-DFS-2015.json",
+      "referenceNumber": "305",
+      "name": "Unicode License Agreement - Data Files and Software (2015)",
+      "licenseId": "Unicode-DFS-2015",
+      "seeAlso": [
+        "https://web.archive.org/web/20151224134844/http://unicode.org/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Unicode-DFS-2016.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Unicode-DFS-2016.json",
+      "referenceNumber": "306",
+      "name": "Unicode License Agreement - Data Files and Software (2016)",
+      "licenseId": "Unicode-DFS-2016",
+      "seeAlso": [
+        "http://www.unicode.org/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Unicode-TOU.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Unicode-TOU.json",
+      "referenceNumber": "307",
+      "name": "Unicode Terms of Use",
+      "licenseId": "Unicode-TOU",
+      "seeAlso": [
+        "http://www.unicode.org/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Unlicense.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Unlicense.json",
+      "referenceNumber": "308",
+      "name": "The Unlicense",
+      "licenseId": "Unlicense",
+      "seeAlso": [
+        "http://unlicense.org/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./VOSTROM.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/VOSTROM.json",
+      "referenceNumber": "309",
+      "name": "VOSTROM Public License for Open Source",
+      "licenseId": "VOSTROM",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/VOSTROM"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./VSL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/VSL-1.0.json",
+      "referenceNumber": "310",
+      "name": "Vovida Software License v1.0",
+      "licenseId": "VSL-1.0",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/VSL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Vim.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Vim.json",
+      "referenceNumber": "311",
+      "name": "Vim License",
+      "licenseId": "Vim",
+      "seeAlso": [
+        "http://vimdoc.sourceforge.net/htmldoc/uganda.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./W3C-19980720.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/W3C-19980720.json",
+      "referenceNumber": "312",
+      "name": "W3C Software Notice and License (1998-07-20)",
+      "licenseId": "W3C-19980720",
+      "seeAlso": [
+        "http://www.w3.org/Consortium/Legal/copyright-software-19980720.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./W3C-20150513.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/W3C-20150513.json",
+      "referenceNumber": "313",
+      "name": "W3C Software Notice and Document License (2015-05-13)",
+      "licenseId": "W3C-20150513",
+      "seeAlso": [
+        "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./W3C.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/W3C.json",
+      "referenceNumber": "314",
+      "name": "W3C Software Notice and License (2002-12-31)",
+      "licenseId": "W3C",
+      "seeAlso": [
+        "http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html",
+        "http://www.opensource.org/licenses/W3C"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./WTFPL.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/WTFPL.json",
+      "referenceNumber": "315",
+      "name": "Do What The F*ck You Want To Public License",
+      "licenseId": "WTFPL",
+      "seeAlso": [
+        "http://sam.zoy.org/wtfpl/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Watcom-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Watcom-1.0.json",
+      "referenceNumber": "316",
+      "name": "Sybase Open Watcom Public License 1.0",
+      "licenseId": "Watcom-1.0",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/Watcom-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Wsuipa.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Wsuipa.json",
+      "referenceNumber": "317",
+      "name": "Wsuipa License",
+      "licenseId": "Wsuipa",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Wsuipa"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./X11.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/X11.json",
+      "referenceNumber": "318",
+      "name": "X11 License",
+      "licenseId": "X11",
+      "seeAlso": [
+        "http://www.xfree86.org/3.3.6/COPYRIGHT2.html#3"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./XFree86-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/XFree86-1.1.json",
+      "referenceNumber": "319",
+      "name": "XFree86 License 1.1",
+      "licenseId": "XFree86-1.1",
+      "seeAlso": [
+        "http://www.xfree86.org/current/LICENSE4.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./XSkat.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/XSkat.json",
+      "referenceNumber": "320",
+      "name": "XSkat License",
+      "licenseId": "XSkat",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/XSkat_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Xerox.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Xerox.json",
+      "referenceNumber": "321",
+      "name": "Xerox License",
+      "licenseId": "Xerox",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Xerox"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Xnet.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Xnet.json",
+      "referenceNumber": "322",
+      "name": "X.Net License",
+      "licenseId": "Xnet",
+      "seeAlso": [
+        "http://opensource.org/licenses/Xnet"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./YPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/YPL-1.0.json",
+      "referenceNumber": "323",
+      "name": "Yahoo! Public License v1.0",
+      "licenseId": "YPL-1.0",
+      "seeAlso": [
+        "http://www.zimbra.com/license/yahoo_public_license_1.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./YPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/YPL-1.1.json",
+      "referenceNumber": "324",
+      "name": "Yahoo! Public License v1.1",
+      "licenseId": "YPL-1.1",
+      "seeAlso": [
+        "http://www.zimbra.com/license/yahoo_public_license_1.1.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./ZPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/ZPL-1.1.json",
+      "referenceNumber": "325",
+      "name": "Zope Public License 1.1",
+      "licenseId": "ZPL-1.1",
+      "seeAlso": [
+        "http://old.zope.org/Resources/License/ZPL-1.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./ZPL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/ZPL-2.0.json",
+      "referenceNumber": "326",
+      "name": "Zope Public License 2.0",
+      "licenseId": "ZPL-2.0",
+      "seeAlso": [
+        "http://old.zope.org/Resources/License/ZPL-2.0",
+        "http://opensource.org/licenses/ZPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./ZPL-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/ZPL-2.1.json",
+      "referenceNumber": "327",
+      "name": "Zope Public License 2.1",
+      "licenseId": "ZPL-2.1",
+      "seeAlso": [
+        "http://old.zope.org/Resources/ZPL/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Zed.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Zed.json",
+      "referenceNumber": "328",
+      "name": "Zed License",
+      "licenseId": "Zed",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Zed"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Zend-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Zend-2.0.json",
+      "referenceNumber": "329",
+      "name": "Zend License v2.0",
+      "licenseId": "Zend-2.0",
+      "seeAlso": [
+        "https://web.archive.org/web/20130517195954/http://www.zend.com/license/2_00.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Zimbra-1.3.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Zimbra-1.3.json",
+      "referenceNumber": "330",
+      "name": "Zimbra Public License v1.3",
+      "licenseId": "Zimbra-1.3",
+      "seeAlso": [
+        "http://web.archive.org/web/20100302225219/http://www.zimbra.com/license/zimbra-public-license-1-3.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Zimbra-1.4.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Zimbra-1.4.json",
+      "referenceNumber": "331",
+      "name": "Zimbra Public License v1.4",
+      "licenseId": "Zimbra-1.4",
+      "seeAlso": [
+        "http://www.zimbra.com/legal/zimbra-public-license-1-4"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Zlib.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Zlib.json",
+      "referenceNumber": "332",
+      "name": "zlib License",
+      "licenseId": "Zlib",
+      "seeAlso": [
+        "http://www.zlib.net/zlib_license.html",
+        "http://www.opensource.org/licenses/Zlib"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./bzip2-1.0.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/bzip2-1.0.5.json",
+      "referenceNumber": "333",
+      "name": "bzip2 and libbzip2 License v1.0.5",
+      "licenseId": "bzip2-1.0.5",
+      "seeAlso": [
+        "http://bzip.org/1.0.5/bzip2-manual-1.0.5.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./bzip2-1.0.6.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/bzip2-1.0.6.json",
+      "referenceNumber": "334",
+      "name": "bzip2 and libbzip2 License v1.0.6",
+      "licenseId": "bzip2-1.0.6",
+      "seeAlso": [
+        "https://github.com/asimonov-im/bzip2/blob/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./curl.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/curl.json",
+      "referenceNumber": "335",
+      "name": "curl License",
+      "licenseId": "curl",
+      "seeAlso": [
+        "https://github.com/bagder/curl/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./diffmark.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/diffmark.json",
+      "referenceNumber": "336",
+      "name": "diffmark license",
+      "licenseId": "diffmark",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/diffmark"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./dvipdfm.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/dvipdfm.json",
+      "referenceNumber": "337",
+      "name": "dvipdfm License",
+      "licenseId": "dvipdfm",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/dvipdfm"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./eGenix.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/eGenix.json",
+      "referenceNumber": "338",
+      "name": "eGenix.com Public License 1.1.0",
+      "licenseId": "eGenix",
+      "seeAlso": [
+        "http://www.egenix.com/products/eGenix.com-Public-License-1.1.0.pdf",
+        "https://fedoraproject.org/wiki/Licensing/eGenix.com_Public_License_1.1.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./gSOAP-1.3b.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/gSOAP-1.3b.json",
+      "referenceNumber": "339",
+      "name": "gSOAP Public License v1.3b",
+      "licenseId": "gSOAP-1.3b",
+      "seeAlso": [
+        "http://www.cs.fsu.edu/~engelen/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./gnuplot.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/gnuplot.json",
+      "referenceNumber": "340",
+      "name": "gnuplot License",
+      "licenseId": "gnuplot",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Gnuplot"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./iMatix.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/iMatix.json",
+      "referenceNumber": "341",
+      "name": "iMatix Standard Function Library Agreement",
+      "licenseId": "iMatix",
+      "seeAlso": [
+        "http://legacy.imatix.com/html/sfl/sfl4.htm#license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./libtiff.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/libtiff.json",
+      "referenceNumber": "342",
+      "name": "libtiff License",
+      "licenseId": "libtiff",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/libtiff"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./mpich2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/mpich2.json",
+      "referenceNumber": "343",
+      "name": "mpich2 License",
+      "licenseId": "mpich2",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./psfrag.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/psfrag.json",
+      "referenceNumber": "344",
+      "name": "psfrag License",
+      "licenseId": "psfrag",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/psfrag"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./psutils.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/psutils.json",
+      "referenceNumber": "345",
+      "name": "psutils License",
+      "licenseId": "psutils",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/psutils"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./xinetd.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/xinetd.json",
+      "referenceNumber": "346",
+      "name": "xinetd License",
+      "licenseId": "xinetd",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Xinetd_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./xpp.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/xpp.json",
+      "referenceNumber": "347",
+      "name": "XPP License",
+      "licenseId": "xpp",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/xpp"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./zlib-acknowledgement.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/zlib-acknowledgement.json",
+      "referenceNumber": "348",
+      "name": "zlib/libpng License with Acknowledgement",
+      "licenseId": "zlib-acknowledgement",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/ZlibWithAcknowledgement"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./AGPL-1.0.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/AGPL-1.0.json",
+      "referenceNumber": "349",
+      "name": "Affero General Public License v1.0",
+      "licenseId": "AGPL-1.0",
+      "seeAlso": [
+        "http://www.affero.org/oagpl.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./AGPL-3.0.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/AGPL-3.0.json",
+      "referenceNumber": "350",
+      "name": "GNU Affero General Public License v3.0",
+      "licenseId": "AGPL-3.0",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/agpl.txt",
+        "http://www.opensource.org/licenses/AGPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GFDL-1.1.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.1.json",
+      "referenceNumber": "351",
+      "name": "GNU Free Documentation License v1.1",
+      "licenseId": "GFDL-1.1",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.2.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.2.json",
+      "referenceNumber": "352",
+      "name": "GNU Free Documentation License v1.2",
+      "licenseId": "GFDL-1.2",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.3.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.3.json",
+      "referenceNumber": "353",
+      "name": "GNU Free Documentation License v1.3",
+      "licenseId": "GFDL-1.3",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-1.0+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-1.0+.json",
+      "referenceNumber": "354",
+      "name": "GNU General Public License v1.0 or later",
+      "licenseId": "GPL-1.0+",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-1.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-1.0.json",
+      "referenceNumber": "355",
+      "name": "GNU General Public License v1.0 only",
+      "licenseId": "GPL-1.0",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-2.0+.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-2.0+.json",
+      "referenceNumber": "356",
+      "name": "GNU General Public License v2.0 or later",
+      "licenseId": "GPL-2.0+",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "http://www.opensource.org/licenses/GPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-2.0-with-GCC-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-GCC-exception.json",
+      "referenceNumber": "357",
+      "name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
+      "licenseId": "GPL-2.0-with-GCC-exception",
+      "seeAlso": [
+        "https://gcc.gnu.org/git/?p\u003dgcc.git;a\u003dblob;f\u003dgcc/libgcc1.c;h\u003d762f5143fc6eed57b6797c82710f3538aa52b40b;hb\u003dcb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-2.0-with-autoconf-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-autoconf-exception.json",
+      "referenceNumber": "358",
+      "name": "GNU General Public License v2.0 w/Autoconf exception",
+      "licenseId": "GPL-2.0-with-autoconf-exception",
+      "seeAlso": [
+        "http://ac-archive.sourceforge.net/doc/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-2.0-with-bison-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-bison-exception.json",
+      "referenceNumber": "359",
+      "name": "GNU General Public License v2.0 w/Bison exception",
+      "licenseId": "GPL-2.0-with-bison-exception",
+      "seeAlso": [
+        "http://git.savannah.gnu.org/cgit/bison.git/tree/data/yacc.c?id\u003d193d7c7054ba7197b0789e14965b739162319b5e#n141"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-2.0-with-classpath-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-classpath-exception.json",
+      "referenceNumber": "360",
+      "name": "GNU General Public License v2.0 w/Classpath exception",
+      "licenseId": "GPL-2.0-with-classpath-exception",
+      "seeAlso": [
+        "http://www.gnu.org/software/classpath/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-2.0-with-font-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-font-exception.json",
+      "referenceNumber": "361",
+      "name": "GNU General Public License v2.0 w/Font exception",
+      "licenseId": "GPL-2.0-with-font-exception",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/gpl-faq.html#FontException"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-2.0.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-2.0.json",
+      "referenceNumber": "362",
+      "name": "GNU General Public License v2.0 only",
+      "licenseId": "GPL-2.0",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "http://www.opensource.org/licenses/GPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-3.0+.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-3.0+.json",
+      "referenceNumber": "363",
+      "name": "GNU General Public License v3.0 or later",
+      "licenseId": "GPL-3.0+",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "http://www.opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-3.0-with-GCC-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-with-GCC-exception.json",
+      "referenceNumber": "364",
+      "name": "GNU General Public License v3.0 w/GCC Runtime Library exception",
+      "licenseId": "GPL-3.0-with-GCC-exception",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/gcc-exception-3.1.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-3.0-with-autoconf-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-with-autoconf-exception.json",
+      "referenceNumber": "365",
+      "name": "GNU General Public License v3.0 w/Autoconf exception",
+      "licenseId": "GPL-3.0-with-autoconf-exception",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/autoconf-exception-3.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-3.0.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-3.0.json",
+      "referenceNumber": "366",
+      "name": "GNU General Public License v3.0 only",
+      "licenseId": "GPL-3.0",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "http://www.opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-2.0+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-2.0+.json",
+      "referenceNumber": "367",
+      "name": "GNU Library General Public License v2 or later",
+      "licenseId": "LGPL-2.0+",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-2.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-2.0.json",
+      "referenceNumber": "368",
+      "name": "GNU Library General Public License v2 only",
+      "licenseId": "LGPL-2.0",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-2.1+.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-2.1+.json",
+      "referenceNumber": "369",
+      "name": "GNU Library General Public License v2.1 or later",
+      "licenseId": "LGPL-2.1+",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "http://www.opensource.org/licenses/LGPL-2.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-2.1.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-2.1.json",
+      "referenceNumber": "370",
+      "name": "GNU Lesser General Public License v2.1 only",
+      "licenseId": "LGPL-2.1",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "http://www.opensource.org/licenses/LGPL-2.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-3.0+.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-3.0+.json",
+      "referenceNumber": "371",
+      "name": "GNU Lesser General Public License v3.0 or later",
+      "licenseId": "LGPL-3.0+",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "http://www.opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-3.0.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-3.0.json",
+      "referenceNumber": "372",
+      "name": "GNU Lesser General Public License v3.0 only",
+      "licenseId": "LGPL-3.0",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "http://www.opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Nunit.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Nunit.json",
+      "referenceNumber": "373",
+      "name": "Nunit License",
+      "licenseId": "Nunit",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Nunit"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./StandardML-NJ.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/StandardML-NJ.json",
+      "referenceNumber": "374",
+      "name": "Standard ML of New Jersey License",
+      "licenseId": "StandardML-NJ",
+      "seeAlso": [
+        "http://www.smlnj.org//license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./eCos-2.0.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/eCos-2.0.json",
+      "referenceNumber": "375",
+      "name": "eCos license version 2.0",
+      "licenseId": "eCos-2.0",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/ecos-license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./wxWindows.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/wxWindows.json",
+      "referenceNumber": "376",
+      "name": "wxWindows Library License",
+      "licenseId": "wxWindows",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/WXwindows"
+      ],
+      "isOsiApproved": false
+    }
+  ],
+  "releaseDate": "2018-08-23"
+}

--- a/data/spdx_licenses.json
+++ b/data/spdx_licenses.json
@@ -1,23 +1,23 @@
 {
-  "licenseListVersion": "v3.1-67-geb2589b",
+  "licenseListVersion": "v3.4-5-gb3d735f",
   "licenses": [
     {
       "reference": "./0BSD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/0BSD.json",
-      "referenceNumber": "1",
+      "referenceNumber": "310",
       "name": "BSD Zero Clause License",
       "licenseId": "0BSD",
       "seeAlso": [
         "http://landley.net/toybox/license.html"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": true
     },
     {
       "reference": "./AAL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AAL.json",
-      "referenceNumber": "2",
+      "referenceNumber": "20",
       "name": "Attribution Assurance License",
       "licenseId": "AAL",
       "seeAlso": [
@@ -29,7 +29,7 @@
       "reference": "./ADSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ADSL.json",
-      "referenceNumber": "3",
+      "referenceNumber": "18",
       "name": "Amazon Digital Services License",
       "licenseId": "ADSL",
       "seeAlso": [
@@ -42,7 +42,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-1.1.json",
-      "referenceNumber": "4",
+      "referenceNumber": "112",
       "name": "Academic Free License v1.1",
       "licenseId": "AFL-1.1",
       "seeAlso": [
@@ -56,7 +56,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-1.2.json",
-      "referenceNumber": "5",
+      "referenceNumber": "130",
       "name": "Academic Free License v1.2",
       "licenseId": "AFL-1.2",
       "seeAlso": [
@@ -70,7 +70,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-2.0.json",
-      "referenceNumber": "6",
+      "referenceNumber": "109",
       "name": "Academic Free License v2.0",
       "licenseId": "AFL-2.0",
       "seeAlso": [
@@ -83,7 +83,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-2.1.json",
-      "referenceNumber": "7",
+      "referenceNumber": "244",
       "name": "Academic Free License v2.1",
       "licenseId": "AFL-2.1",
       "seeAlso": [
@@ -96,7 +96,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-3.0.json",
-      "referenceNumber": "8",
+      "referenceNumber": "209",
       "name": "Academic Free License v3.0",
       "licenseId": "AFL-3.0",
       "seeAlso": [
@@ -106,10 +106,23 @@
       "isOsiApproved": true
     },
     {
+      "reference": "./AGPL-1.0.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/AGPL-1.0.json",
+      "referenceNumber": "325",
+      "name": "Affero General Public License v1.0",
+      "licenseId": "AGPL-1.0",
+      "seeAlso": [
+        "http://www.affero.org/oagpl.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./AGPL-1.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AGPL-1.0-only.json",
-      "referenceNumber": "9",
+      "referenceNumber": "370",
       "name": "Affero General Public License v1.0 only",
       "licenseId": "AGPL-1.0-only",
       "seeAlso": [
@@ -121,7 +134,7 @@
       "reference": "./AGPL-1.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AGPL-1.0-or-later.json",
-      "referenceNumber": "10",
+      "referenceNumber": "322",
       "name": "Affero General Public License v1.0 or later",
       "licenseId": "AGPL-1.0-or-later",
       "seeAlso": [
@@ -130,11 +143,25 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./AGPL-3.0.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/AGPL-3.0.json",
+      "referenceNumber": "222",
+      "name": "GNU Affero General Public License v3.0",
+      "licenseId": "AGPL-3.0",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/agpl.txt",
+        "http://www.opensource.org/licenses/AGPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
       "reference": "./AGPL-3.0-only.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AGPL-3.0-only.json",
-      "referenceNumber": "11",
+      "referenceNumber": "90",
       "name": "GNU Affero General Public License v3.0 only",
       "licenseId": "AGPL-3.0-only",
       "seeAlso": [
@@ -148,7 +175,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AGPL-3.0-or-later.json",
-      "referenceNumber": "12",
+      "referenceNumber": "148",
       "name": "GNU Affero General Public License v3.0 or later",
       "licenseId": "AGPL-3.0-or-later",
       "seeAlso": [
@@ -161,7 +188,7 @@
       "reference": "./AMDPLPA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AMDPLPA.json",
-      "referenceNumber": "13",
+      "referenceNumber": "31",
       "name": "AMD\u0027s plpa_map.c License",
       "licenseId": "AMDPLPA",
       "seeAlso": [
@@ -173,7 +200,7 @@
       "reference": "./AML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AML.json",
-      "referenceNumber": "14",
+      "referenceNumber": "141",
       "name": "Apple MIT License",
       "licenseId": "AML",
       "seeAlso": [
@@ -185,7 +212,7 @@
       "reference": "./AMPAS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AMPAS.json",
-      "referenceNumber": "15",
+      "referenceNumber": "184",
       "name": "Academy of Motion Picture Arts and Sciences BSD",
       "licenseId": "AMPAS",
       "seeAlso": [
@@ -197,7 +224,7 @@
       "reference": "./ANTLR-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ANTLR-PD.json",
-      "referenceNumber": "16",
+      "referenceNumber": "381",
       "name": "ANTLR Software Rights Notice",
       "licenseId": "ANTLR-PD",
       "seeAlso": [
@@ -209,7 +236,7 @@
       "reference": "./APAFML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APAFML.json",
-      "referenceNumber": "17",
+      "referenceNumber": "188",
       "name": "Adobe Postscript AFM License",
       "licenseId": "APAFML",
       "seeAlso": [
@@ -221,7 +248,7 @@
       "reference": "./APL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APL-1.0.json",
-      "referenceNumber": "18",
+      "referenceNumber": "245",
       "name": "Adaptive Public License 1.0",
       "licenseId": "APL-1.0",
       "seeAlso": [
@@ -233,7 +260,7 @@
       "reference": "./APSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APSL-1.0.json",
-      "referenceNumber": "19",
+      "referenceNumber": "342",
       "name": "Apple Public Source License 1.0",
       "licenseId": "APSL-1.0",
       "seeAlso": [
@@ -245,7 +272,7 @@
       "reference": "./APSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APSL-1.1.json",
-      "referenceNumber": "20",
+      "referenceNumber": "315",
       "name": "Apple Public Source License 1.1",
       "licenseId": "APSL-1.1",
       "seeAlso": [
@@ -257,7 +284,7 @@
       "reference": "./APSL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APSL-1.2.json",
-      "referenceNumber": "21",
+      "referenceNumber": "32",
       "name": "Apple Public Source License 1.2",
       "licenseId": "APSL-1.2",
       "seeAlso": [
@@ -270,7 +297,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/APSL-2.0.json",
-      "referenceNumber": "22",
+      "referenceNumber": "103",
       "name": "Apple Public Source License 2.0",
       "licenseId": "APSL-2.0",
       "seeAlso": [
@@ -282,7 +309,7 @@
       "reference": "./Abstyles.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Abstyles.json",
-      "referenceNumber": "23",
+      "referenceNumber": "76",
       "name": "Abstyles License",
       "licenseId": "Abstyles",
       "seeAlso": [
@@ -294,7 +321,7 @@
       "reference": "./Adobe-2006.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Adobe-2006.json",
-      "referenceNumber": "24",
+      "referenceNumber": "277",
       "name": "Adobe Systems Incorporated Source Code License Agreement",
       "licenseId": "Adobe-2006",
       "seeAlso": [
@@ -306,7 +333,7 @@
       "reference": "./Adobe-Glyph.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Adobe-Glyph.json",
-      "referenceNumber": "25",
+      "referenceNumber": "101",
       "name": "Adobe Glyph List License",
       "licenseId": "Adobe-Glyph",
       "seeAlso": [
@@ -318,7 +345,7 @@
       "reference": "./Afmparse.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Afmparse.json",
-      "referenceNumber": "26",
+      "referenceNumber": "40",
       "name": "Afmparse License",
       "licenseId": "Afmparse",
       "seeAlso": [
@@ -330,7 +357,7 @@
       "reference": "./Aladdin.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Aladdin.json",
-      "referenceNumber": "27",
+      "referenceNumber": "251",
       "name": "Aladdin Free Public License",
       "licenseId": "Aladdin",
       "seeAlso": [
@@ -343,7 +370,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Apache-1.0.json",
-      "referenceNumber": "28",
+      "referenceNumber": "230",
       "name": "Apache License 1.0",
       "licenseId": "Apache-1.0",
       "seeAlso": [
@@ -356,7 +383,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Apache-1.1.json",
-      "referenceNumber": "29",
+      "referenceNumber": "80",
       "name": "Apache License 1.1",
       "licenseId": "Apache-1.1",
       "seeAlso": [
@@ -370,7 +397,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Apache-2.0.json",
-      "referenceNumber": "30",
+      "referenceNumber": "24",
       "name": "Apache License 2.0",
       "licenseId": "Apache-2.0",
       "seeAlso": [
@@ -380,10 +407,22 @@
       "isOsiApproved": true
     },
     {
+      "reference": "./Artistic-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Artistic-1.0.json",
+      "referenceNumber": "158",
+      "name": "Artistic License 1.0",
+      "licenseId": "Artistic-1.0",
+      "seeAlso": [
+        "http://opensource.org/licenses/Artistic-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
       "reference": "./Artistic-1.0-Perl.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Artistic-1.0-Perl.json",
-      "referenceNumber": "31",
+      "referenceNumber": "363",
       "name": "Artistic License 1.0 (Perl)",
       "licenseId": "Artistic-1.0-Perl",
       "seeAlso": [
@@ -395,21 +434,9 @@
       "reference": "./Artistic-1.0-cl8.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Artistic-1.0-cl8.json",
-      "referenceNumber": "32",
+      "referenceNumber": "12",
       "name": "Artistic License 1.0 w/clause 8",
       "licenseId": "Artistic-1.0-cl8",
-      "seeAlso": [
-        "http://opensource.org/licenses/Artistic-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Artistic-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Artistic-1.0.json",
-      "referenceNumber": "33",
-      "name": "Artistic License 1.0",
-      "licenseId": "Artistic-1.0",
       "seeAlso": [
         "http://opensource.org/licenses/Artistic-1.0"
       ],
@@ -420,7 +447,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Artistic-2.0.json",
-      "referenceNumber": "34",
+      "referenceNumber": "182",
       "name": "Artistic License 2.0",
       "licenseId": "Artistic-2.0",
       "seeAlso": [
@@ -433,7 +460,7 @@
       "reference": "./BSD-1-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-1-Clause.json",
-      "referenceNumber": "35",
+      "referenceNumber": "345",
       "name": "BSD 1-Clause License",
       "licenseId": "BSD-1-Clause",
       "seeAlso": [
@@ -442,11 +469,23 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./BSD-2-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause.json",
+      "referenceNumber": "316",
+      "name": "BSD 2-Clause \"Simplified\" License",
+      "licenseId": "BSD-2-Clause",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/BSD-2-Clause"
+      ],
+      "isOsiApproved": true
+    },
+    {
       "reference": "./BSD-2-Clause-FreeBSD.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-FreeBSD.json",
-      "referenceNumber": "36",
+      "referenceNumber": "115",
       "name": "BSD 2-Clause FreeBSD License",
       "licenseId": "BSD-2-Clause-FreeBSD",
       "seeAlso": [
@@ -458,7 +497,7 @@
       "reference": "./BSD-2-Clause-NetBSD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-NetBSD.json",
-      "referenceNumber": "37",
+      "referenceNumber": "367",
       "name": "BSD 2-Clause NetBSD License",
       "licenseId": "BSD-2-Clause-NetBSD",
       "seeAlso": [
@@ -470,7 +509,7 @@
       "reference": "./BSD-2-Clause-Patent.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-Patent.json",
-      "referenceNumber": "38",
+      "referenceNumber": "162",
       "name": "BSD-2-Clause Plus Patent License",
       "licenseId": "BSD-2-Clause-Patent",
       "seeAlso": [
@@ -479,14 +518,15 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./BSD-2-Clause.html",
+      "reference": "./BSD-3-Clause.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause.json",
-      "referenceNumber": "39",
-      "name": "BSD 2-Clause \"Simplified\" License",
-      "licenseId": "BSD-2-Clause",
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause.json",
+      "referenceNumber": "262",
+      "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+      "licenseId": "BSD-3-Clause",
       "seeAlso": [
-        "http://www.opensource.org/licenses/BSD-2-Clause"
+        "http://www.opensource.org/licenses/BSD-3-Clause"
       ],
       "isOsiApproved": true
     },
@@ -494,7 +534,7 @@
       "reference": "./BSD-3-Clause-Attribution.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-Attribution.json",
-      "referenceNumber": "40",
+      "referenceNumber": "37",
       "name": "BSD with attribution",
       "licenseId": "BSD-3-Clause-Attribution",
       "seeAlso": [
@@ -507,7 +547,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-Clear.json",
-      "referenceNumber": "41",
+      "referenceNumber": "205",
       "name": "BSD 3-Clause Clear License",
       "licenseId": "BSD-3-Clause-Clear",
       "seeAlso": [
@@ -519,7 +559,7 @@
       "reference": "./BSD-3-Clause-LBNL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-LBNL.json",
-      "referenceNumber": "42",
+      "referenceNumber": "327",
       "name": "Lawrence Berkeley National Labs BSD variant license",
       "licenseId": "BSD-3-Clause-LBNL",
       "seeAlso": [
@@ -528,22 +568,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./BSD-3-Clause-No-Nuclear-License-2014.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.json",
-      "referenceNumber": "43",
-      "name": "BSD 3-Clause No Nuclear License 2014",
-      "licenseId": "BSD-3-Clause-No-Nuclear-License-2014",
-      "seeAlso": [
-        "https://java.net/projects/javaeetutorial/pages/BerkeleyLicense"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./BSD-3-Clause-No-Nuclear-License.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.json",
-      "referenceNumber": "44",
+      "referenceNumber": "11",
       "name": "BSD 3-Clause No Nuclear License",
       "licenseId": "BSD-3-Clause-No-Nuclear-License",
       "seeAlso": [
@@ -552,10 +580,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./BSD-3-Clause-No-Nuclear-License-2014.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.json",
+      "referenceNumber": "131",
+      "name": "BSD 3-Clause No Nuclear License 2014",
+      "licenseId": "BSD-3-Clause-No-Nuclear-License-2014",
+      "seeAlso": [
+        "https://java.net/projects/javaeetutorial/pages/BerkeleyLicense"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./BSD-3-Clause-No-Nuclear-Warranty.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.json",
-      "referenceNumber": "45",
+      "referenceNumber": "42",
       "name": "BSD 3-Clause No Nuclear Warranty",
       "licenseId": "BSD-3-Clause-No-Nuclear-Warranty",
       "seeAlso": [
@@ -564,36 +604,11 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./BSD-3-Clause.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause.json",
-      "referenceNumber": "46",
-      "name": "BSD 3-Clause \"New\" or \"Revised\" License",
-      "licenseId": "BSD-3-Clause",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/BSD-3-Clause"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./BSD-4-Clause-UC.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-4-Clause-UC.json",
-      "referenceNumber": "47",
-      "name": "BSD-4-Clause (University of California-Specific)",
-      "licenseId": "BSD-4-Clause-UC",
-      "seeAlso": [
-        "http://www.freebsd.org/copyright/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./BSD-4-Clause.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-4-Clause.json",
-      "referenceNumber": "48",
+      "referenceNumber": "155",
       "name": "BSD 4-Clause \"Original\" or \"Old\" License",
       "licenseId": "BSD-4-Clause",
       "seeAlso": [
@@ -602,10 +617,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./BSD-4-Clause-UC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/BSD-4-Clause-UC.json",
+      "referenceNumber": "196",
+      "name": "BSD-4-Clause (University of California-Specific)",
+      "licenseId": "BSD-4-Clause-UC",
+      "seeAlso": [
+        "http://www.freebsd.org/copyright/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./BSD-Protection.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-Protection.json",
-      "referenceNumber": "49",
+      "referenceNumber": "113",
       "name": "BSD Protection License",
       "licenseId": "BSD-Protection",
       "seeAlso": [
@@ -617,7 +644,7 @@
       "reference": "./BSD-Source-Code.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-Source-Code.json",
-      "referenceNumber": "50",
+      "referenceNumber": "300",
       "name": "BSD Source Code Attribution",
       "licenseId": "BSD-Source-Code",
       "seeAlso": [
@@ -630,7 +657,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSL-1.0.json",
-      "referenceNumber": "51",
+      "referenceNumber": "217",
       "name": "Boost Software License 1.0",
       "licenseId": "BSL-1.0",
       "seeAlso": [
@@ -643,7 +670,7 @@
       "reference": "./Bahyph.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Bahyph.json",
-      "referenceNumber": "52",
+      "referenceNumber": "353",
       "name": "Bahyph License",
       "licenseId": "Bahyph",
       "seeAlso": [
@@ -655,7 +682,7 @@
       "reference": "./Barr.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Barr.json",
-      "referenceNumber": "53",
+      "referenceNumber": "323",
       "name": "Barr License",
       "licenseId": "Barr",
       "seeAlso": [
@@ -667,7 +694,7 @@
       "reference": "./Beerware.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Beerware.json",
-      "referenceNumber": "54",
+      "referenceNumber": "16",
       "name": "Beerware License",
       "licenseId": "Beerware",
       "seeAlso": [
@@ -680,7 +707,7 @@
       "reference": "./BitTorrent-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BitTorrent-1.0.json",
-      "referenceNumber": "55",
+      "referenceNumber": "211",
       "name": "BitTorrent Open Source License v1.0",
       "licenseId": "BitTorrent-1.0",
       "seeAlso": [
@@ -693,7 +720,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BitTorrent-1.1.json",
-      "referenceNumber": "56",
+      "referenceNumber": "172",
       "name": "BitTorrent Open Source License v1.1",
       "licenseId": "BitTorrent-1.1",
       "seeAlso": [
@@ -705,7 +732,7 @@
       "reference": "./Borceux.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Borceux.json",
-      "referenceNumber": "57",
+      "referenceNumber": "303",
       "name": "Borceux license",
       "licenseId": "Borceux",
       "seeAlso": [
@@ -717,7 +744,7 @@
       "reference": "./CATOSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CATOSL-1.1.json",
-      "referenceNumber": "58",
+      "referenceNumber": "255",
       "name": "Computer Associates Trusted Open Source License 1.1",
       "licenseId": "CATOSL-1.1",
       "seeAlso": [
@@ -729,7 +756,7 @@
       "reference": "./CC-BY-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-1.0.json",
-      "referenceNumber": "59",
+      "referenceNumber": "122",
       "name": "Creative Commons Attribution 1.0 Generic",
       "licenseId": "CC-BY-1.0",
       "seeAlso": [
@@ -741,7 +768,7 @@
       "reference": "./CC-BY-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-2.0.json",
-      "referenceNumber": "60",
+      "referenceNumber": "225",
       "name": "Creative Commons Attribution 2.0 Generic",
       "licenseId": "CC-BY-2.0",
       "seeAlso": [
@@ -753,7 +780,7 @@
       "reference": "./CC-BY-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-2.5.json",
-      "referenceNumber": "61",
+      "referenceNumber": "123",
       "name": "Creative Commons Attribution 2.5 Generic",
       "licenseId": "CC-BY-2.5",
       "seeAlso": [
@@ -765,7 +792,7 @@
       "reference": "./CC-BY-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-3.0.json",
-      "referenceNumber": "62",
+      "referenceNumber": "249",
       "name": "Creative Commons Attribution 3.0 Unported",
       "licenseId": "CC-BY-3.0",
       "seeAlso": [
@@ -778,7 +805,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-4.0.json",
-      "referenceNumber": "63",
+      "referenceNumber": "321",
       "name": "Creative Commons Attribution 4.0 International",
       "licenseId": "CC-BY-4.0",
       "seeAlso": [
@@ -790,7 +817,7 @@
       "reference": "./CC-BY-NC-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-1.0.json",
-      "referenceNumber": "64",
+      "referenceNumber": "124",
       "name": "Creative Commons Attribution Non Commercial 1.0 Generic",
       "licenseId": "CC-BY-NC-1.0",
       "seeAlso": [
@@ -802,7 +829,7 @@
       "reference": "./CC-BY-NC-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-2.0.json",
-      "referenceNumber": "65",
+      "referenceNumber": "237",
       "name": "Creative Commons Attribution Non Commercial 2.0 Generic",
       "licenseId": "CC-BY-NC-2.0",
       "seeAlso": [
@@ -814,7 +841,7 @@
       "reference": "./CC-BY-NC-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-2.5.json",
-      "referenceNumber": "66",
+      "referenceNumber": "1",
       "name": "Creative Commons Attribution Non Commercial 2.5 Generic",
       "licenseId": "CC-BY-NC-2.5",
       "seeAlso": [
@@ -826,7 +853,7 @@
       "reference": "./CC-BY-NC-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-3.0.json",
-      "referenceNumber": "67",
+      "referenceNumber": "248",
       "name": "Creative Commons Attribution Non Commercial 3.0 Unported",
       "licenseId": "CC-BY-NC-3.0",
       "seeAlso": [
@@ -838,7 +865,7 @@
       "reference": "./CC-BY-NC-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-4.0.json",
-      "referenceNumber": "68",
+      "referenceNumber": "179",
       "name": "Creative Commons Attribution Non Commercial 4.0 International",
       "licenseId": "CC-BY-NC-4.0",
       "seeAlso": [
@@ -850,7 +877,7 @@
       "reference": "./CC-BY-NC-ND-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-1.0.json",
-      "referenceNumber": "69",
+      "referenceNumber": "57",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
       "licenseId": "CC-BY-NC-ND-1.0",
       "seeAlso": [
@@ -862,7 +889,7 @@
       "reference": "./CC-BY-NC-ND-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-2.0.json",
-      "referenceNumber": "70",
+      "referenceNumber": "34",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
       "licenseId": "CC-BY-NC-ND-2.0",
       "seeAlso": [
@@ -874,7 +901,7 @@
       "reference": "./CC-BY-NC-ND-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-2.5.json",
-      "referenceNumber": "71",
+      "referenceNumber": "151",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
       "licenseId": "CC-BY-NC-ND-2.5",
       "seeAlso": [
@@ -886,7 +913,7 @@
       "reference": "./CC-BY-NC-ND-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-3.0.json",
-      "referenceNumber": "72",
+      "referenceNumber": "46",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
       "licenseId": "CC-BY-NC-ND-3.0",
       "seeAlso": [
@@ -898,7 +925,7 @@
       "reference": "./CC-BY-NC-ND-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-4.0.json",
-      "referenceNumber": "73",
+      "referenceNumber": "273",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
       "licenseId": "CC-BY-NC-ND-4.0",
       "seeAlso": [
@@ -910,7 +937,7 @@
       "reference": "./CC-BY-NC-SA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-1.0.json",
-      "referenceNumber": "74",
+      "referenceNumber": "171",
       "name": "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
       "licenseId": "CC-BY-NC-SA-1.0",
       "seeAlso": [
@@ -922,7 +949,7 @@
       "reference": "./CC-BY-NC-SA-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-2.0.json",
-      "referenceNumber": "75",
+      "referenceNumber": "77",
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
       "licenseId": "CC-BY-NC-SA-2.0",
       "seeAlso": [
@@ -934,7 +961,7 @@
       "reference": "./CC-BY-NC-SA-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-2.5.json",
-      "referenceNumber": "76",
+      "referenceNumber": "60",
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
       "licenseId": "CC-BY-NC-SA-2.5",
       "seeAlso": [
@@ -946,7 +973,7 @@
       "reference": "./CC-BY-NC-SA-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-3.0.json",
-      "referenceNumber": "77",
+      "referenceNumber": "21",
       "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported",
       "licenseId": "CC-BY-NC-SA-3.0",
       "seeAlso": [
@@ -958,7 +985,7 @@
       "reference": "./CC-BY-NC-SA-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-4.0.json",
-      "referenceNumber": "78",
+      "referenceNumber": "45",
       "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
       "licenseId": "CC-BY-NC-SA-4.0",
       "seeAlso": [
@@ -970,7 +997,7 @@
       "reference": "./CC-BY-ND-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-1.0.json",
-      "referenceNumber": "79",
+      "referenceNumber": "48",
       "name": "Creative Commons Attribution No Derivatives 1.0 Generic",
       "licenseId": "CC-BY-ND-1.0",
       "seeAlso": [
@@ -982,7 +1009,7 @@
       "reference": "./CC-BY-ND-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-2.0.json",
-      "referenceNumber": "80",
+      "referenceNumber": "279",
       "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
       "licenseId": "CC-BY-ND-2.0",
       "seeAlso": [
@@ -994,7 +1021,7 @@
       "reference": "./CC-BY-ND-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-2.5.json",
-      "referenceNumber": "81",
+      "referenceNumber": "66",
       "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
       "licenseId": "CC-BY-ND-2.5",
       "seeAlso": [
@@ -1006,7 +1033,7 @@
       "reference": "./CC-BY-ND-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-3.0.json",
-      "referenceNumber": "82",
+      "referenceNumber": "379",
       "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
       "licenseId": "CC-BY-ND-3.0",
       "seeAlso": [
@@ -1018,7 +1045,7 @@
       "reference": "./CC-BY-ND-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-4.0.json",
-      "referenceNumber": "83",
+      "referenceNumber": "126",
       "name": "Creative Commons Attribution No Derivatives 4.0 International",
       "licenseId": "CC-BY-ND-4.0",
       "seeAlso": [
@@ -1030,7 +1057,7 @@
       "reference": "./CC-BY-SA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-1.0.json",
-      "referenceNumber": "84",
+      "referenceNumber": "313",
       "name": "Creative Commons Attribution Share Alike 1.0 Generic",
       "licenseId": "CC-BY-SA-1.0",
       "seeAlso": [
@@ -1042,7 +1069,7 @@
       "reference": "./CC-BY-SA-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-2.0.json",
-      "referenceNumber": "85",
+      "referenceNumber": "136",
       "name": "Creative Commons Attribution Share Alike 2.0 Generic",
       "licenseId": "CC-BY-SA-2.0",
       "seeAlso": [
@@ -1054,7 +1081,7 @@
       "reference": "./CC-BY-SA-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-2.5.json",
-      "referenceNumber": "86",
+      "referenceNumber": "298",
       "name": "Creative Commons Attribution Share Alike 2.5 Generic",
       "licenseId": "CC-BY-SA-2.5",
       "seeAlso": [
@@ -1066,7 +1093,7 @@
       "reference": "./CC-BY-SA-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-3.0.json",
-      "referenceNumber": "87",
+      "referenceNumber": "380",
       "name": "Creative Commons Attribution Share Alike 3.0 Unported",
       "licenseId": "CC-BY-SA-3.0",
       "seeAlso": [
@@ -1079,7 +1106,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-4.0.json",
-      "referenceNumber": "88",
+      "referenceNumber": "30",
       "name": "Creative Commons Attribution Share Alike 4.0 International",
       "licenseId": "CC-BY-SA-4.0",
       "seeAlso": [
@@ -1092,7 +1119,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CC0-1.0.json",
-      "referenceNumber": "89",
+      "referenceNumber": "206",
       "name": "Creative Commons Zero v1.0 Universal",
       "licenseId": "CC0-1.0",
       "seeAlso": [
@@ -1105,7 +1132,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CDDL-1.0.json",
-      "referenceNumber": "90",
+      "referenceNumber": "132",
       "name": "Common Development and Distribution License 1.0",
       "licenseId": "CDDL-1.0",
       "seeAlso": [
@@ -1117,7 +1144,7 @@
       "reference": "./CDDL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CDDL-1.1.json",
-      "referenceNumber": "91",
+      "referenceNumber": "362",
       "name": "Common Development and Distribution License 1.1",
       "licenseId": "CDDL-1.1",
       "seeAlso": [
@@ -1130,7 +1157,7 @@
       "reference": "./CDLA-Permissive-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CDLA-Permissive-1.0.json",
-      "referenceNumber": "92",
+      "referenceNumber": "243",
       "name": "Community Data License Agreement Permissive 1.0",
       "licenseId": "CDLA-Permissive-1.0",
       "seeAlso": [
@@ -1142,7 +1169,7 @@
       "reference": "./CDLA-Sharing-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CDLA-Sharing-1.0.json",
-      "referenceNumber": "93",
+      "referenceNumber": "302",
       "name": "Community Data License Agreement Sharing 1.0",
       "licenseId": "CDLA-Sharing-1.0",
       "seeAlso": [
@@ -1154,7 +1181,7 @@
       "reference": "./CECILL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CECILL-1.0.json",
-      "referenceNumber": "94",
+      "referenceNumber": "216",
       "name": "CeCILL Free Software License Agreement v1.0",
       "licenseId": "CECILL-1.0",
       "seeAlso": [
@@ -1166,7 +1193,7 @@
       "reference": "./CECILL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CECILL-1.1.json",
-      "referenceNumber": "95",
+      "referenceNumber": "292",
       "name": "CeCILL Free Software License Agreement v1.1",
       "licenseId": "CECILL-1.1",
       "seeAlso": [
@@ -1179,7 +1206,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CECILL-2.0.json",
-      "referenceNumber": "96",
+      "referenceNumber": "340",
       "name": "CeCILL Free Software License Agreement v2.0",
       "licenseId": "CECILL-2.0",
       "seeAlso": [
@@ -1191,7 +1218,7 @@
       "reference": "./CECILL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CECILL-2.1.json",
-      "referenceNumber": "97",
+      "referenceNumber": "114",
       "name": "CeCILL Free Software License Agreement v2.1",
       "licenseId": "CECILL-2.1",
       "seeAlso": [
@@ -1204,7 +1231,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CECILL-B.json",
-      "referenceNumber": "98",
+      "referenceNumber": "330",
       "name": "CeCILL-B Free Software License Agreement",
       "licenseId": "CECILL-B",
       "seeAlso": [
@@ -1217,7 +1244,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CECILL-C.json",
-      "referenceNumber": "99",
+      "referenceNumber": "73",
       "name": "CeCILL-C Free Software License Agreement",
       "licenseId": "CECILL-C",
       "seeAlso": [
@@ -1229,7 +1256,7 @@
       "reference": "./CNRI-Jython.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CNRI-Jython.json",
-      "referenceNumber": "100",
+      "referenceNumber": "89",
       "name": "CNRI Jython License",
       "licenseId": "CNRI-Jython",
       "seeAlso": [
@@ -1238,22 +1265,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CNRI-Python-GPL-Compatible.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CNRI-Python-GPL-Compatible.json",
-      "referenceNumber": "101",
-      "name": "CNRI Python Open Source GPL Compatible License Agreement",
-      "licenseId": "CNRI-Python-GPL-Compatible",
-      "seeAlso": [
-        "http://www.python.org/download/releases/1.6.1/download_win/"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./CNRI-Python.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CNRI-Python.json",
-      "referenceNumber": "102",
+      "referenceNumber": "43",
       "name": "CNRI Python License",
       "licenseId": "CNRI-Python",
       "seeAlso": [
@@ -1262,11 +1277,23 @@
       "isOsiApproved": true
     },
     {
+      "reference": "./CNRI-Python-GPL-Compatible.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CNRI-Python-GPL-Compatible.json",
+      "referenceNumber": "195",
+      "name": "CNRI Python Open Source GPL Compatible License Agreement",
+      "licenseId": "CNRI-Python-GPL-Compatible",
+      "seeAlso": [
+        "http://www.python.org/download/releases/1.6.1/download_win/"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./CPAL-1.0.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CPAL-1.0.json",
-      "referenceNumber": "103",
+      "referenceNumber": "163",
       "name": "Common Public Attribution License 1.0",
       "licenseId": "CPAL-1.0",
       "seeAlso": [
@@ -1279,7 +1306,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CPL-1.0.json",
-      "referenceNumber": "104",
+      "referenceNumber": "165",
       "name": "Common Public License 1.0",
       "licenseId": "CPL-1.0",
       "seeAlso": [
@@ -1291,7 +1318,7 @@
       "reference": "./CPOL-1.02.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CPOL-1.02.json",
-      "referenceNumber": "105",
+      "referenceNumber": "26",
       "name": "Code Project Open License 1.02",
       "licenseId": "CPOL-1.02",
       "seeAlso": [
@@ -1303,7 +1330,7 @@
       "reference": "./CUA-OPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CUA-OPL-1.0.json",
-      "referenceNumber": "106",
+      "referenceNumber": "352",
       "name": "CUA Office Public License v1.0",
       "licenseId": "CUA-OPL-1.0",
       "seeAlso": [
@@ -1315,7 +1342,7 @@
       "reference": "./Caldera.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Caldera.json",
-      "referenceNumber": "107",
+      "referenceNumber": "102",
       "name": "Caldera License",
       "licenseId": "Caldera",
       "seeAlso": [
@@ -1328,7 +1355,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ClArtistic.json",
-      "referenceNumber": "108",
+      "referenceNumber": "263",
       "name": "Clarified Artistic License",
       "licenseId": "ClArtistic",
       "seeAlso": [
@@ -1342,7 +1369,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Condor-1.1.json",
-      "referenceNumber": "109",
+      "referenceNumber": "299",
       "name": "Condor Public License v1.1",
       "licenseId": "Condor-1.1",
       "seeAlso": [
@@ -1355,7 +1382,7 @@
       "reference": "./Crossword.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Crossword.json",
-      "referenceNumber": "110",
+      "referenceNumber": "350",
       "name": "Crossword License",
       "licenseId": "Crossword",
       "seeAlso": [
@@ -1367,7 +1394,7 @@
       "reference": "./CrystalStacker.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CrystalStacker.json",
-      "referenceNumber": "111",
+      "referenceNumber": "161",
       "name": "CrystalStacker License",
       "licenseId": "CrystalStacker",
       "seeAlso": [
@@ -1379,7 +1406,7 @@
       "reference": "./Cube.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Cube.json",
-      "referenceNumber": "112",
+      "referenceNumber": "357",
       "name": "Cube License",
       "licenseId": "Cube",
       "seeAlso": [
@@ -1391,7 +1418,7 @@
       "reference": "./D-FSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/D-FSL-1.0.json",
-      "referenceNumber": "113",
+      "referenceNumber": "175",
       "name": "Deutsche Freie Software Lizenz",
       "licenseId": "D-FSL-1.0",
       "seeAlso": [
@@ -1410,7 +1437,7 @@
       "reference": "./DOC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/DOC.json",
-      "referenceNumber": "114",
+      "referenceNumber": "153",
       "name": "DOC License",
       "licenseId": "DOC",
       "seeAlso": [
@@ -1422,7 +1449,7 @@
       "reference": "./DSDP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/DSDP.json",
-      "referenceNumber": "115",
+      "referenceNumber": "135",
       "name": "DSDP License",
       "licenseId": "DSDP",
       "seeAlso": [
@@ -1434,7 +1461,7 @@
       "reference": "./Dotseqn.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Dotseqn.json",
-      "referenceNumber": "116",
+      "referenceNumber": "376",
       "name": "Dotseqn License",
       "licenseId": "Dotseqn",
       "seeAlso": [
@@ -1446,7 +1473,7 @@
       "reference": "./ECL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ECL-1.0.json",
-      "referenceNumber": "117",
+      "referenceNumber": "382",
       "name": "Educational Community License v1.0",
       "licenseId": "ECL-1.0",
       "seeAlso": [
@@ -1459,7 +1486,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ECL-2.0.json",
-      "referenceNumber": "118",
+      "referenceNumber": "290",
       "name": "Educational Community License v2.0",
       "licenseId": "ECL-2.0",
       "seeAlso": [
@@ -1471,7 +1498,7 @@
       "reference": "./EFL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/EFL-1.0.json",
-      "referenceNumber": "119",
+      "referenceNumber": "143",
       "name": "Eiffel Forum License v1.0",
       "licenseId": "EFL-1.0",
       "seeAlso": [
@@ -1485,7 +1512,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EFL-2.0.json",
-      "referenceNumber": "120",
+      "referenceNumber": "154",
       "name": "Eiffel Forum License v2.0",
       "licenseId": "EFL-2.0",
       "seeAlso": [
@@ -1499,7 +1526,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EPL-1.0.json",
-      "referenceNumber": "121",
+      "referenceNumber": "207",
       "name": "Eclipse Public License 1.0",
       "licenseId": "EPL-1.0",
       "seeAlso": [
@@ -1513,7 +1540,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EPL-2.0.json",
-      "referenceNumber": "122",
+      "referenceNumber": "128",
       "name": "Eclipse Public License 2.0",
       "licenseId": "EPL-2.0",
       "seeAlso": [
@@ -1527,7 +1554,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EUDatagrid.json",
-      "referenceNumber": "123",
+      "referenceNumber": "185",
       "name": "EU DataGrid Software License",
       "licenseId": "EUDatagrid",
       "seeAlso": [
@@ -1540,7 +1567,7 @@
       "reference": "./EUPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/EUPL-1.0.json",
-      "referenceNumber": "124",
+      "referenceNumber": "166",
       "name": "European Union Public License 1.0",
       "licenseId": "EUPL-1.0",
       "seeAlso": [
@@ -1554,7 +1581,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EUPL-1.1.json",
-      "referenceNumber": "125",
+      "referenceNumber": "87",
       "name": "European Union Public License 1.1",
       "licenseId": "EUPL-1.1",
       "seeAlso": [
@@ -1569,7 +1596,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EUPL-1.2.json",
-      "referenceNumber": "126",
+      "referenceNumber": "373",
       "name": "European Union Public License 1.2",
       "licenseId": "EUPL-1.2",
       "seeAlso": [
@@ -1585,7 +1612,7 @@
       "reference": "./Entessa.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Entessa.json",
-      "referenceNumber": "127",
+      "referenceNumber": "94",
       "name": "Entessa Public License v1.0",
       "licenseId": "Entessa",
       "seeAlso": [
@@ -1597,7 +1624,7 @@
       "reference": "./ErlPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ErlPL-1.1.json",
-      "referenceNumber": "128",
+      "referenceNumber": "150",
       "name": "Erlang Public License v1.1",
       "licenseId": "ErlPL-1.1",
       "seeAlso": [
@@ -1609,7 +1636,7 @@
       "reference": "./Eurosym.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Eurosym.json",
-      "referenceNumber": "129",
+      "referenceNumber": "107",
       "name": "Eurosym License",
       "licenseId": "Eurosym",
       "seeAlso": [
@@ -1622,7 +1649,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/FSFAP.json",
-      "referenceNumber": "130",
+      "referenceNumber": "108",
       "name": "FSF All Permissive License",
       "licenseId": "FSFAP",
       "seeAlso": [
@@ -1634,7 +1661,7 @@
       "reference": "./FSFUL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/FSFUL.json",
-      "referenceNumber": "131",
+      "referenceNumber": "186",
       "name": "FSF Unlimited License",
       "licenseId": "FSFUL",
       "seeAlso": [
@@ -1646,7 +1673,7 @@
       "reference": "./FSFULLR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/FSFULLR.json",
-      "referenceNumber": "132",
+      "referenceNumber": "41",
       "name": "FSF Unlimited License (with License Retention)",
       "licenseId": "FSFULLR",
       "seeAlso": [
@@ -1659,7 +1686,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/FTL.json",
-      "referenceNumber": "133",
+      "referenceNumber": "233",
       "name": "Freetype Project License",
       "licenseId": "FTL",
       "seeAlso": [
@@ -1672,7 +1699,7 @@
       "reference": "./Fair.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Fair.json",
-      "referenceNumber": "134",
+      "referenceNumber": "289",
       "name": "Fair License",
       "licenseId": "Fair",
       "seeAlso": [
@@ -1685,7 +1712,7 @@
       "reference": "./Frameworx-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Frameworx-1.0.json",
-      "referenceNumber": "135",
+      "referenceNumber": "375",
       "name": "Frameworx Open License 1.0",
       "licenseId": "Frameworx-1.0",
       "seeAlso": [
@@ -1697,7 +1724,7 @@
       "reference": "./FreeImage.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/FreeImage.json",
-      "referenceNumber": "136",
+      "referenceNumber": "269",
       "name": "FreeImage Public License v1.0",
       "licenseId": "FreeImage",
       "seeAlso": [
@@ -1706,11 +1733,24 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./GFDL-1.1.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.1.json",
+      "referenceNumber": "93",
+      "name": "GNU Free Documentation License v1.1",
+      "licenseId": "GFDL-1.1",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./GFDL-1.1-only.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-only.json",
-      "referenceNumber": "137",
+      "referenceNumber": "97",
       "name": "GNU Free Documentation License v1.1 only",
       "licenseId": "GFDL-1.1-only",
       "seeAlso": [
@@ -1723,7 +1763,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-or-later.json",
-      "referenceNumber": "138",
+      "referenceNumber": "337",
       "name": "GNU Free Documentation License v1.1 or later",
       "licenseId": "GFDL-1.1-or-later",
       "seeAlso": [
@@ -1732,11 +1772,24 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./GFDL-1.2.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.2.json",
+      "referenceNumber": "190",
+      "name": "GNU Free Documentation License v1.2",
+      "licenseId": "GFDL-1.2",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./GFDL-1.2-only.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-only.json",
-      "referenceNumber": "139",
+      "referenceNumber": "229",
       "name": "GNU Free Documentation License v1.2 only",
       "licenseId": "GFDL-1.2-only",
       "seeAlso": [
@@ -1749,7 +1802,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-or-later.json",
-      "referenceNumber": "140",
+      "referenceNumber": "208",
       "name": "GNU Free Documentation License v1.2 or later",
       "licenseId": "GFDL-1.2-or-later",
       "seeAlso": [
@@ -1758,11 +1811,24 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./GFDL-1.3.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.3.json",
+      "referenceNumber": "106",
+      "name": "GNU Free Documentation License v1.3",
+      "licenseId": "GFDL-1.3",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./GFDL-1.3-only.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-only.json",
-      "referenceNumber": "141",
+      "referenceNumber": "67",
       "name": "GNU Free Documentation License v1.3 only",
       "licenseId": "GFDL-1.3-only",
       "seeAlso": [
@@ -1775,7 +1841,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-or-later.json",
-      "referenceNumber": "142",
+      "referenceNumber": "3",
       "name": "GNU Free Documentation License v1.3 or later",
       "licenseId": "GFDL-1.3-or-later",
       "seeAlso": [
@@ -1787,7 +1853,7 @@
       "reference": "./GL2PS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/GL2PS.json",
-      "referenceNumber": "143",
+      "referenceNumber": "118",
       "name": "GL2PS License",
       "licenseId": "GL2PS",
       "seeAlso": [
@@ -1796,10 +1862,34 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./GPL-1.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-1.0.json",
+      "referenceNumber": "75",
+      "name": "GNU General Public License v1.0 only",
+      "licenseId": "GPL-1.0",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-1.0+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-1.0+.json",
+      "referenceNumber": "168",
+      "name": "GNU General Public License v1.0 or later",
+      "licenseId": "GPL-1.0+",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./GPL-1.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/GPL-1.0-only.json",
-      "referenceNumber": "144",
+      "referenceNumber": "14",
       "name": "GNU General Public License v1.0 only",
       "licenseId": "GPL-1.0-only",
       "seeAlso": [
@@ -1811,7 +1901,7 @@
       "reference": "./GPL-1.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/GPL-1.0-or-later.json",
-      "referenceNumber": "145",
+      "referenceNumber": "344",
       "name": "GNU General Public License v1.0 or later",
       "licenseId": "GPL-1.0-or-later",
       "seeAlso": [
@@ -1820,11 +1910,39 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./GPL-2.0.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-2.0.json",
+      "referenceNumber": "140",
+      "name": "GNU General Public License v2.0 only",
+      "licenseId": "GPL-2.0",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "http://www.opensource.org/licenses/GPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-2.0+.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-2.0+.json",
+      "referenceNumber": "72",
+      "name": "GNU General Public License v2.0 or later",
+      "licenseId": "GPL-2.0+",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "http://www.opensource.org/licenses/GPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
       "reference": "./GPL-2.0-only.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-only.json",
-      "referenceNumber": "146",
+      "referenceNumber": "226",
       "name": "GNU General Public License v2.0 only",
       "licenseId": "GPL-2.0-only",
       "seeAlso": [
@@ -1838,2630 +1956,9 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-or-later.json",
-      "referenceNumber": "147",
+      "referenceNumber": "54",
       "name": "GNU General Public License v2.0 or later",
       "licenseId": "GPL-2.0-or-later",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-3.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-only.json",
-      "referenceNumber": "148",
-      "name": "GNU General Public License v3.0 only",
-      "licenseId": "GPL-3.0-only",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-3.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-or-later.json",
-      "referenceNumber": "149",
-      "name": "GNU General Public License v3.0 or later",
-      "licenseId": "GPL-3.0-or-later",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Giftware.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Giftware.json",
-      "referenceNumber": "150",
-      "name": "Giftware License",
-      "licenseId": "Giftware",
-      "seeAlso": [
-        "http://liballeg.org/license.html#allegro-4-the-giftware-license"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Glide.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Glide.json",
-      "referenceNumber": "151",
-      "name": "3dfx Glide License",
-      "licenseId": "Glide",
-      "seeAlso": [
-        "http://www.users.on.net/~triforce/glidexp/COPYING.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Glulxe.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Glulxe.json",
-      "referenceNumber": "152",
-      "name": "Glulxe License",
-      "licenseId": "Glulxe",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Glulxe"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./HPND.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/HPND.json",
-      "referenceNumber": "153",
-      "name": "Historical Permission Notice and Disclaimer",
-      "licenseId": "HPND",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/HPND"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./HaskellReport.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/HaskellReport.json",
-      "referenceNumber": "154",
-      "name": "Haskell Language Report License",
-      "licenseId": "HaskellReport",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Haskell_Language_Report_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./IBM-pibs.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/IBM-pibs.json",
-      "referenceNumber": "155",
-      "name": "IBM PowerPC Initialization and Boot Software",
-      "licenseId": "IBM-pibs",
-      "seeAlso": [
-        "http://git.denx.de/?p\u003du-boot.git;a\u003dblob;f\u003darch/powerpc/cpu/ppc4xx/miiphy.c;h\u003d297155fdafa064b955e53e9832de93bfb0cfb85b;hb\u003d9fab4bf4cc077c21e43941866f3f2c196f28670d"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./ICU.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/ICU.json",
-      "referenceNumber": "156",
-      "name": "ICU License",
-      "licenseId": "ICU",
-      "seeAlso": [
-        "http://source.icu-project.org/repos/icu/icu/trunk/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./IJG.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/IJG.json",
-      "referenceNumber": "157",
-      "name": "Independent JPEG Group License",
-      "licenseId": "IJG",
-      "seeAlso": [
-        "http://dev.w3.org/cvsweb/Amaya/libjpeg/Attic/README?rev\u003d1.2"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./IPA.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/IPA.json",
-      "referenceNumber": "158",
-      "name": "IPA Font License",
-      "licenseId": "IPA",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/IPA"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./IPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/IPL-1.0.json",
-      "referenceNumber": "159",
-      "name": "IBM Public License v1.0",
-      "licenseId": "IPL-1.0",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/IPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./ISC.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/ISC.json",
-      "referenceNumber": "160",
-      "name": "ISC License",
-      "licenseId": "ISC",
-      "seeAlso": [
-        "https://www.isc.org/downloads/software-support-policy/isc-license/",
-        "http://www.opensource.org/licenses/ISC"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./ImageMagick.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/ImageMagick.json",
-      "referenceNumber": "161",
-      "name": "ImageMagick License",
-      "licenseId": "ImageMagick",
-      "seeAlso": [
-        "http://www.imagemagick.org/script/license.php"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Imlib2.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Imlib2.json",
-      "referenceNumber": "162",
-      "name": "Imlib2 License",
-      "licenseId": "Imlib2",
-      "seeAlso": [
-        "http://trac.enlightenment.org/e/browser/trunk/imlib2/COPYING",
-        "https://git.enlightenment.org/legacy/imlib2.git/tree/COPYING"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Info-ZIP.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Info-ZIP.json",
-      "referenceNumber": "163",
-      "name": "Info-ZIP License",
-      "licenseId": "Info-ZIP",
-      "seeAlso": [
-        "http://www.info-zip.org/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Intel-ACPI.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Intel-ACPI.json",
-      "referenceNumber": "164",
-      "name": "Intel ACPI Software License Agreement",
-      "licenseId": "Intel-ACPI",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Intel_ACPI_Software_License_Agreement"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Intel.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Intel.json",
-      "referenceNumber": "165",
-      "name": "Intel Open Source License",
-      "licenseId": "Intel",
-      "seeAlso": [
-        "http://opensource.org/licenses/Intel"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Interbase-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Interbase-1.0.json",
-      "referenceNumber": "166",
-      "name": "Interbase Public License v1.0",
-      "licenseId": "Interbase-1.0",
-      "seeAlso": [
-        "https://web.archive.org/web/20060319014854/http://info.borland.com/devsupport/interbase/opensource/IPL.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./JSON.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/JSON.json",
-      "referenceNumber": "167",
-      "name": "JSON License",
-      "licenseId": "JSON",
-      "seeAlso": [
-        "http://www.json.org/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./JasPer-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/JasPer-2.0.json",
-      "referenceNumber": "168",
-      "name": "JasPer License",
-      "licenseId": "JasPer-2.0",
-      "seeAlso": [
-        "http://www.ece.uvic.ca/~mdadams/jasper/LICENSE"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LAL-1.2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LAL-1.2.json",
-      "referenceNumber": "169",
-      "name": "Licence Art Libre 1.2",
-      "licenseId": "LAL-1.2",
-      "seeAlso": [
-        "http://artlibre.org/licence/lal/licence-art-libre-12/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LAL-1.3.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LAL-1.3.json",
-      "referenceNumber": "170",
-      "name": "Licence Art Libre 1.3",
-      "licenseId": "LAL-1.3",
-      "seeAlso": [
-        "http://artlibre.org/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LGPL-2.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.0-only.json",
-      "referenceNumber": "171",
-      "name": "GNU Library General Public License v2 only",
-      "licenseId": "LGPL-2.0-only",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-2.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.0-or-later.json",
-      "referenceNumber": "172",
-      "name": "GNU Library General Public License v2 or later",
-      "licenseId": "LGPL-2.0-or-later",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-2.1-only.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.1-only.json",
-      "referenceNumber": "173",
-      "name": "GNU Lesser General Public License v2.1 only",
-      "licenseId": "LGPL-2.1-only",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-2.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-2.1-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.1-or-later.json",
-      "referenceNumber": "174",
-      "name": "GNU Lesser General Public License v2.1 or later",
-      "licenseId": "LGPL-2.1-or-later",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-2.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-3.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-3.0-only.json",
-      "referenceNumber": "175",
-      "name": "GNU Lesser General Public License v3.0 only",
-      "licenseId": "LGPL-3.0-only",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-3.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-3.0-or-later.json",
-      "referenceNumber": "176",
-      "name": "GNU Lesser General Public License v3.0 or later",
-      "licenseId": "LGPL-3.0-or-later",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPLLR.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LGPLLR.json",
-      "referenceNumber": "177",
-      "name": "Lesser General Public License For Linguistic Resources",
-      "licenseId": "LGPLLR",
-      "seeAlso": [
-        "http://www-igm.univ-mlv.fr/~unitex/lgpllr.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LPL-1.0.json",
-      "referenceNumber": "178",
-      "name": "Lucent Public License Version 1.0",
-      "licenseId": "LPL-1.0",
-      "seeAlso": [
-        "http://opensource.org/licenses/LPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LPL-1.02.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LPL-1.02.json",
-      "referenceNumber": "179",
-      "name": "Lucent Public License v1.02",
-      "licenseId": "LPL-1.02",
-      "seeAlso": [
-        "http://plan9.bell-labs.com/plan9/license.html",
-        "http://www.opensource.org/licenses/LPL-1.02"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LPPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LPPL-1.0.json",
-      "referenceNumber": "180",
-      "name": "LaTeX Project Public License v1.0",
-      "licenseId": "LPPL-1.0",
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-0.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LPPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LPPL-1.1.json",
-      "referenceNumber": "181",
-      "name": "LaTeX Project Public License v1.1",
-      "licenseId": "LPPL-1.1",
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-1.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LPPL-1.2.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LPPL-1.2.json",
-      "referenceNumber": "182",
-      "name": "LaTeX Project Public License v1.2",
-      "licenseId": "LPPL-1.2",
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-2.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LPPL-1.3a.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LPPL-1.3a.json",
-      "referenceNumber": "183",
-      "name": "LaTeX Project Public License v1.3a",
-      "licenseId": "LPPL-1.3a",
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-3a.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LPPL-1.3c.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LPPL-1.3c.json",
-      "referenceNumber": "184",
-      "name": "LaTeX Project Public License v1.3c",
-      "licenseId": "LPPL-1.3c",
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-3c.txt",
-        "http://www.opensource.org/licenses/LPPL-1.3c"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Latex2e.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Latex2e.json",
-      "referenceNumber": "185",
-      "name": "Latex2e License",
-      "licenseId": "Latex2e",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Latex2e"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Leptonica.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Leptonica.json",
-      "referenceNumber": "186",
-      "name": "Leptonica License",
-      "licenseId": "Leptonica",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Leptonica"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LiLiQ-P-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LiLiQ-P-1.1.json",
-      "referenceNumber": "187",
-      "name": "Licence Libre du Québec – Permissive version 1.1",
-      "licenseId": "LiLiQ-P-1.1",
-      "seeAlso": [
-        "https://forge.gouv.qc.ca/licence/fr/liliq-v1-1/",
-        "http://opensource.org/licenses/LiLiQ-P-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LiLiQ-R-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LiLiQ-R-1.1.json",
-      "referenceNumber": "188",
-      "name": "Licence Libre du Québec – Réciprocité version 1.1",
-      "licenseId": "LiLiQ-R-1.1",
-      "seeAlso": [
-        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-liliq-r-v1-1/",
-        "http://opensource.org/licenses/LiLiQ-R-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LiLiQ-Rplus-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LiLiQ-Rplus-1.1.json",
-      "referenceNumber": "189",
-      "name": "Licence Libre du Québec – Réciprocité forte version 1.1",
-      "licenseId": "LiLiQ-Rplus-1.1",
-      "seeAlso": [
-        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-forte-liliq-r-v1-1/",
-        "http://opensource.org/licenses/LiLiQ-Rplus-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Libpng.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Libpng.json",
-      "referenceNumber": "190",
-      "name": "libpng License",
-      "licenseId": "Libpng",
-      "seeAlso": [
-        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Linux-OpenIB.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Linux-OpenIB.json",
-      "referenceNumber": "191",
-      "name": "Linux Kernel Variant of OpenIB.org license",
-      "licenseId": "Linux-OpenIB",
-      "seeAlso": [
-        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/infiniband/core/sa.h"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./MIT-0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MIT-0.json",
-      "referenceNumber": "192",
-      "name": "MIT No Attribution",
-      "licenseId": "MIT-0",
-      "seeAlso": [
-        "https://github.com/aws/mit-0",
-        "https://romanrm.net/mit-zero",
-        "https://github.com/awsdocs/aws-cloud9-user-guide/blob/master/LICENSE-SAMPLECODE"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./MIT-CMU.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MIT-CMU.json",
-      "referenceNumber": "193",
-      "name": "CMU License",
-      "licenseId": "MIT-CMU",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing:MIT?rd\u003dLicensing/MIT#CMU_Style"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./MIT-advertising.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MIT-advertising.json",
-      "referenceNumber": "194",
-      "name": "Enlightenment License (e16)",
-      "licenseId": "MIT-advertising",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MIT_With_Advertising"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./MIT-enna.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MIT-enna.json",
-      "referenceNumber": "195",
-      "name": "enna License",
-      "licenseId": "MIT-enna",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MIT#enna"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./MIT-feh.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MIT-feh.json",
-      "referenceNumber": "196",
-      "name": "feh License",
-      "licenseId": "MIT-feh",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MIT#feh"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./MIT.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/MIT.json",
-      "referenceNumber": "197",
-      "name": "MIT License",
-      "licenseId": "MIT",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/MIT"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./MITNFA.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MITNFA.json",
-      "referenceNumber": "198",
-      "name": "MIT +no-false-attribs license",
-      "licenseId": "MITNFA",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MITNFA"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./MPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MPL-1.0.json",
-      "referenceNumber": "199",
-      "name": "Mozilla Public License 1.0",
-      "licenseId": "MPL-1.0",
-      "seeAlso": [
-        "http://www.mozilla.org/MPL/MPL-1.0.html",
-        "http://opensource.org/licenses/MPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./MPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/MPL-1.1.json",
-      "referenceNumber": "200",
-      "name": "Mozilla Public License 1.1",
-      "licenseId": "MPL-1.1",
-      "seeAlso": [
-        "http://www.mozilla.org/MPL/MPL-1.1.html",
-        "http://www.opensource.org/licenses/MPL-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./MPL-2.0-no-copyleft-exception.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MPL-2.0-no-copyleft-exception.json",
-      "referenceNumber": "201",
-      "name": "Mozilla Public License 2.0 (no copyleft exception)",
-      "licenseId": "MPL-2.0-no-copyleft-exception",
-      "seeAlso": [
-        "http://www.mozilla.org/MPL/2.0/",
-        "http://opensource.org/licenses/MPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./MPL-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/MPL-2.0.json",
-      "referenceNumber": "202",
-      "name": "Mozilla Public License 2.0",
-      "licenseId": "MPL-2.0",
-      "seeAlso": [
-        "http://www.mozilla.org/MPL/2.0/",
-        "http://opensource.org/licenses/MPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./MS-PL.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/MS-PL.json",
-      "referenceNumber": "203",
-      "name": "Microsoft Public License",
-      "licenseId": "MS-PL",
-      "seeAlso": [
-        "http://www.microsoft.com/opensource/licenses.mspx",
-        "http://www.opensource.org/licenses/MS-PL"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./MS-RL.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/MS-RL.json",
-      "referenceNumber": "204",
-      "name": "Microsoft Reciprocal License",
-      "licenseId": "MS-RL",
-      "seeAlso": [
-        "http://www.microsoft.com/opensource/licenses.mspx",
-        "http://www.opensource.org/licenses/MS-RL"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./MTLL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MTLL.json",
-      "referenceNumber": "205",
-      "name": "Matrix Template Library License",
-      "licenseId": "MTLL",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Matrix_Template_Library_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./MakeIndex.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MakeIndex.json",
-      "referenceNumber": "206",
-      "name": "MakeIndex License",
-      "licenseId": "MakeIndex",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MakeIndex"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./MirOS.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MirOS.json",
-      "referenceNumber": "207",
-      "name": "MirOS License",
-      "licenseId": "MirOS",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/MirOS"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Motosoto.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Motosoto.json",
-      "referenceNumber": "208",
-      "name": "Motosoto License",
-      "licenseId": "Motosoto",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/Motosoto"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Multics.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Multics.json",
-      "referenceNumber": "209",
-      "name": "Multics License",
-      "licenseId": "Multics",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/Multics"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Mup.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Mup.json",
-      "referenceNumber": "210",
-      "name": "Mup License",
-      "licenseId": "Mup",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Mup"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NASA-1.3.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NASA-1.3.json",
-      "referenceNumber": "211",
-      "name": "NASA Open Source Agreement 1.3",
-      "licenseId": "NASA-1.3",
-      "seeAlso": [
-        "http://ti.arc.nasa.gov/opensource/nosa/",
-        "http://www.opensource.org/licenses/NASA-1.3"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./NBPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NBPL-1.0.json",
-      "referenceNumber": "212",
-      "name": "Net Boolean Public License v1",
-      "licenseId": "NBPL-1.0",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d37b4b3f6cc4bf34e1d3dec61e69914b9819d8894"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NCSA.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/NCSA.json",
-      "referenceNumber": "213",
-      "name": "University of Illinois/NCSA Open Source License",
-      "licenseId": "NCSA",
-      "seeAlso": [
-        "http://otm.illinois.edu/uiuc_openSource",
-        "http://www.opensource.org/licenses/NCSA"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./NGPL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NGPL.json",
-      "referenceNumber": "214",
-      "name": "Nethack General Public License",
-      "licenseId": "NGPL",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/NGPL"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./NLOD-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NLOD-1.0.json",
-      "referenceNumber": "215",
-      "name": "Norwegian Licence for Open Government Data",
-      "licenseId": "NLOD-1.0",
-      "seeAlso": [
-        "http://data.norge.no/nlod/en/1.0"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NLPL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NLPL.json",
-      "referenceNumber": "216",
-      "name": "No Limit Public License",
-      "licenseId": "NLPL",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/NLPL"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NOSL.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/NOSL.json",
-      "referenceNumber": "217",
-      "name": "Netizen Open Source License",
-      "licenseId": "NOSL",
-      "seeAlso": [
-        "http://bits.netizen.com.au/licenses/NOSL/nosl.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/NPL-1.0.json",
-      "referenceNumber": "218",
-      "name": "Netscape Public License v1.0",
-      "licenseId": "NPL-1.0",
-      "seeAlso": [
-        "http://www.mozilla.org/MPL/NPL/1.0/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/NPL-1.1.json",
-      "referenceNumber": "219",
-      "name": "Netscape Public License v1.1",
-      "licenseId": "NPL-1.1",
-      "seeAlso": [
-        "http://www.mozilla.org/MPL/NPL/1.1/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NPOSL-3.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NPOSL-3.0.json",
-      "referenceNumber": "220",
-      "name": "Non-Profit Open Software License 3.0",
-      "licenseId": "NPOSL-3.0",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/NOSL3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./NRL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NRL.json",
-      "referenceNumber": "221",
-      "name": "NRL License",
-      "licenseId": "NRL",
-      "seeAlso": [
-        "http://web.mit.edu/network/isakmp/nrllicense.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NTP.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NTP.json",
-      "referenceNumber": "222",
-      "name": "NTP License",
-      "licenseId": "NTP",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/NTP"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Naumen.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Naumen.json",
-      "referenceNumber": "223",
-      "name": "Naumen Public License",
-      "licenseId": "Naumen",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/Naumen"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Net-SNMP.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Net-SNMP.json",
-      "referenceNumber": "224",
-      "name": "Net-SNMP License",
-      "licenseId": "Net-SNMP",
-      "seeAlso": [
-        "http://net-snmp.sourceforge.net/about/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NetCDF.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NetCDF.json",
-      "referenceNumber": "225",
-      "name": "NetCDF license",
-      "licenseId": "NetCDF",
-      "seeAlso": [
-        "http://www.unidata.ucar.edu/software/netcdf/copyright.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Newsletr.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Newsletr.json",
-      "referenceNumber": "226",
-      "name": "Newsletr License",
-      "licenseId": "Newsletr",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Newsletr"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Nokia.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Nokia.json",
-      "referenceNumber": "227",
-      "name": "Nokia Open Source License",
-      "licenseId": "Nokia",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/nokia"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Noweb.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Noweb.json",
-      "referenceNumber": "228",
-      "name": "Noweb License",
-      "licenseId": "Noweb",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Noweb"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OCCT-PL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OCCT-PL.json",
-      "referenceNumber": "229",
-      "name": "Open CASCADE Technology Public License",
-      "licenseId": "OCCT-PL",
-      "seeAlso": [
-        "http://www.opencascade.com/content/occt-public-license"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OCLC-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OCLC-2.0.json",
-      "referenceNumber": "230",
-      "name": "OCLC Research Public License 2.0",
-      "licenseId": "OCLC-2.0",
-      "seeAlso": [
-        "http://www.oclc.org/research/activities/software/license/v2final.htm",
-        "http://www.opensource.org/licenses/OCLC-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./ODC-By-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/ODC-By-1.0.json",
-      "referenceNumber": "231",
-      "name": "Open Data Commons Attribution License v1.0",
-      "licenseId": "ODC-By-1.0",
-      "seeAlso": [
-        "https://opendatacommons.org/licenses/by/1.0/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./ODbL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/ODbL-1.0.json",
-      "referenceNumber": "232",
-      "name": "ODC Open Database License v1.0",
-      "licenseId": "ODbL-1.0",
-      "seeAlso": [
-        "http://www.opendatacommons.org/licenses/odbl/1.0/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OFL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OFL-1.0.json",
-      "referenceNumber": "233",
-      "name": "SIL Open Font License 1.0",
-      "licenseId": "OFL-1.0",
-      "seeAlso": [
-        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL10_web"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OFL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OFL-1.1.json",
-      "referenceNumber": "234",
-      "name": "SIL Open Font License 1.1",
-      "licenseId": "OFL-1.1",
-      "seeAlso": [
-        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL_web",
-        "http://www.opensource.org/licenses/OFL-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./OGTSL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OGTSL.json",
-      "referenceNumber": "235",
-      "name": "Open Group Test Suite License",
-      "licenseId": "OGTSL",
-      "seeAlso": [
-        "http://www.opengroup.org/testing/downloads/The_Open_Group_TSL.txt",
-        "http://www.opensource.org/licenses/OGTSL"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./OLDAP-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-1.1.json",
-      "referenceNumber": "236",
-      "name": "Open LDAP Public License v1.1",
-      "licenseId": "OLDAP-1.1",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d806557a5ad59804ef3a44d5abfbe91d706b0791f"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-1.2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-1.2.json",
-      "referenceNumber": "237",
-      "name": "Open LDAP Public License v1.2",
-      "licenseId": "OLDAP-1.2",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d42b0383c50c299977b5893ee695cf4e486fb0dc7"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-1.3.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-1.3.json",
-      "referenceNumber": "238",
-      "name": "Open LDAP Public License v1.3",
-      "licenseId": "OLDAP-1.3",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003de5f8117f0ce088d0bd7a8e18ddf37eaa40eb09b1"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-1.4.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-1.4.json",
-      "referenceNumber": "239",
-      "name": "Open LDAP Public License v1.4",
-      "licenseId": "OLDAP-1.4",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dc9f95c2f3f2ffb5e0ae55fe7388af75547660941"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.0.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.0.1.json",
-      "referenceNumber": "240",
-      "name": "Open LDAP Public License v2.0.1",
-      "licenseId": "OLDAP-2.0.1",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003db6d68acd14e51ca3aab4428bf26522aa74873f0e"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.0.json",
-      "referenceNumber": "241",
-      "name": "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
-      "licenseId": "OLDAP-2.0",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dcbf50f4e1185a21abd4c0a54d3f4341fe28f36ea"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.1.json",
-      "referenceNumber": "242",
-      "name": "Open LDAP Public License v2.1",
-      "licenseId": "OLDAP-2.1",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003db0d176738e96a0d3b9f85cb51e140a86f21be715"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.2.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.1.json",
-      "referenceNumber": "243",
-      "name": "Open LDAP Public License v2.2.1",
-      "licenseId": "OLDAP-2.2.1",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d4bc786f34b50aa301be6f5600f58a980070f481e"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.2.2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.2.json",
-      "referenceNumber": "244",
-      "name": "Open LDAP Public License 2.2.2",
-      "licenseId": "OLDAP-2.2.2",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003ddf2cc1e21eb7c160695f5b7cffd6296c151ba188"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.json",
-      "referenceNumber": "245",
-      "name": "Open LDAP Public License v2.2",
-      "licenseId": "OLDAP-2.2",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d470b0c18ec67621c85881b2733057fecf4a1acc3"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.3.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.3.json",
-      "referenceNumber": "246",
-      "name": "Open LDAP Public License v2.3",
-      "licenseId": "OLDAP-2.3",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dd32cf54a32d581ab475d23c810b0a7fbaf8d63c3"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.4.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.4.json",
-      "referenceNumber": "247",
-      "name": "Open LDAP Public License v2.4",
-      "licenseId": "OLDAP-2.4",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dcd1284c4a91a8a380d904eee68d1583f989ed386"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.5.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.5.json",
-      "referenceNumber": "248",
-      "name": "Open LDAP Public License v2.5",
-      "licenseId": "OLDAP-2.5",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d6852b9d90022e8593c98205413380536b1b5a7cf"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.6.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.6.json",
-      "referenceNumber": "249",
-      "name": "Open LDAP Public License v2.6",
-      "licenseId": "OLDAP-2.6",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d1cae062821881f41b73012ba816434897abf4205"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.7.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.7.json",
-      "referenceNumber": "250",
-      "name": "Open LDAP Public License v2.7",
-      "licenseId": "OLDAP-2.7",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d47c2415c1df81556eeb39be6cad458ef87c534a2"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OLDAP-2.8.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.8.json",
-      "referenceNumber": "251",
-      "name": "Open LDAP Public License v2.8",
-      "licenseId": "OLDAP-2.8",
-      "seeAlso": [
-        "http://www.openldap.org/software/release/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OML.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OML.json",
-      "referenceNumber": "252",
-      "name": "Open Market License",
-      "licenseId": "OML",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Open_Market_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OPL-1.0.json",
-      "referenceNumber": "253",
-      "name": "Open Public License v1.0",
-      "licenseId": "OPL-1.0",
-      "seeAlso": [
-        "http://old.koalateam.com/jackaroo/OPL_1_0.TXT",
-        "https://fedoraproject.org/wiki/Licensing/Open_Public_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OSET-PL-2.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OSET-PL-2.1.json",
-      "referenceNumber": "254",
-      "name": "OSET Public License version 2.1",
-      "licenseId": "OSET-PL-2.1",
-      "seeAlso": [
-        "http://www.osetfoundation.org/public-license",
-        "http://opensource.org/licenses/OPL-2.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./OSL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OSL-1.0.json",
-      "referenceNumber": "255",
-      "name": "Open Software License 1.0",
-      "licenseId": "OSL-1.0",
-      "seeAlso": [
-        "http://opensource.org/licenses/OSL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./OSL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OSL-1.1.json",
-      "referenceNumber": "256",
-      "name": "Open Software License 1.1",
-      "licenseId": "OSL-1.1",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/OSL1.1"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./OSL-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OSL-2.0.json",
-      "referenceNumber": "257",
-      "name": "Open Software License 2.0",
-      "licenseId": "OSL-2.0",
-      "seeAlso": [
-        "http://web.archive.org/web/20041020171434/http://www.rosenlaw.com/osl2.0.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./OSL-2.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OSL-2.1.json",
-      "referenceNumber": "258",
-      "name": "Open Software License 2.1",
-      "licenseId": "OSL-2.1",
-      "seeAlso": [
-        "http://web.archive.org/web/20050212003940/http://www.rosenlaw.com/osl21.htm",
-        "http://opensource.org/licenses/OSL-2.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./OSL-3.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OSL-3.0.json",
-      "referenceNumber": "259",
-      "name": "Open Software License 3.0",
-      "licenseId": "OSL-3.0",
-      "seeAlso": [
-        "http://www.rosenlaw.com/OSL3.0.htm",
-        "http://www.opensource.org/licenses/OSL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./OpenSSL.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OpenSSL.json",
-      "referenceNumber": "260",
-      "name": "OpenSSL License",
-      "licenseId": "OpenSSL",
-      "seeAlso": [
-        "http://www.openssl.org/source/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./PDDL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/PDDL-1.0.json",
-      "referenceNumber": "261",
-      "name": "ODC Public Domain Dedication \u0026 License 1.0",
-      "licenseId": "PDDL-1.0",
-      "seeAlso": [
-        "http://opendatacommons.org/licenses/pddl/1.0/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./PHP-3.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/PHP-3.0.json",
-      "referenceNumber": "262",
-      "name": "PHP License v3.0",
-      "licenseId": "PHP-3.0",
-      "seeAlso": [
-        "http://www.php.net/license/3_0.txt",
-        "http://www.opensource.org/licenses/PHP-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./PHP-3.01.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/PHP-3.01.json",
-      "referenceNumber": "263",
-      "name": "PHP License v3.01",
-      "licenseId": "PHP-3.01",
-      "seeAlso": [
-        "http://www.php.net/license/3_01.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Plexus.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Plexus.json",
-      "referenceNumber": "264",
-      "name": "Plexus Classworlds License",
-      "licenseId": "Plexus",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Plexus_Classworlds_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./PostgreSQL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/PostgreSQL.json",
-      "referenceNumber": "265",
-      "name": "PostgreSQL License",
-      "licenseId": "PostgreSQL",
-      "seeAlso": [
-        "http://www.postgresql.org/about/licence",
-        "http://www.opensource.org/licenses/PostgreSQL"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Python-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Python-2.0.json",
-      "referenceNumber": "266",
-      "name": "Python License 2.0",
-      "licenseId": "Python-2.0",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/Python-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./QPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/QPL-1.0.json",
-      "referenceNumber": "267",
-      "name": "Q Public License 1.0",
-      "licenseId": "QPL-1.0",
-      "seeAlso": [
-        "http://doc.qt.nokia.com/3.3/license.html",
-        "http://www.opensource.org/licenses/QPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Qhull.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Qhull.json",
-      "referenceNumber": "268",
-      "name": "Qhull License",
-      "licenseId": "Qhull",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Qhull"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./RHeCos-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/RHeCos-1.1.json",
-      "referenceNumber": "269",
-      "name": "Red Hat eCos Public License v1.1",
-      "licenseId": "RHeCos-1.1",
-      "seeAlso": [
-        "http://ecos.sourceware.org/old-license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./RPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/RPL-1.1.json",
-      "referenceNumber": "270",
-      "name": "Reciprocal Public License 1.1",
-      "licenseId": "RPL-1.1",
-      "seeAlso": [
-        "http://opensource.org/licenses/RPL-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./RPL-1.5.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/RPL-1.5.json",
-      "referenceNumber": "271",
-      "name": "Reciprocal Public License 1.5",
-      "licenseId": "RPL-1.5",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/RPL-1.5"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./RPSL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/RPSL-1.0.json",
-      "referenceNumber": "272",
-      "name": "RealNetworks Public Source License v1.0",
-      "licenseId": "RPSL-1.0",
-      "seeAlso": [
-        "https://helixcommunity.org/content/rpsl",
-        "http://www.opensource.org/licenses/RPSL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./RSA-MD.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/RSA-MD.json",
-      "referenceNumber": "273",
-      "name": "RSA Message-Digest License ",
-      "licenseId": "RSA-MD",
-      "seeAlso": [
-        "http://www.faqs.org/rfcs/rfc1321.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./RSCPL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/RSCPL.json",
-      "referenceNumber": "274",
-      "name": "Ricoh Source Code Public License",
-      "licenseId": "RSCPL",
-      "seeAlso": [
-        "http://wayback.archive.org/web/20060715140826/http://www.risource.org/RPL/RPL-1.0A.shtml",
-        "http://www.opensource.org/licenses/RSCPL"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Rdisc.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Rdisc.json",
-      "referenceNumber": "275",
-      "name": "Rdisc License",
-      "licenseId": "Rdisc",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Rdisc_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Ruby.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Ruby.json",
-      "referenceNumber": "276",
-      "name": "Ruby License",
-      "licenseId": "Ruby",
-      "seeAlso": [
-        "http://www.ruby-lang.org/en/LICENSE.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SAX-PD.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SAX-PD.json",
-      "referenceNumber": "277",
-      "name": "Sax Public Domain Notice",
-      "licenseId": "SAX-PD",
-      "seeAlso": [
-        "http://www.saxproject.org/copying.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SCEA.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SCEA.json",
-      "referenceNumber": "278",
-      "name": "SCEA Shared Source License",
-      "licenseId": "SCEA",
-      "seeAlso": [
-        "http://research.scea.com/scea_shared_source_license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SGI-B-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SGI-B-1.0.json",
-      "referenceNumber": "279",
-      "name": "SGI Free Software License B v1.0",
-      "licenseId": "SGI-B-1.0",
-      "seeAlso": [
-        "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.1.0.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SGI-B-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SGI-B-1.1.json",
-      "referenceNumber": "280",
-      "name": "SGI Free Software License B v1.1",
-      "licenseId": "SGI-B-1.1",
-      "seeAlso": [
-        "http://oss.sgi.com/projects/FreeB/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SGI-B-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/SGI-B-2.0.json",
-      "referenceNumber": "281",
-      "name": "SGI Free Software License B v2.0",
-      "licenseId": "SGI-B-2.0",
-      "seeAlso": [
-        "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.2.0.pdf"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SISSL-1.2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SISSL-1.2.json",
-      "referenceNumber": "282",
-      "name": "Sun Industry Standards Source License v1.2",
-      "licenseId": "SISSL-1.2",
-      "seeAlso": [
-        "http://gridscheduler.sourceforge.net/Gridengine_SISSL_license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SISSL.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/SISSL.json",
-      "referenceNumber": "283",
-      "name": "Sun Industry Standards Source License v1.1",
-      "licenseId": "SISSL",
-      "seeAlso": [
-        "http://www.openoffice.org/licenses/sissl_license.html",
-        "http://opensource.org/licenses/SISSL"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./SMLNJ.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/SMLNJ.json",
-      "referenceNumber": "284",
-      "name": "Standard ML of New Jersey License",
-      "licenseId": "SMLNJ",
-      "seeAlso": [
-        "https://www.smlnj.org/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SMPPL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SMPPL.json",
-      "referenceNumber": "285",
-      "name": "Secure Messaging Protocol Public License",
-      "licenseId": "SMPPL",
-      "seeAlso": [
-        "https://github.com/dcblake/SMP/blob/master/Documentation/License.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SNIA.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SNIA.json",
-      "referenceNumber": "286",
-      "name": "SNIA Public License 1.1",
-      "licenseId": "SNIA",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/SNIA_Public_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/SPL-1.0.json",
-      "referenceNumber": "287",
-      "name": "Sun Public License v1.0",
-      "licenseId": "SPL-1.0",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/SPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./SWL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SWL.json",
-      "referenceNumber": "288",
-      "name": "Scheme Widget Library (SWL) Software License Agreement",
-      "licenseId": "SWL",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/SWL"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Saxpath.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Saxpath.json",
-      "referenceNumber": "289",
-      "name": "Saxpath License",
-      "licenseId": "Saxpath",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Saxpath_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Sendmail.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Sendmail.json",
-      "referenceNumber": "290",
-      "name": "Sendmail License",
-      "licenseId": "Sendmail",
-      "seeAlso": [
-        "http://www.sendmail.com/pdfs/open_source/sendmail_license.pdf",
-        "https://web.archive.org/web/20160322142305/https://www.sendmail.com/pdfs/open_source/sendmail_license.pdf"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SimPL-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SimPL-2.0.json",
-      "referenceNumber": "291",
-      "name": "Simple Public License 2.0",
-      "licenseId": "SimPL-2.0",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/SimPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Sleepycat.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Sleepycat.json",
-      "referenceNumber": "292",
-      "name": "Sleepycat License",
-      "licenseId": "Sleepycat",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/Sleepycat"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Spencer-86.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Spencer-86.json",
-      "referenceNumber": "293",
-      "name": "Spencer License 86",
-      "licenseId": "Spencer-86",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Spencer-94.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Spencer-94.json",
-      "referenceNumber": "294",
-      "name": "Spencer License 94",
-      "licenseId": "Spencer-94",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Spencer-99.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Spencer-99.json",
-      "referenceNumber": "295",
-      "name": "Spencer License 99",
-      "licenseId": "Spencer-99",
-      "seeAlso": [
-        "http://www.opensource.apple.com/source/tcl/tcl-5/tcl/generic/regfronts.c"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SugarCRM-1.1.3.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SugarCRM-1.1.3.json",
-      "referenceNumber": "296",
-      "name": "SugarCRM Public License v1.1.3",
-      "licenseId": "SugarCRM-1.1.3",
-      "seeAlso": [
-        "http://www.sugarcrm.com/crm/SPL"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./TCL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/TCL.json",
-      "referenceNumber": "297",
-      "name": "TCL/TK License",
-      "licenseId": "TCL",
-      "seeAlso": [
-        "http://www.tcl.tk/software/tcltk/license.html",
-        "https://fedoraproject.org/wiki/Licensing/TCL"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./TCP-wrappers.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/TCP-wrappers.json",
-      "referenceNumber": "298",
-      "name": "TCP Wrappers License",
-      "licenseId": "TCP-wrappers",
-      "seeAlso": [
-        "http://rc.quest.com/topics/openssh/license.php#tcpwrappers"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./TMate.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/TMate.json",
-      "referenceNumber": "299",
-      "name": "TMate Open Source License",
-      "licenseId": "TMate",
-      "seeAlso": [
-        "http://svnkit.com/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./TORQUE-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/TORQUE-1.1.json",
-      "referenceNumber": "300",
-      "name": "TORQUE v2.5+ Software License v1.1",
-      "licenseId": "TORQUE-1.1",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/TORQUEv1.1"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./TOSL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/TOSL.json",
-      "referenceNumber": "301",
-      "name": "Trusster Open Source License",
-      "licenseId": "TOSL",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/TOSL"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./TU-Berlin-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/TU-Berlin-1.0.json",
-      "referenceNumber": "302",
-      "name": "Technische Universitaet Berlin License 1.0",
-      "licenseId": "TU-Berlin-1.0",
-      "seeAlso": [
-        "https://github.com/swh/ladspa/blob/7bf6f3799fdba70fda297c2d8fd9f526803d9680/gsm/COPYRIGHT"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./TU-Berlin-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/TU-Berlin-2.0.json",
-      "referenceNumber": "303",
-      "name": "Technische Universitaet Berlin License 2.0",
-      "licenseId": "TU-Berlin-2.0",
-      "seeAlso": [
-        "https://github.com/CorsixTH/deps/blob/fd339a9f526d1d9c9f01ccf39e438a015da50035/licences/libgsm.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./UPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/UPL-1.0.json",
-      "referenceNumber": "304",
-      "name": "Universal Permissive License v1.0",
-      "licenseId": "UPL-1.0",
-      "seeAlso": [
-        "http://opensource.org/licenses/UPL"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Unicode-DFS-2015.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Unicode-DFS-2015.json",
-      "referenceNumber": "305",
-      "name": "Unicode License Agreement - Data Files and Software (2015)",
-      "licenseId": "Unicode-DFS-2015",
-      "seeAlso": [
-        "https://web.archive.org/web/20151224134844/http://unicode.org/copyright.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Unicode-DFS-2016.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Unicode-DFS-2016.json",
-      "referenceNumber": "306",
-      "name": "Unicode License Agreement - Data Files and Software (2016)",
-      "licenseId": "Unicode-DFS-2016",
-      "seeAlso": [
-        "http://www.unicode.org/copyright.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Unicode-TOU.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Unicode-TOU.json",
-      "referenceNumber": "307",
-      "name": "Unicode Terms of Use",
-      "licenseId": "Unicode-TOU",
-      "seeAlso": [
-        "http://www.unicode.org/copyright.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Unlicense.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Unlicense.json",
-      "referenceNumber": "308",
-      "name": "The Unlicense",
-      "licenseId": "Unlicense",
-      "seeAlso": [
-        "http://unlicense.org/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./VOSTROM.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/VOSTROM.json",
-      "referenceNumber": "309",
-      "name": "VOSTROM Public License for Open Source",
-      "licenseId": "VOSTROM",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/VOSTROM"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./VSL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/VSL-1.0.json",
-      "referenceNumber": "310",
-      "name": "Vovida Software License v1.0",
-      "licenseId": "VSL-1.0",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/VSL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Vim.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Vim.json",
-      "referenceNumber": "311",
-      "name": "Vim License",
-      "licenseId": "Vim",
-      "seeAlso": [
-        "http://vimdoc.sourceforge.net/htmldoc/uganda.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./W3C-19980720.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/W3C-19980720.json",
-      "referenceNumber": "312",
-      "name": "W3C Software Notice and License (1998-07-20)",
-      "licenseId": "W3C-19980720",
-      "seeAlso": [
-        "http://www.w3.org/Consortium/Legal/copyright-software-19980720.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./W3C-20150513.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/W3C-20150513.json",
-      "referenceNumber": "313",
-      "name": "W3C Software Notice and Document License (2015-05-13)",
-      "licenseId": "W3C-20150513",
-      "seeAlso": [
-        "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./W3C.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/W3C.json",
-      "referenceNumber": "314",
-      "name": "W3C Software Notice and License (2002-12-31)",
-      "licenseId": "W3C",
-      "seeAlso": [
-        "http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html",
-        "http://www.opensource.org/licenses/W3C"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./WTFPL.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/WTFPL.json",
-      "referenceNumber": "315",
-      "name": "Do What The F*ck You Want To Public License",
-      "licenseId": "WTFPL",
-      "seeAlso": [
-        "http://sam.zoy.org/wtfpl/COPYING"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Watcom-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Watcom-1.0.json",
-      "referenceNumber": "316",
-      "name": "Sybase Open Watcom Public License 1.0",
-      "licenseId": "Watcom-1.0",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/Watcom-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Wsuipa.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Wsuipa.json",
-      "referenceNumber": "317",
-      "name": "Wsuipa License",
-      "licenseId": "Wsuipa",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Wsuipa"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./X11.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/X11.json",
-      "referenceNumber": "318",
-      "name": "X11 License",
-      "licenseId": "X11",
-      "seeAlso": [
-        "http://www.xfree86.org/3.3.6/COPYRIGHT2.html#3"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./XFree86-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/XFree86-1.1.json",
-      "referenceNumber": "319",
-      "name": "XFree86 License 1.1",
-      "licenseId": "XFree86-1.1",
-      "seeAlso": [
-        "http://www.xfree86.org/current/LICENSE4.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./XSkat.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/XSkat.json",
-      "referenceNumber": "320",
-      "name": "XSkat License",
-      "licenseId": "XSkat",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/XSkat_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Xerox.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Xerox.json",
-      "referenceNumber": "321",
-      "name": "Xerox License",
-      "licenseId": "Xerox",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Xerox"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Xnet.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Xnet.json",
-      "referenceNumber": "322",
-      "name": "X.Net License",
-      "licenseId": "Xnet",
-      "seeAlso": [
-        "http://opensource.org/licenses/Xnet"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./YPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/YPL-1.0.json",
-      "referenceNumber": "323",
-      "name": "Yahoo! Public License v1.0",
-      "licenseId": "YPL-1.0",
-      "seeAlso": [
-        "http://www.zimbra.com/license/yahoo_public_license_1.0.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./YPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/YPL-1.1.json",
-      "referenceNumber": "324",
-      "name": "Yahoo! Public License v1.1",
-      "licenseId": "YPL-1.1",
-      "seeAlso": [
-        "http://www.zimbra.com/license/yahoo_public_license_1.1.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./ZPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/ZPL-1.1.json",
-      "referenceNumber": "325",
-      "name": "Zope Public License 1.1",
-      "licenseId": "ZPL-1.1",
-      "seeAlso": [
-        "http://old.zope.org/Resources/License/ZPL-1.1"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./ZPL-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/ZPL-2.0.json",
-      "referenceNumber": "326",
-      "name": "Zope Public License 2.0",
-      "licenseId": "ZPL-2.0",
-      "seeAlso": [
-        "http://old.zope.org/Resources/License/ZPL-2.0",
-        "http://opensource.org/licenses/ZPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./ZPL-2.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/ZPL-2.1.json",
-      "referenceNumber": "327",
-      "name": "Zope Public License 2.1",
-      "licenseId": "ZPL-2.1",
-      "seeAlso": [
-        "http://old.zope.org/Resources/ZPL/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Zed.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Zed.json",
-      "referenceNumber": "328",
-      "name": "Zed License",
-      "licenseId": "Zed",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Zed"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Zend-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Zend-2.0.json",
-      "referenceNumber": "329",
-      "name": "Zend License v2.0",
-      "licenseId": "Zend-2.0",
-      "seeAlso": [
-        "https://web.archive.org/web/20130517195954/http://www.zend.com/license/2_00.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Zimbra-1.3.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Zimbra-1.3.json",
-      "referenceNumber": "330",
-      "name": "Zimbra Public License v1.3",
-      "licenseId": "Zimbra-1.3",
-      "seeAlso": [
-        "http://web.archive.org/web/20100302225219/http://www.zimbra.com/license/zimbra-public-license-1-3.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Zimbra-1.4.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Zimbra-1.4.json",
-      "referenceNumber": "331",
-      "name": "Zimbra Public License v1.4",
-      "licenseId": "Zimbra-1.4",
-      "seeAlso": [
-        "http://www.zimbra.com/legal/zimbra-public-license-1-4"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Zlib.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Zlib.json",
-      "referenceNumber": "332",
-      "name": "zlib License",
-      "licenseId": "Zlib",
-      "seeAlso": [
-        "http://www.zlib.net/zlib_license.html",
-        "http://www.opensource.org/licenses/Zlib"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./bzip2-1.0.5.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/bzip2-1.0.5.json",
-      "referenceNumber": "333",
-      "name": "bzip2 and libbzip2 License v1.0.5",
-      "licenseId": "bzip2-1.0.5",
-      "seeAlso": [
-        "http://bzip.org/1.0.5/bzip2-manual-1.0.5.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./bzip2-1.0.6.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/bzip2-1.0.6.json",
-      "referenceNumber": "334",
-      "name": "bzip2 and libbzip2 License v1.0.6",
-      "licenseId": "bzip2-1.0.6",
-      "seeAlso": [
-        "https://github.com/asimonov-im/bzip2/blob/master/LICENSE"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./curl.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/curl.json",
-      "referenceNumber": "335",
-      "name": "curl License",
-      "licenseId": "curl",
-      "seeAlso": [
-        "https://github.com/bagder/curl/blob/master/COPYING"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./diffmark.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/diffmark.json",
-      "referenceNumber": "336",
-      "name": "diffmark license",
-      "licenseId": "diffmark",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/diffmark"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./dvipdfm.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/dvipdfm.json",
-      "referenceNumber": "337",
-      "name": "dvipdfm License",
-      "licenseId": "dvipdfm",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/dvipdfm"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./eGenix.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/eGenix.json",
-      "referenceNumber": "338",
-      "name": "eGenix.com Public License 1.1.0",
-      "licenseId": "eGenix",
-      "seeAlso": [
-        "http://www.egenix.com/products/eGenix.com-Public-License-1.1.0.pdf",
-        "https://fedoraproject.org/wiki/Licensing/eGenix.com_Public_License_1.1.0"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./gSOAP-1.3b.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/gSOAP-1.3b.json",
-      "referenceNumber": "339",
-      "name": "gSOAP Public License v1.3b",
-      "licenseId": "gSOAP-1.3b",
-      "seeAlso": [
-        "http://www.cs.fsu.edu/~engelen/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./gnuplot.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/gnuplot.json",
-      "referenceNumber": "340",
-      "name": "gnuplot License",
-      "licenseId": "gnuplot",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Gnuplot"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./iMatix.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/iMatix.json",
-      "referenceNumber": "341",
-      "name": "iMatix Standard Function Library Agreement",
-      "licenseId": "iMatix",
-      "seeAlso": [
-        "http://legacy.imatix.com/html/sfl/sfl4.htm#license"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./libtiff.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/libtiff.json",
-      "referenceNumber": "342",
-      "name": "libtiff License",
-      "licenseId": "libtiff",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/libtiff"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./mpich2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/mpich2.json",
-      "referenceNumber": "343",
-      "name": "mpich2 License",
-      "licenseId": "mpich2",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MIT"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./psfrag.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/psfrag.json",
-      "referenceNumber": "344",
-      "name": "psfrag License",
-      "licenseId": "psfrag",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/psfrag"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./psutils.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/psutils.json",
-      "referenceNumber": "345",
-      "name": "psutils License",
-      "licenseId": "psutils",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/psutils"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./xinetd.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/xinetd.json",
-      "referenceNumber": "346",
-      "name": "xinetd License",
-      "licenseId": "xinetd",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Xinetd_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./xpp.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/xpp.json",
-      "referenceNumber": "347",
-      "name": "XPP License",
-      "licenseId": "xpp",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/xpp"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./zlib-acknowledgement.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/zlib-acknowledgement.json",
-      "referenceNumber": "348",
-      "name": "zlib/libpng License with Acknowledgement",
-      "licenseId": "zlib-acknowledgement",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/ZlibWithAcknowledgement"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./AGPL-1.0.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/AGPL-1.0.json",
-      "referenceNumber": "349",
-      "name": "Affero General Public License v1.0",
-      "licenseId": "AGPL-1.0",
-      "seeAlso": [
-        "http://www.affero.org/oagpl.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./AGPL-3.0.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/AGPL-3.0.json",
-      "referenceNumber": "350",
-      "name": "GNU Affero General Public License v3.0",
-      "licenseId": "AGPL-3.0",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/agpl.txt",
-        "http://www.opensource.org/licenses/AGPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GFDL-1.1.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.1.json",
-      "referenceNumber": "351",
-      "name": "GNU Free Documentation License v1.1",
-      "licenseId": "GFDL-1.1",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GFDL-1.2.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.2.json",
-      "referenceNumber": "352",
-      "name": "GNU Free Documentation License v1.2",
-      "licenseId": "GFDL-1.2",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GFDL-1.3.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.3.json",
-      "referenceNumber": "353",
-      "name": "GNU Free Documentation License v1.3",
-      "licenseId": "GFDL-1.3",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/fdl-1.3.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-1.0+.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-1.0+.json",
-      "referenceNumber": "354",
-      "name": "GNU General Public License v1.0 or later",
-      "licenseId": "GPL-1.0+",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-1.0.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-1.0.json",
-      "referenceNumber": "355",
-      "name": "GNU General Public License v1.0 only",
-      "licenseId": "GPL-1.0",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-2.0+.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0+.json",
-      "referenceNumber": "356",
-      "name": "GNU General Public License v2.0 or later",
-      "licenseId": "GPL-2.0+",
       "seeAlso": [
         "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
         "http://www.opensource.org/licenses/GPL-2.0"
@@ -4472,7 +1969,7 @@
       "reference": "./GPL-2.0-with-GCC-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-GCC-exception.json",
-      "referenceNumber": "357",
+      "referenceNumber": "111",
       "name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
       "licenseId": "GPL-2.0-with-GCC-exception",
       "seeAlso": [
@@ -4484,7 +1981,7 @@
       "reference": "./GPL-2.0-with-autoconf-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-autoconf-exception.json",
-      "referenceNumber": "358",
+      "referenceNumber": "343",
       "name": "GNU General Public License v2.0 w/Autoconf exception",
       "licenseId": "GPL-2.0-with-autoconf-exception",
       "seeAlso": [
@@ -4496,7 +1993,7 @@
       "reference": "./GPL-2.0-with-bison-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-bison-exception.json",
-      "referenceNumber": "359",
+      "referenceNumber": "364",
       "name": "GNU General Public License v2.0 w/Bison exception",
       "licenseId": "GPL-2.0-with-bison-exception",
       "seeAlso": [
@@ -4508,7 +2005,7 @@
       "reference": "./GPL-2.0-with-classpath-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-classpath-exception.json",
-      "referenceNumber": "360",
+      "referenceNumber": "58",
       "name": "GNU General Public License v2.0 w/Classpath exception",
       "licenseId": "GPL-2.0-with-classpath-exception",
       "seeAlso": [
@@ -4529,16 +2026,16 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./GPL-2.0.html",
+      "reference": "./GPL-3.0.html",
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0.json",
-      "referenceNumber": "362",
-      "name": "GNU General Public License v2.0 only",
-      "licenseId": "GPL-2.0",
+      "detailsUrl": "http://spdx.org/licenses/GPL-3.0.json",
+      "referenceNumber": "235",
+      "name": "GNU General Public License v3.0 only",
+      "licenseId": "GPL-3.0",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-2.0"
+        "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "http://www.opensource.org/licenses/GPL-3.0"
       ],
       "isOsiApproved": true
     },
@@ -4547,9 +2044,37 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0+.json",
-      "referenceNumber": "363",
+      "referenceNumber": "70",
       "name": "GNU General Public License v3.0 or later",
       "licenseId": "GPL-3.0+",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "http://www.opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-3.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-only.json",
+      "referenceNumber": "199",
+      "name": "GNU General Public License v3.0 only",
+      "licenseId": "GPL-3.0-only",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "http://www.opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-3.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-or-later.json",
+      "referenceNumber": "189",
+      "name": "GNU General Public License v3.0 or later",
+      "licenseId": "GPL-3.0-or-later",
       "seeAlso": [
         "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
         "http://www.opensource.org/licenses/GPL-3.0"
@@ -4560,7 +2085,7 @@
       "reference": "./GPL-3.0-with-GCC-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0-with-GCC-exception.json",
-      "referenceNumber": "364",
+      "referenceNumber": "214",
       "name": "GNU General Public License v3.0 w/GCC Runtime Library exception",
       "licenseId": "GPL-3.0-with-GCC-exception",
       "seeAlso": [
@@ -4572,7 +2097,7 @@
       "reference": "./GPL-3.0-with-autoconf-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0-with-autoconf-exception.json",
-      "referenceNumber": "365",
+      "referenceNumber": "228",
       "name": "GNU General Public License v3.0 w/Autoconf exception",
       "licenseId": "GPL-3.0-with-autoconf-exception",
       "seeAlso": [
@@ -4581,36 +2106,271 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./GPL-3.0.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-3.0.json",
-      "referenceNumber": "366",
-      "name": "GNU General Public License v3.0 only",
-      "licenseId": "GPL-3.0",
+      "reference": "./Giftware.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Giftware.json",
+      "referenceNumber": "356",
+      "name": "Giftware License",
+      "licenseId": "Giftware",
       "seeAlso": [
-        "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-3.0"
+        "http://liballeg.org/license.html#allegro-4-the-giftware-license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Glide.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Glide.json",
+      "referenceNumber": "360",
+      "name": "3dfx Glide License",
+      "licenseId": "Glide",
+      "seeAlso": [
+        "http://www.users.on.net/~triforce/glidexp/COPYING.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Glulxe.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Glulxe.json",
+      "referenceNumber": "88",
+      "name": "Glulxe License",
+      "licenseId": "Glulxe",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Glulxe"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./HPND.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/HPND.json",
+      "referenceNumber": "257",
+      "name": "Historical Permission Notice and Disclaimer",
+      "licenseId": "HPND",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/HPND"
       ],
       "isOsiApproved": true
     },
     {
-      "reference": "./LGPL-2.0+.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.0+.json",
-      "referenceNumber": "367",
-      "name": "GNU Library General Public License v2 or later",
-      "licenseId": "LGPL-2.0+",
+      "reference": "./HaskellReport.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/HaskellReport.json",
+      "referenceNumber": "116",
+      "name": "Haskell Language Report License",
+      "licenseId": "HaskellReport",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+        "https://fedoraproject.org/wiki/Licensing/Haskell_Language_Report_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./IBM-pibs.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/IBM-pibs.json",
+      "referenceNumber": "200",
+      "name": "IBM PowerPC Initialization and Boot Software",
+      "licenseId": "IBM-pibs",
+      "seeAlso": [
+        "http://git.denx.de/?p\u003du-boot.git;a\u003dblob;f\u003darch/powerpc/cpu/ppc4xx/miiphy.c;h\u003d297155fdafa064b955e53e9832de93bfb0cfb85b;hb\u003d9fab4bf4cc077c21e43941866f3f2c196f28670d"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./ICU.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/ICU.json",
+      "referenceNumber": "187",
+      "name": "ICU License",
+      "licenseId": "ICU",
+      "seeAlso": [
+        "http://source.icu-project.org/repos/icu/icu/trunk/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./IJG.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/IJG.json",
+      "referenceNumber": "53",
+      "name": "Independent JPEG Group License",
+      "licenseId": "IJG",
+      "seeAlso": [
+        "http://dev.w3.org/cvsweb/Amaya/libjpeg/Attic/README?rev\u003d1.2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./IPA.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/IPA.json",
+      "referenceNumber": "304",
+      "name": "IPA Font License",
+      "licenseId": "IPA",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/IPA"
       ],
       "isOsiApproved": true
+    },
+    {
+      "reference": "./IPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/IPL-1.0.json",
+      "referenceNumber": "29",
+      "name": "IBM Public License v1.0",
+      "licenseId": "IPL-1.0",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/IPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./ISC.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/ISC.json",
+      "referenceNumber": "104",
+      "name": "ISC License",
+      "licenseId": "ISC",
+      "seeAlso": [
+        "https://www.isc.org/downloads/software-support-policy/isc-license/",
+        "http://www.opensource.org/licenses/ISC"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./ImageMagick.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/ImageMagick.json",
+      "referenceNumber": "224",
+      "name": "ImageMagick License",
+      "licenseId": "ImageMagick",
+      "seeAlso": [
+        "http://www.imagemagick.org/script/license.php"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Imlib2.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Imlib2.json",
+      "referenceNumber": "250",
+      "name": "Imlib2 License",
+      "licenseId": "Imlib2",
+      "seeAlso": [
+        "http://trac.enlightenment.org/e/browser/trunk/imlib2/COPYING",
+        "https://git.enlightenment.org/legacy/imlib2.git/tree/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Info-ZIP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Info-ZIP.json",
+      "referenceNumber": "99",
+      "name": "Info-ZIP License",
+      "licenseId": "Info-ZIP",
+      "seeAlso": [
+        "http://www.info-zip.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Intel.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Intel.json",
+      "referenceNumber": "160",
+      "name": "Intel Open Source License",
+      "licenseId": "Intel",
+      "seeAlso": [
+        "http://opensource.org/licenses/Intel"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Intel-ACPI.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Intel-ACPI.json",
+      "referenceNumber": "84",
+      "name": "Intel ACPI Software License Agreement",
+      "licenseId": "Intel-ACPI",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Intel_ACPI_Software_License_Agreement"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Interbase-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Interbase-1.0.json",
+      "referenceNumber": "79",
+      "name": "Interbase Public License v1.0",
+      "licenseId": "Interbase-1.0",
+      "seeAlso": [
+        "https://web.archive.org/web/20060319014854/http://info.borland.com/devsupport/interbase/opensource/IPL.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./JSON.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/JSON.json",
+      "referenceNumber": "358",
+      "name": "JSON License",
+      "licenseId": "JSON",
+      "seeAlso": [
+        "http://www.json.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./JasPer-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/JasPer-2.0.json",
+      "referenceNumber": "232",
+      "name": "JasPer License",
+      "licenseId": "JasPer-2.0",
+      "seeAlso": [
+        "http://www.ece.uvic.ca/~mdadams/jasper/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LAL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LAL-1.2.json",
+      "referenceNumber": "366",
+      "name": "Licence Art Libre 1.2",
+      "licenseId": "LAL-1.2",
+      "seeAlso": [
+        "http://artlibre.org/licence/lal/licence-art-libre-12/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LAL-1.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LAL-1.3.json",
+      "referenceNumber": "149",
+      "name": "Licence Art Libre 1.3",
+      "licenseId": "LAL-1.3",
+      "seeAlso": [
+        "http://artlibre.org/"
+      ],
+      "isOsiApproved": false
     },
     {
       "reference": "./LGPL-2.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.0.json",
-      "referenceNumber": "368",
+      "referenceNumber": "260",
       "name": "GNU Library General Public License v2 only",
       "licenseId": "LGPL-2.0",
       "seeAlso": [
@@ -4619,16 +2379,38 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./LGPL-2.1+.html",
+      "reference": "./LGPL-2.0+.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.1+.json",
-      "referenceNumber": "369",
-      "name": "GNU Library General Public License v2.1 or later",
-      "licenseId": "LGPL-2.1+",
+      "detailsUrl": "http://spdx.org/licenses/LGPL-2.0+.json",
+      "referenceNumber": "50",
+      "name": "GNU Library General Public License v2 or later",
+      "licenseId": "LGPL-2.0+",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-2.1"
+        "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-2.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-2.0-only.json",
+      "referenceNumber": "268",
+      "name": "GNU Library General Public License v2 only",
+      "licenseId": "LGPL-2.0-only",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-2.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-2.0-or-later.json",
+      "referenceNumber": "210",
+      "name": "GNU Library General Public License v2 or later",
+      "licenseId": "LGPL-2.0-or-later",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
       ],
       "isOsiApproved": true
     },
@@ -4637,7 +2419,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.1.json",
-      "referenceNumber": "370",
+      "referenceNumber": "159",
       "name": "GNU Lesser General Public License v2.1 only",
       "licenseId": "LGPL-2.1",
       "seeAlso": [
@@ -4647,16 +2429,44 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./LGPL-3.0+.html",
+      "reference": "./LGPL-2.1+.html",
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-3.0+.json",
-      "referenceNumber": "371",
-      "name": "GNU Lesser General Public License v3.0 or later",
-      "licenseId": "LGPL-3.0+",
+      "detailsUrl": "http://spdx.org/licenses/LGPL-2.1+.json",
+      "referenceNumber": "62",
+      "name": "GNU Library General Public License v2.1 or later",
+      "licenseId": "LGPL-2.1+",
       "seeAlso": [
-        "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-3.0"
+        "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "http://www.opensource.org/licenses/LGPL-2.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-2.1-only.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-2.1-only.json",
+      "referenceNumber": "2",
+      "name": "GNU Lesser General Public License v2.1 only",
+      "licenseId": "LGPL-2.1-only",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "http://www.opensource.org/licenses/LGPL-2.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-2.1-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-2.1-or-later.json",
+      "referenceNumber": "328",
+      "name": "GNU Lesser General Public License v2.1 or later",
+      "licenseId": "LGPL-2.1-or-later",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "http://www.opensource.org/licenses/LGPL-2.1"
       ],
       "isOsiApproved": true
     },
@@ -4665,7 +2475,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-3.0.json",
-      "referenceNumber": "372",
+      "referenceNumber": "203",
       "name": "GNU Lesser General Public License v3.0 only",
       "licenseId": "LGPL-3.0",
       "seeAlso": [
@@ -4675,11 +2485,705 @@
       "isOsiApproved": true
     },
     {
+      "reference": "./LGPL-3.0+.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-3.0+.json",
+      "referenceNumber": "145",
+      "name": "GNU Lesser General Public License v3.0 or later",
+      "licenseId": "LGPL-3.0+",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "http://www.opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-3.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-3.0-only.json",
+      "referenceNumber": "247",
+      "name": "GNU Lesser General Public License v3.0 only",
+      "licenseId": "LGPL-3.0-only",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "http://www.opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-3.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-3.0-or-later.json",
+      "referenceNumber": "293",
+      "name": "GNU Lesser General Public License v3.0 or later",
+      "licenseId": "LGPL-3.0-or-later",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "http://www.opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPLLR.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LGPLLR.json",
+      "referenceNumber": "98",
+      "name": "Lesser General Public License For Linguistic Resources",
+      "licenseId": "LGPLLR",
+      "seeAlso": [
+        "http://www-igm.univ-mlv.fr/~unitex/lgpllr.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LPL-1.0.json",
+      "referenceNumber": "85",
+      "name": "Lucent Public License Version 1.0",
+      "licenseId": "LPL-1.0",
+      "seeAlso": [
+        "http://opensource.org/licenses/LPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LPL-1.02.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/LPL-1.02.json",
+      "referenceNumber": "125",
+      "name": "Lucent Public License v1.02",
+      "licenseId": "LPL-1.02",
+      "seeAlso": [
+        "http://plan9.bell-labs.com/plan9/license.html",
+        "http://www.opensource.org/licenses/LPL-1.02"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LPPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LPPL-1.0.json",
+      "referenceNumber": "252",
+      "name": "LaTeX Project Public License v1.0",
+      "licenseId": "LPPL-1.0",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-0.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LPPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LPPL-1.1.json",
+      "referenceNumber": "301",
+      "name": "LaTeX Project Public License v1.1",
+      "licenseId": "LPPL-1.1",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LPPL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/LPPL-1.2.json",
+      "referenceNumber": "378",
+      "name": "LaTeX Project Public License v1.2",
+      "licenseId": "LPPL-1.2",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LPPL-1.3a.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/LPPL-1.3a.json",
+      "referenceNumber": "297",
+      "name": "LaTeX Project Public License v1.3a",
+      "licenseId": "LPPL-1.3a",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-3a.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LPPL-1.3c.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LPPL-1.3c.json",
+      "referenceNumber": "317",
+      "name": "LaTeX Project Public License v1.3c",
+      "licenseId": "LPPL-1.3c",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-3c.txt",
+        "http://www.opensource.org/licenses/LPPL-1.3c"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Latex2e.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Latex2e.json",
+      "referenceNumber": "275",
+      "name": "Latex2e License",
+      "licenseId": "Latex2e",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Latex2e"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Leptonica.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Leptonica.json",
+      "referenceNumber": "152",
+      "name": "Leptonica License",
+      "licenseId": "Leptonica",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Leptonica"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LiLiQ-P-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LiLiQ-P-1.1.json",
+      "referenceNumber": "365",
+      "name": "Licence Libre du Québec – Permissive version 1.1",
+      "licenseId": "LiLiQ-P-1.1",
+      "seeAlso": [
+        "https://forge.gouv.qc.ca/licence/fr/liliq-v1-1/",
+        "http://opensource.org/licenses/LiLiQ-P-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LiLiQ-R-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LiLiQ-R-1.1.json",
+      "referenceNumber": "278",
+      "name": "Licence Libre du Québec – Réciprocité version 1.1",
+      "licenseId": "LiLiQ-R-1.1",
+      "seeAlso": [
+        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-liliq-r-v1-1/",
+        "http://opensource.org/licenses/LiLiQ-R-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LiLiQ-Rplus-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LiLiQ-Rplus-1.1.json",
+      "referenceNumber": "133",
+      "name": "Licence Libre du Québec – Réciprocité forte version 1.1",
+      "licenseId": "LiLiQ-Rplus-1.1",
+      "seeAlso": [
+        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-forte-liliq-r-v1-1/",
+        "http://opensource.org/licenses/LiLiQ-Rplus-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Libpng.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Libpng.json",
+      "referenceNumber": "96",
+      "name": "libpng License",
+      "licenseId": "Libpng",
+      "seeAlso": [
+        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Linux-OpenIB.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Linux-OpenIB.json",
+      "referenceNumber": "4",
+      "name": "Linux Kernel Variant of OpenIB.org license",
+      "licenseId": "Linux-OpenIB",
+      "seeAlso": [
+        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/infiniband/core/sa.h"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MIT.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/MIT.json",
+      "referenceNumber": "194",
+      "name": "MIT License",
+      "licenseId": "MIT",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/MIT"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MIT-0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MIT-0.json",
+      "referenceNumber": "5",
+      "name": "MIT No Attribution",
+      "licenseId": "MIT-0",
+      "seeAlso": [
+        "https://github.com/aws/mit-0",
+        "https://romanrm.net/mit-zero",
+        "https://github.com/awsdocs/aws-cloud9-user-guide/blob/master/LICENSE-SAMPLECODE"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MIT-CMU.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MIT-CMU.json",
+      "referenceNumber": "8",
+      "name": "CMU License",
+      "licenseId": "MIT-CMU",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:MIT?rd\u003dLicensing/MIT#CMU_Style"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MIT-advertising.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MIT-advertising.json",
+      "referenceNumber": "7",
+      "name": "Enlightenment License (e16)",
+      "licenseId": "MIT-advertising",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT_With_Advertising"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MIT-enna.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MIT-enna.json",
+      "referenceNumber": "23",
+      "name": "enna License",
+      "licenseId": "MIT-enna",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT#enna"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MIT-feh.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MIT-feh.json",
+      "referenceNumber": "36",
+      "name": "feh License",
+      "licenseId": "MIT-feh",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT#feh"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MITNFA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MITNFA.json",
+      "referenceNumber": "286",
+      "name": "MIT +no-false-attribs license",
+      "licenseId": "MITNFA",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MITNFA"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MPL-1.0.json",
+      "referenceNumber": "47",
+      "name": "Mozilla Public License 1.0",
+      "licenseId": "MPL-1.0",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/MPL-1.0.html",
+        "http://opensource.org/licenses/MPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/MPL-1.1.json",
+      "referenceNumber": "296",
+      "name": "Mozilla Public License 1.1",
+      "licenseId": "MPL-1.1",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/MPL-1.1.html",
+        "http://www.opensource.org/licenses/MPL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MPL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/MPL-2.0.json",
+      "referenceNumber": "227",
+      "name": "Mozilla Public License 2.0",
+      "licenseId": "MPL-2.0",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/2.0/",
+        "http://opensource.org/licenses/MPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MPL-2.0-no-copyleft-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MPL-2.0-no-copyleft-exception.json",
+      "referenceNumber": "295",
+      "name": "Mozilla Public License 2.0 (no copyleft exception)",
+      "licenseId": "MPL-2.0-no-copyleft-exception",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/2.0/",
+        "http://opensource.org/licenses/MPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MS-PL.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/MS-PL.json",
+      "referenceNumber": "326",
+      "name": "Microsoft Public License",
+      "licenseId": "MS-PL",
+      "seeAlso": [
+        "http://www.microsoft.com/opensource/licenses.mspx",
+        "http://www.opensource.org/licenses/MS-PL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MS-RL.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/MS-RL.json",
+      "referenceNumber": "272",
+      "name": "Microsoft Reciprocal License",
+      "licenseId": "MS-RL",
+      "seeAlso": [
+        "http://www.microsoft.com/opensource/licenses.mspx",
+        "http://www.opensource.org/licenses/MS-RL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MTLL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MTLL.json",
+      "referenceNumber": "174",
+      "name": "Matrix Template Library License",
+      "licenseId": "MTLL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Matrix_Template_Library_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MakeIndex.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MakeIndex.json",
+      "referenceNumber": "180",
+      "name": "MakeIndex License",
+      "licenseId": "MakeIndex",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MakeIndex"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MirOS.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MirOS.json",
+      "referenceNumber": "291",
+      "name": "MirOS License",
+      "licenseId": "MirOS",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/MirOS"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Motosoto.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Motosoto.json",
+      "referenceNumber": "308",
+      "name": "Motosoto License",
+      "licenseId": "Motosoto",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/Motosoto"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Multics.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Multics.json",
+      "referenceNumber": "61",
+      "name": "Multics License",
+      "licenseId": "Multics",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/Multics"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Mup.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Mup.json",
+      "referenceNumber": "341",
+      "name": "Mup License",
+      "licenseId": "Mup",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Mup"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NASA-1.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/NASA-1.3.json",
+      "referenceNumber": "83",
+      "name": "NASA Open Source Agreement 1.3",
+      "licenseId": "NASA-1.3",
+      "seeAlso": [
+        "http://ti.arc.nasa.gov/opensource/nosa/",
+        "http://www.opensource.org/licenses/NASA-1.3"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./NBPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/NBPL-1.0.json",
+      "referenceNumber": "348",
+      "name": "Net Boolean Public License v1",
+      "licenseId": "NBPL-1.0",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d37b4b3f6cc4bf34e1d3dec61e69914b9819d8894"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NCSA.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/NCSA.json",
+      "referenceNumber": "56",
+      "name": "University of Illinois/NCSA Open Source License",
+      "licenseId": "NCSA",
+      "seeAlso": [
+        "http://otm.illinois.edu/uiuc_openSource",
+        "http://www.opensource.org/licenses/NCSA"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./NGPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/NGPL.json",
+      "referenceNumber": "69",
+      "name": "Nethack General Public License",
+      "licenseId": "NGPL",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/NGPL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./NLOD-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/NLOD-1.0.json",
+      "referenceNumber": "202",
+      "name": "Norwegian Licence for Open Government Data",
+      "licenseId": "NLOD-1.0",
+      "seeAlso": [
+        "http://data.norge.no/nlod/en/1.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NLPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/NLPL.json",
+      "referenceNumber": "333",
+      "name": "No Limit Public License",
+      "licenseId": "NLPL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/NLPL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NOSL.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/NOSL.json",
+      "referenceNumber": "369",
+      "name": "Netizen Open Source License",
+      "licenseId": "NOSL",
+      "seeAlso": [
+        "http://bits.netizen.com.au/licenses/NOSL/nosl.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/NPL-1.0.json",
+      "referenceNumber": "319",
+      "name": "Netscape Public License v1.0",
+      "licenseId": "NPL-1.0",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/NPL/1.0/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/NPL-1.1.json",
+      "referenceNumber": "178",
+      "name": "Netscape Public License v1.1",
+      "licenseId": "NPL-1.1",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/NPL/1.1/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NPOSL-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/NPOSL-3.0.json",
+      "referenceNumber": "215",
+      "name": "Non-Profit Open Software License 3.0",
+      "licenseId": "NPOSL-3.0",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/NOSL3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./NRL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/NRL.json",
+      "referenceNumber": "51",
+      "name": "NRL License",
+      "licenseId": "NRL",
+      "seeAlso": [
+        "http://web.mit.edu/network/isakmp/nrllicense.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NTP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/NTP.json",
+      "referenceNumber": "254",
+      "name": "NTP License",
+      "licenseId": "NTP",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/NTP"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Naumen.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Naumen.json",
+      "referenceNumber": "270",
+      "name": "Naumen Public License",
+      "licenseId": "Naumen",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/Naumen"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Net-SNMP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Net-SNMP.json",
+      "referenceNumber": "276",
+      "name": "Net-SNMP License",
+      "licenseId": "Net-SNMP",
+      "seeAlso": [
+        "http://net-snmp.sourceforge.net/about/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NetCDF.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/NetCDF.json",
+      "referenceNumber": "44",
+      "name": "NetCDF license",
+      "licenseId": "NetCDF",
+      "seeAlso": [
+        "http://www.unidata.ucar.edu/software/netcdf/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Newsletr.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Newsletr.json",
+      "referenceNumber": "271",
+      "name": "Newsletr License",
+      "licenseId": "Newsletr",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Newsletr"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Nokia.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Nokia.json",
+      "referenceNumber": "318",
+      "name": "Nokia Open Source License",
+      "licenseId": "Nokia",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/nokia"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Noweb.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Noweb.json",
+      "referenceNumber": "351",
+      "name": "Noweb License",
+      "licenseId": "Noweb",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Noweb"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./Nunit.html",
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Nunit.json",
-      "referenceNumber": "373",
+      "referenceNumber": "280",
       "name": "Nunit License",
       "licenseId": "Nunit",
       "seeAlso": [
@@ -4688,11 +3192,899 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./OCCT-PL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OCCT-PL.json",
+      "referenceNumber": "274",
+      "name": "Open CASCADE Technology Public License",
+      "licenseId": "OCCT-PL",
+      "seeAlso": [
+        "http://www.opencascade.com/content/occt-public-license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OCLC-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OCLC-2.0.json",
+      "referenceNumber": "105",
+      "name": "OCLC Research Public License 2.0",
+      "licenseId": "OCLC-2.0",
+      "seeAlso": [
+        "http://www.oclc.org/research/activities/software/license/v2final.htm",
+        "http://www.opensource.org/licenses/OCLC-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./ODC-By-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/ODC-By-1.0.json",
+      "referenceNumber": "138",
+      "name": "Open Data Commons Attribution License v1.0",
+      "licenseId": "ODC-By-1.0",
+      "seeAlso": [
+        "https://opendatacommons.org/licenses/by/1.0/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./ODbL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/ODbL-1.0.json",
+      "referenceNumber": "239",
+      "name": "ODC Open Database License v1.0",
+      "licenseId": "ODbL-1.0",
+      "seeAlso": [
+        "http://www.opendatacommons.org/licenses/odbl/1.0/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OFL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/OFL-1.0.json",
+      "referenceNumber": "146",
+      "name": "SIL Open Font License 1.0",
+      "licenseId": "OFL-1.0",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL10_web"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OFL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/OFL-1.1.json",
+      "referenceNumber": "306",
+      "name": "SIL Open Font License 1.1",
+      "licenseId": "OFL-1.1",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL_web",
+        "http://www.opensource.org/licenses/OFL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OGL-UK-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OGL-UK-1.0.json",
+      "referenceNumber": "110",
+      "name": "Open Government Licence v1.0",
+      "licenseId": "OGL-UK-1.0",
+      "seeAlso": [
+        "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/1/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OGL-UK-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OGL-UK-2.0.json",
+      "referenceNumber": "281",
+      "name": "Open Government Licence v2.0",
+      "licenseId": "OGL-UK-2.0",
+      "seeAlso": [
+        "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OGL-UK-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OGL-UK-3.0.json",
+      "referenceNumber": "219",
+      "name": "Open Government Licence v3.0",
+      "licenseId": "OGL-UK-3.0",
+      "seeAlso": [
+        "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OGTSL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OGTSL.json",
+      "referenceNumber": "119",
+      "name": "Open Group Test Suite License",
+      "licenseId": "OGTSL",
+      "seeAlso": [
+        "http://www.opengroup.org/testing/downloads/The_Open_Group_TSL.txt",
+        "http://www.opensource.org/licenses/OGTSL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OLDAP-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-1.1.json",
+      "referenceNumber": "92",
+      "name": "Open LDAP Public License v1.1",
+      "licenseId": "OLDAP-1.1",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d806557a5ad59804ef3a44d5abfbe91d706b0791f"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-1.2.json",
+      "referenceNumber": "183",
+      "name": "Open LDAP Public License v1.2",
+      "licenseId": "OLDAP-1.2",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d42b0383c50c299977b5893ee695cf4e486fb0dc7"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-1.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-1.3.json",
+      "referenceNumber": "100",
+      "name": "Open LDAP Public License v1.3",
+      "licenseId": "OLDAP-1.3",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003de5f8117f0ce088d0bd7a8e18ddf37eaa40eb09b1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-1.4.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-1.4.json",
+      "referenceNumber": "28",
+      "name": "Open LDAP Public License v1.4",
+      "licenseId": "OLDAP-1.4",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dc9f95c2f3f2ffb5e0ae55fe7388af75547660941"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.0.json",
+      "referenceNumber": "259",
+      "name": "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
+      "licenseId": "OLDAP-2.0",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dcbf50f4e1185a21abd4c0a54d3f4341fe28f36ea"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.0.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.0.1.json",
+      "referenceNumber": "338",
+      "name": "Open LDAP Public License v2.0.1",
+      "licenseId": "OLDAP-2.0.1",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003db6d68acd14e51ca3aab4428bf26522aa74873f0e"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.1.json",
+      "referenceNumber": "147",
+      "name": "Open LDAP Public License v2.1",
+      "licenseId": "OLDAP-2.1",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003db0d176738e96a0d3b9f85cb51e140a86f21be715"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.json",
+      "referenceNumber": "349",
+      "name": "Open LDAP Public License v2.2",
+      "licenseId": "OLDAP-2.2",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d470b0c18ec67621c85881b2733057fecf4a1acc3"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.1.json",
+      "referenceNumber": "329",
+      "name": "Open LDAP Public License v2.2.1",
+      "licenseId": "OLDAP-2.2.1",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d4bc786f34b50aa301be6f5600f58a980070f481e"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.2.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.2.json",
+      "referenceNumber": "192",
+      "name": "Open LDAP Public License 2.2.2",
+      "licenseId": "OLDAP-2.2.2",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003ddf2cc1e21eb7c160695f5b7cffd6296c151ba188"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.3.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.3.json",
+      "referenceNumber": "157",
+      "name": "Open LDAP Public License v2.3",
+      "licenseId": "OLDAP-2.3",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dd32cf54a32d581ab475d23c810b0a7fbaf8d63c3"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.4.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.4.json",
+      "referenceNumber": "64",
+      "name": "Open LDAP Public License v2.4",
+      "licenseId": "OLDAP-2.4",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dcd1284c4a91a8a380d904eee68d1583f989ed386"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.5.json",
+      "referenceNumber": "176",
+      "name": "Open LDAP Public License v2.5",
+      "licenseId": "OLDAP-2.5",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d6852b9d90022e8593c98205413380536b1b5a7cf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.6.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.6.json",
+      "referenceNumber": "59",
+      "name": "Open LDAP Public License v2.6",
+      "licenseId": "OLDAP-2.6",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d1cae062821881f41b73012ba816434897abf4205"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.7.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.7.json",
+      "referenceNumber": "117",
+      "name": "Open LDAP Public License v2.7",
+      "licenseId": "OLDAP-2.7",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d47c2415c1df81556eeb39be6cad458ef87c534a2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OLDAP-2.8.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.8.json",
+      "referenceNumber": "35",
+      "name": "Open LDAP Public License v2.8",
+      "licenseId": "OLDAP-2.8",
+      "seeAlso": [
+        "http://www.openldap.org/software/release/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OML.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OML.json",
+      "referenceNumber": "63",
+      "name": "Open Market License",
+      "licenseId": "OML",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Open_Market_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OPL-1.0.json",
+      "referenceNumber": "332",
+      "name": "Open Public License v1.0",
+      "licenseId": "OPL-1.0",
+      "seeAlso": [
+        "http://old.koalateam.com/jackaroo/OPL_1_0.TXT",
+        "https://fedoraproject.org/wiki/Licensing/Open_Public_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OSET-PL-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OSET-PL-2.1.json",
+      "referenceNumber": "283",
+      "name": "OSET Public License version 2.1",
+      "licenseId": "OSET-PL-2.1",
+      "seeAlso": [
+        "http://www.osetfoundation.org/public-license",
+        "http://opensource.org/licenses/OPL-2.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OSL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/OSL-1.0.json",
+      "referenceNumber": "81",
+      "name": "Open Software License 1.0",
+      "licenseId": "OSL-1.0",
+      "seeAlso": [
+        "http://opensource.org/licenses/OSL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OSL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/OSL-1.1.json",
+      "referenceNumber": "324",
+      "name": "Open Software License 1.1",
+      "licenseId": "OSL-1.1",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/OSL1.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OSL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/OSL-2.0.json",
+      "referenceNumber": "19",
+      "name": "Open Software License 2.0",
+      "licenseId": "OSL-2.0",
+      "seeAlso": [
+        "http://web.archive.org/web/20041020171434/http://www.rosenlaw.com/osl2.0.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OSL-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/OSL-2.1.json",
+      "referenceNumber": "22",
+      "name": "Open Software License 2.1",
+      "licenseId": "OSL-2.1",
+      "seeAlso": [
+        "http://web.archive.org/web/20050212003940/http://www.rosenlaw.com/osl21.htm",
+        "http://opensource.org/licenses/OSL-2.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OSL-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/OSL-3.0.json",
+      "referenceNumber": "95",
+      "name": "Open Software License 3.0",
+      "licenseId": "OSL-3.0",
+      "seeAlso": [
+        "https://web.archive.org/web/20120101081418/http://rosenlaw.com:80/OSL3.0.htm",
+        "http://www.opensource.org/licenses/OSL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OpenSSL.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/OpenSSL.json",
+      "referenceNumber": "242",
+      "name": "OpenSSL License",
+      "licenseId": "OpenSSL",
+      "seeAlso": [
+        "http://www.openssl.org/source/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./PDDL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/PDDL-1.0.json",
+      "referenceNumber": "13",
+      "name": "ODC Public Domain Dedication \u0026 License 1.0",
+      "licenseId": "PDDL-1.0",
+      "seeAlso": [
+        "http://opendatacommons.org/licenses/pddl/1.0/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./PHP-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/PHP-3.0.json",
+      "referenceNumber": "371",
+      "name": "PHP License v3.0",
+      "licenseId": "PHP-3.0",
+      "seeAlso": [
+        "http://www.php.net/license/3_0.txt",
+        "http://www.opensource.org/licenses/PHP-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./PHP-3.01.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/PHP-3.01.json",
+      "referenceNumber": "307",
+      "name": "PHP License v3.01",
+      "licenseId": "PHP-3.01",
+      "seeAlso": [
+        "http://www.php.net/license/3_01.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Plexus.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Plexus.json",
+      "referenceNumber": "218",
+      "name": "Plexus Classworlds License",
+      "licenseId": "Plexus",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Plexus_Classworlds_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./PostgreSQL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/PostgreSQL.json",
+      "referenceNumber": "240",
+      "name": "PostgreSQL License",
+      "licenseId": "PostgreSQL",
+      "seeAlso": [
+        "http://www.postgresql.org/about/licence",
+        "http://www.opensource.org/licenses/PostgreSQL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Python-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Python-2.0.json",
+      "referenceNumber": "33",
+      "name": "Python License 2.0",
+      "licenseId": "Python-2.0",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/Python-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./QPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/QPL-1.0.json",
+      "referenceNumber": "25",
+      "name": "Q Public License 1.0",
+      "licenseId": "QPL-1.0",
+      "seeAlso": [
+        "http://doc.qt.nokia.com/3.3/license.html",
+        "http://www.opensource.org/licenses/QPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Qhull.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Qhull.json",
+      "referenceNumber": "65",
+      "name": "Qhull License",
+      "licenseId": "Qhull",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Qhull"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./RHeCos-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/RHeCos-1.1.json",
+      "referenceNumber": "142",
+      "name": "Red Hat eCos Public License v1.1",
+      "licenseId": "RHeCos-1.1",
+      "seeAlso": [
+        "http://ecos.sourceware.org/old-license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./RPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/RPL-1.1.json",
+      "referenceNumber": "261",
+      "name": "Reciprocal Public License 1.1",
+      "licenseId": "RPL-1.1",
+      "seeAlso": [
+        "http://opensource.org/licenses/RPL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./RPL-1.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/RPL-1.5.json",
+      "referenceNumber": "220",
+      "name": "Reciprocal Public License 1.5",
+      "licenseId": "RPL-1.5",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/RPL-1.5"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./RPSL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/RPSL-1.0.json",
+      "referenceNumber": "265",
+      "name": "RealNetworks Public Source License v1.0",
+      "licenseId": "RPSL-1.0",
+      "seeAlso": [
+        "https://helixcommunity.org/content/rpsl",
+        "http://www.opensource.org/licenses/RPSL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./RSA-MD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/RSA-MD.json",
+      "referenceNumber": "78",
+      "name": "RSA Message-Digest License ",
+      "licenseId": "RSA-MD",
+      "seeAlso": [
+        "http://www.faqs.org/rfcs/rfc1321.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./RSCPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/RSCPL.json",
+      "referenceNumber": "204",
+      "name": "Ricoh Source Code Public License",
+      "licenseId": "RSCPL",
+      "seeAlso": [
+        "http://wayback.archive.org/web/20060715140826/http://www.risource.org/RPL/RPL-1.0A.shtml",
+        "http://www.opensource.org/licenses/RSCPL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Rdisc.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Rdisc.json",
+      "referenceNumber": "287",
+      "name": "Rdisc License",
+      "licenseId": "Rdisc",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Rdisc_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Ruby.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Ruby.json",
+      "referenceNumber": "256",
+      "name": "Ruby License",
+      "licenseId": "Ruby",
+      "seeAlso": [
+        "http://www.ruby-lang.org/en/LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SAX-PD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SAX-PD.json",
+      "referenceNumber": "134",
+      "name": "Sax Public Domain Notice",
+      "licenseId": "SAX-PD",
+      "seeAlso": [
+        "http://www.saxproject.org/copying.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SCEA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SCEA.json",
+      "referenceNumber": "15",
+      "name": "SCEA Shared Source License",
+      "licenseId": "SCEA",
+      "seeAlso": [
+        "http://research.scea.com/scea_shared_source_license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SGI-B-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SGI-B-1.0.json",
+      "referenceNumber": "86",
+      "name": "SGI Free Software License B v1.0",
+      "licenseId": "SGI-B-1.0",
+      "seeAlso": [
+        "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.1.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SGI-B-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SGI-B-1.1.json",
+      "referenceNumber": "234",
+      "name": "SGI Free Software License B v1.1",
+      "licenseId": "SGI-B-1.1",
+      "seeAlso": [
+        "http://oss.sgi.com/projects/FreeB/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SGI-B-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/SGI-B-2.0.json",
+      "referenceNumber": "264",
+      "name": "SGI Free Software License B v2.0",
+      "licenseId": "SGI-B-2.0",
+      "seeAlso": [
+        "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.2.0.pdf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SISSL.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/SISSL.json",
+      "referenceNumber": "71",
+      "name": "Sun Industry Standards Source License v1.1",
+      "licenseId": "SISSL",
+      "seeAlso": [
+        "http://www.openoffice.org/licenses/sissl_license.html",
+        "http://opensource.org/licenses/SISSL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./SISSL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SISSL-1.2.json",
+      "referenceNumber": "6",
+      "name": "Sun Industry Standards Source License v1.2",
+      "licenseId": "SISSL-1.2",
+      "seeAlso": [
+        "http://gridscheduler.sourceforge.net/Gridengine_SISSL_license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SMLNJ.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/SMLNJ.json",
+      "referenceNumber": "288",
+      "name": "Standard ML of New Jersey License",
+      "licenseId": "SMLNJ",
+      "seeAlso": [
+        "https://www.smlnj.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SMPPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SMPPL.json",
+      "referenceNumber": "121",
+      "name": "Secure Messaging Protocol Public License",
+      "licenseId": "SMPPL",
+      "seeAlso": [
+        "https://github.com/dcblake/SMP/blob/master/Documentation/License.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SNIA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SNIA.json",
+      "referenceNumber": "223",
+      "name": "SNIA Public License 1.1",
+      "licenseId": "SNIA",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/SNIA_Public_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/SPL-1.0.json",
+      "referenceNumber": "52",
+      "name": "Sun Public License v1.0",
+      "licenseId": "SPL-1.0",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/SPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./SWL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SWL.json",
+      "referenceNumber": "201",
+      "name": "Scheme Widget Library (SWL) Software License Agreement",
+      "licenseId": "SWL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/SWL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Saxpath.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Saxpath.json",
+      "referenceNumber": "17",
+      "name": "Saxpath License",
+      "licenseId": "Saxpath",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Saxpath_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Sendmail.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Sendmail.json",
+      "referenceNumber": "144",
+      "name": "Sendmail License",
+      "licenseId": "Sendmail",
+      "seeAlso": [
+        "http://www.sendmail.com/pdfs/open_source/sendmail_license.pdf",
+        "https://web.archive.org/web/20160322142305/https://www.sendmail.com/pdfs/open_source/sendmail_license.pdf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Sendmail-8.23.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Sendmail-8.23.json",
+      "referenceNumber": "39",
+      "name": "Sendmail License 8.23",
+      "licenseId": "Sendmail-8.23",
+      "seeAlso": [
+        "https://www.proofpoint.com/sites/default/files/sendmail-license.pdf",
+        "https://web.archive.org/web/20181003101040/https://www.proofpoint.com/sites/default/files/sendmail-license.pdf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SimPL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SimPL-2.0.json",
+      "referenceNumber": "177",
+      "name": "Simple Public License 2.0",
+      "licenseId": "SimPL-2.0",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/SimPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Sleepycat.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Sleepycat.json",
+      "referenceNumber": "282",
+      "name": "Sleepycat License",
+      "licenseId": "Sleepycat",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/Sleepycat"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Spencer-86.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Spencer-86.json",
+      "referenceNumber": "305",
+      "name": "Spencer License 86",
+      "licenseId": "Spencer-86",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Spencer-94.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Spencer-94.json",
+      "referenceNumber": "27",
+      "name": "Spencer License 94",
+      "licenseId": "Spencer-94",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Spencer-99.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Spencer-99.json",
+      "referenceNumber": "372",
+      "name": "Spencer License 99",
+      "licenseId": "Spencer-99",
+      "seeAlso": [
+        "http://www.opensource.apple.com/source/tcl/tcl-5/tcl/generic/regfronts.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./StandardML-NJ.html",
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/StandardML-NJ.json",
-      "referenceNumber": "374",
+      "referenceNumber": "212",
       "name": "Standard ML of New Jersey License",
       "licenseId": "StandardML-NJ",
       "seeAlso": [
@@ -4701,11 +4093,556 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./SugarCRM-1.1.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SugarCRM-1.1.3.json",
+      "referenceNumber": "284",
+      "name": "SugarCRM Public License v1.1.3",
+      "licenseId": "SugarCRM-1.1.3",
+      "seeAlso": [
+        "http://www.sugarcrm.com/crm/SPL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./TCL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/TCL.json",
+      "referenceNumber": "258",
+      "name": "TCL/TK License",
+      "licenseId": "TCL",
+      "seeAlso": [
+        "http://www.tcl.tk/software/tcltk/license.html",
+        "https://fedoraproject.org/wiki/Licensing/TCL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./TCP-wrappers.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/TCP-wrappers.json",
+      "referenceNumber": "266",
+      "name": "TCP Wrappers License",
+      "licenseId": "TCP-wrappers",
+      "seeAlso": [
+        "http://rc.quest.com/topics/openssh/license.php#tcpwrappers"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./TMate.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/TMate.json",
+      "referenceNumber": "246",
+      "name": "TMate Open Source License",
+      "licenseId": "TMate",
+      "seeAlso": [
+        "http://svnkit.com/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./TORQUE-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/TORQUE-1.1.json",
+      "referenceNumber": "164",
+      "name": "TORQUE v2.5+ Software License v1.1",
+      "licenseId": "TORQUE-1.1",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/TORQUEv1.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./TOSL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/TOSL.json",
+      "referenceNumber": "347",
+      "name": "Trusster Open Source License",
+      "licenseId": "TOSL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/TOSL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./TU-Berlin-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/TU-Berlin-1.0.json",
+      "referenceNumber": "359",
+      "name": "Technische Universitaet Berlin License 1.0",
+      "licenseId": "TU-Berlin-1.0",
+      "seeAlso": [
+        "https://github.com/swh/ladspa/blob/7bf6f3799fdba70fda297c2d8fd9f526803d9680/gsm/COPYRIGHT"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./TU-Berlin-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/TU-Berlin-2.0.json",
+      "referenceNumber": "377",
+      "name": "Technische Universitaet Berlin License 2.0",
+      "licenseId": "TU-Berlin-2.0",
+      "seeAlso": [
+        "https://github.com/CorsixTH/deps/blob/fd339a9f526d1d9c9f01ccf39e438a015da50035/licences/libgsm.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./UPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/UPL-1.0.json",
+      "referenceNumber": "198",
+      "name": "Universal Permissive License v1.0",
+      "licenseId": "UPL-1.0",
+      "seeAlso": [
+        "http://opensource.org/licenses/UPL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Unicode-DFS-2015.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Unicode-DFS-2015.json",
+      "referenceNumber": "10",
+      "name": "Unicode License Agreement - Data Files and Software (2015)",
+      "licenseId": "Unicode-DFS-2015",
+      "seeAlso": [
+        "https://web.archive.org/web/20151224134844/http://unicode.org/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Unicode-DFS-2016.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Unicode-DFS-2016.json",
+      "referenceNumber": "368",
+      "name": "Unicode License Agreement - Data Files and Software (2016)",
+      "licenseId": "Unicode-DFS-2016",
+      "seeAlso": [
+        "http://www.unicode.org/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Unicode-TOU.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Unicode-TOU.json",
+      "referenceNumber": "68",
+      "name": "Unicode Terms of Use",
+      "licenseId": "Unicode-TOU",
+      "seeAlso": [
+        "http://www.unicode.org/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Unlicense.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Unlicense.json",
+      "referenceNumber": "285",
+      "name": "The Unlicense",
+      "licenseId": "Unlicense",
+      "seeAlso": [
+        "http://unlicense.org/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./VOSTROM.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/VOSTROM.json",
+      "referenceNumber": "221",
+      "name": "VOSTROM Public License for Open Source",
+      "licenseId": "VOSTROM",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/VOSTROM"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./VSL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/VSL-1.0.json",
+      "referenceNumber": "173",
+      "name": "Vovida Software License v1.0",
+      "licenseId": "VSL-1.0",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/VSL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Vim.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Vim.json",
+      "referenceNumber": "127",
+      "name": "Vim License",
+      "licenseId": "Vim",
+      "seeAlso": [
+        "http://vimdoc.sourceforge.net/htmldoc/uganda.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./W3C.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/W3C.json",
+      "referenceNumber": "339",
+      "name": "W3C Software Notice and License (2002-12-31)",
+      "licenseId": "W3C",
+      "seeAlso": [
+        "http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html",
+        "http://www.opensource.org/licenses/W3C"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./W3C-19980720.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/W3C-19980720.json",
+      "referenceNumber": "314",
+      "name": "W3C Software Notice and License (1998-07-20)",
+      "licenseId": "W3C-19980720",
+      "seeAlso": [
+        "http://www.w3.org/Consortium/Legal/copyright-software-19980720.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./W3C-20150513.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/W3C-20150513.json",
+      "referenceNumber": "49",
+      "name": "W3C Software Notice and Document License (2015-05-13)",
+      "licenseId": "W3C-20150513",
+      "seeAlso": [
+        "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./WTFPL.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/WTFPL.json",
+      "referenceNumber": "355",
+      "name": "Do What The F*ck You Want To Public License",
+      "licenseId": "WTFPL",
+      "seeAlso": [
+        "http://sam.zoy.org/wtfpl/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Watcom-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Watcom-1.0.json",
+      "referenceNumber": "170",
+      "name": "Sybase Open Watcom Public License 1.0",
+      "licenseId": "Watcom-1.0",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/Watcom-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Wsuipa.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Wsuipa.json",
+      "referenceNumber": "129",
+      "name": "Wsuipa License",
+      "licenseId": "Wsuipa",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Wsuipa"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./X11.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/X11.json",
+      "referenceNumber": "181",
+      "name": "X11 License",
+      "licenseId": "X11",
+      "seeAlso": [
+        "http://www.xfree86.org/3.3.6/COPYRIGHT2.html#3"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./XFree86-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/XFree86-1.1.json",
+      "referenceNumber": "236",
+      "name": "XFree86 License 1.1",
+      "licenseId": "XFree86-1.1",
+      "seeAlso": [
+        "http://www.xfree86.org/current/LICENSE4.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./XSkat.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/XSkat.json",
+      "referenceNumber": "91",
+      "name": "XSkat License",
+      "licenseId": "XSkat",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/XSkat_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Xerox.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Xerox.json",
+      "referenceNumber": "156",
+      "name": "Xerox License",
+      "licenseId": "Xerox",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Xerox"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Xnet.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Xnet.json",
+      "referenceNumber": "374",
+      "name": "X.Net License",
+      "licenseId": "Xnet",
+      "seeAlso": [
+        "http://opensource.org/licenses/Xnet"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./YPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/YPL-1.0.json",
+      "referenceNumber": "167",
+      "name": "Yahoo! Public License v1.0",
+      "licenseId": "YPL-1.0",
+      "seeAlso": [
+        "http://www.zimbra.com/license/yahoo_public_license_1.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./YPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/YPL-1.1.json",
+      "referenceNumber": "55",
+      "name": "Yahoo! Public License v1.1",
+      "licenseId": "YPL-1.1",
+      "seeAlso": [
+        "http://www.zimbra.com/license/yahoo_public_license_1.1.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./ZPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/ZPL-1.1.json",
+      "referenceNumber": "346",
+      "name": "Zope Public License 1.1",
+      "licenseId": "ZPL-1.1",
+      "seeAlso": [
+        "http://old.zope.org/Resources/License/ZPL-1.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./ZPL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/ZPL-2.0.json",
+      "referenceNumber": "74",
+      "name": "Zope Public License 2.0",
+      "licenseId": "ZPL-2.0",
+      "seeAlso": [
+        "http://old.zope.org/Resources/License/ZPL-2.0",
+        "http://opensource.org/licenses/ZPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./ZPL-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/ZPL-2.1.json",
+      "referenceNumber": "334",
+      "name": "Zope Public License 2.1",
+      "licenseId": "ZPL-2.1",
+      "seeAlso": [
+        "http://old.zope.org/Resources/ZPL/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Zed.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Zed.json",
+      "referenceNumber": "241",
+      "name": "Zed License",
+      "licenseId": "Zed",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Zed"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Zend-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Zend-2.0.json",
+      "referenceNumber": "191",
+      "name": "Zend License v2.0",
+      "licenseId": "Zend-2.0",
+      "seeAlso": [
+        "https://web.archive.org/web/20130517195954/http://www.zend.com/license/2_00.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Zimbra-1.3.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Zimbra-1.3.json",
+      "referenceNumber": "38",
+      "name": "Zimbra Public License v1.3",
+      "licenseId": "Zimbra-1.3",
+      "seeAlso": [
+        "http://web.archive.org/web/20100302225219/http://www.zimbra.com/license/zimbra-public-license-1-3.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Zimbra-1.4.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Zimbra-1.4.json",
+      "referenceNumber": "231",
+      "name": "Zimbra Public License v1.4",
+      "licenseId": "Zimbra-1.4",
+      "seeAlso": [
+        "http://www.zimbra.com/legal/zimbra-public-license-1-4"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Zlib.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Zlib.json",
+      "referenceNumber": "311",
+      "name": "zlib License",
+      "licenseId": "Zlib",
+      "seeAlso": [
+        "http://www.zlib.net/zlib_license.html",
+        "http://www.opensource.org/licenses/Zlib"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./bzip2-1.0.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/bzip2-1.0.5.json",
+      "referenceNumber": "193",
+      "name": "bzip2 and libbzip2 License v1.0.5",
+      "licenseId": "bzip2-1.0.5",
+      "seeAlso": [
+        "http://bzip.org/1.0.5/bzip2-manual-1.0.5.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./bzip2-1.0.6.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/bzip2-1.0.6.json",
+      "referenceNumber": "294",
+      "name": "bzip2 and libbzip2 License v1.0.6",
+      "licenseId": "bzip2-1.0.6",
+      "seeAlso": [
+        "https://github.com/asimonov-im/bzip2/blob/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./copyleft-next-0.3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/copyleft-next-0.3.0.json",
+      "referenceNumber": "169",
+      "name": "copyleft-next 0.3.0",
+      "licenseId": "copyleft-next-0.3.0",
+      "seeAlso": [
+        "https://github.com/copyleft-next/copyleft-next/blob/master/Releases/copyleft-next-0.3.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./copyleft-next-0.3.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/copyleft-next-0.3.1.json",
+      "referenceNumber": "336",
+      "name": "copyleft-next 0.3.1",
+      "licenseId": "copyleft-next-0.3.1",
+      "seeAlso": [
+        "https://github.com/copyleft-next/copyleft-next/blob/master/Releases/copyleft-next-0.3.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./curl.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/curl.json",
+      "referenceNumber": "253",
+      "name": "curl License",
+      "licenseId": "curl",
+      "seeAlso": [
+        "https://github.com/bagder/curl/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./diffmark.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/diffmark.json",
+      "referenceNumber": "354",
+      "name": "diffmark license",
+      "licenseId": "diffmark",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/diffmark"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./dvipdfm.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/dvipdfm.json",
+      "referenceNumber": "137",
+      "name": "dvipdfm License",
+      "licenseId": "dvipdfm",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/dvipdfm"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./eCos-2.0.html",
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/eCos-2.0.json",
-      "referenceNumber": "375",
+      "referenceNumber": "320",
       "name": "eCos license version 2.0",
       "licenseId": "eCos-2.0",
       "seeAlso": [
@@ -4714,17 +4651,153 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./eGenix.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/eGenix.json",
+      "referenceNumber": "197",
+      "name": "eGenix.com Public License 1.1.0",
+      "licenseId": "eGenix",
+      "seeAlso": [
+        "http://www.egenix.com/products/eGenix.com-Public-License-1.1.0.pdf",
+        "https://fedoraproject.org/wiki/Licensing/eGenix.com_Public_License_1.1.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./gSOAP-1.3b.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/gSOAP-1.3b.json",
+      "referenceNumber": "335",
+      "name": "gSOAP Public License v1.3b",
+      "licenseId": "gSOAP-1.3b",
+      "seeAlso": [
+        "http://www.cs.fsu.edu/~engelen/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./gnuplot.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/gnuplot.json",
+      "referenceNumber": "9",
+      "name": "gnuplot License",
+      "licenseId": "gnuplot",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Gnuplot"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./iMatix.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/iMatix.json",
+      "referenceNumber": "331",
+      "name": "iMatix Standard Function Library Agreement",
+      "licenseId": "iMatix",
+      "seeAlso": [
+        "http://legacy.imatix.com/html/sfl/sfl4.htm#license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./libtiff.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/libtiff.json",
+      "referenceNumber": "213",
+      "name": "libtiff License",
+      "licenseId": "libtiff",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/libtiff"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./mpich2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/mpich2.json",
+      "referenceNumber": "309",
+      "name": "mpich2 License",
+      "licenseId": "mpich2",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./psfrag.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/psfrag.json",
+      "referenceNumber": "238",
+      "name": "psfrag License",
+      "licenseId": "psfrag",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/psfrag"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./psutils.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/psutils.json",
+      "referenceNumber": "120",
+      "name": "psutils License",
+      "licenseId": "psutils",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/psutils"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./wxWindows.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/wxWindows.json",
-      "referenceNumber": "376",
+      "referenceNumber": "82",
       "name": "wxWindows Library License",
       "licenseId": "wxWindows",
       "seeAlso": [
         "http://www.opensource.org/licenses/WXwindows"
       ],
       "isOsiApproved": false
+    },
+    {
+      "reference": "./xinetd.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/xinetd.json",
+      "referenceNumber": "139",
+      "name": "xinetd License",
+      "licenseId": "xinetd",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Xinetd_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./xpp.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/xpp.json",
+      "referenceNumber": "267",
+      "name": "XPP License",
+      "licenseId": "xpp",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/xpp"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./zlib-acknowledgement.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/zlib-acknowledgement.json",
+      "referenceNumber": "312",
+      "name": "zlib/libpng License with Acknowledgement",
+      "licenseId": "zlib-acknowledgement",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/ZlibWithAcknowledgement"
+      ],
+      "isOsiApproved": false
     }
   ],
-  "releaseDate": "2018-08-23"
+  "releaseDate": "2019-01-16"
 }

--- a/spdx_update.py
+++ b/spdx_update.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python
+
+import argparse
+import json
+import logging
+import sys
+
+log = logging.getLogger(__name__)
+
+
+def load_spdx(file_object):
+    data = json.load(file_object)
+    return data
+
+
+def build_short_list(license_data):
+    licenses = {}
+
+    for lic in license_data['licenses']:
+        lid = lic['licenseId']
+        licenses[lid] = {'deprecated': lic['isDeprecatedLicenseId']}
+    return licenses
+
+
+def json_dumps_license_data(short_license_data):
+    dict_buf = json.dumps(short_license_data,
+                          indent=4,
+                          sort_keys=True,
+                          separators=(',', ':'))
+    log.debug('dict_buf: %s', dict_buf)
+    return dict_buf
+
+
+def main(argv):
+    logging.basicConfig(level=logging.INFO)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('input', help='The SPDX license json file input',
+                        type=argparse.FileType())
+    args = parser.parse_args(argv)
+
+    log.debug('args: %s', args)
+
+    data = load_spdx(args.input)
+    short_data = build_short_list(data)
+
+    buf = json_dumps_license_data(short_data)
+
+    print(buf)
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/tests/ansible_galaxy/models/test_collection_info_model.py
+++ b/tests/ansible_galaxy/models/test_collection_info_model.py
@@ -22,6 +22,19 @@ def col_info():
     return test_data
 
 
+def test_license_deprecated(col_info):
+    col_info['license'] = 'AGPL-1.0'
+    res = CollectionInfo(**col_info)
+    # Not much to assert, behavior is just a print() side effect
+    assert res.license == 'AGPL-1.0'
+
+
+def test_license_unknown(col_info):
+    col_info['license'] = 'SOME-UNKNOWN'
+    with pytest.raises(ValueError, match=".*license.*SOME-UNKNOWN.*"):
+        CollectionInfo(**col_info)
+
+
 def test_license_error(col_info):
     col_info['license'] = 'GPLv2'
 


### PR DESCRIPTION
##### SUMMARY

Validate CollectionInfo off static dict of spdx info.

Previously everytime a CollectionInfo() was created, the
spdx_data was being loaded and parsed.

Now check it against a set of data in ansible_galaxy.data.spdx_licenses

If a license id is in the SPDX_LICENSES dict, it is acceptable.
If the license items value is True, then it is deprecated and
a warning is printed.

TODO: mv the deprecated license check so it only runs on 'build'
and not anytime a collection is loaded

Tool to build a python source file form spdx.json

Use this to parse spdx json data when it is updated
and generated a new source file.

And alternative to https://github.com/ansible/mazer/pull/170

##### ISSUE TYPE
 - Bugfix Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.3.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.12-100.fc27.x86_64, #1 SMP Thu Oct 4 16:22:17 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3-2/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3-2/bin/python

```

