### PR TITLE
Remove CollectionInfo() mutable defaults

### DIFF
--- a/ansible_galaxy/models/collection_info.py
+++ b/ansible_galaxy/models/collection_info.py
@@ -18,15 +18,16 @@ TAG_REGEXP = re.compile('^[a-z0-9]+$')
 class CollectionInfo(object):
     name = attr.ib(default=None)
     version = attr.ib(default=None)
-    authors = attr.ib(default=[])
     license = attr.ib(default=None)
     description = attr.ib(default=None)
-    keywords = attr.ib(default=[])
+
+    authors = attr.ib(factory=list)
+    keywords = attr.ib(factory=list)
     readme = attr.ib(default='README.md')
 
     # Note galaxy.yml 'dependencies' field is what mazer and ansible
     # consider 'requirements'. ie, install time requirements.
-    dependencies = attr.ib(default=[])
+    dependencies = attr.ib(factory=list)
 
     @property
     def namespace(self):

--- a/tests/ansible_galaxy/models/test_collection_info_model.py
+++ b/tests/ansible_galaxy/models/test_collection_info_model.py
@@ -39,6 +39,7 @@ def test_name_parse_error():
         'version': '0.0.1',
         'description': 'unit testing thing'
     }
+    # ValueError: Invalid collection metadata. Expecting 'name' to be in Galaxy name format, <namespace>.<collection_name>, instead found 'foo'.
     with pytest.raises(ValueError) as exc:
         CollectionInfo(**test_data)
     assert 'name' in str(exc)
@@ -55,6 +56,77 @@ def test_type_list_error():
     with pytest.raises(ValueError) as exc:
         CollectionInfo(**test_data)
     assert 'authors' in str(exc)
+
+
+def test_empty():
+    test_data = {}
+    # ValueError: Invalid collection metadata. 'name' is required
+    with pytest.raises(ValueError, match=".*'name'.*"):
+        CollectionInfo(**test_data)
+
+
+def test_minimal():
+    test_data = {
+        'name': 'foo.foo',
+        'license': 'GPL-3.0-or-later',
+        'version': '1.0.0',
+        'description': 'unit testing thing',
+    }
+    res = CollectionInfo(**test_data)
+
+    res.authors.append('Faux Author')
+    res.keywords.append('somekeyword')
+    res.dependencies.append(('some_dep', 'stuff'))
+
+    log.debug('res %s res.authors: %s', res, res.authors)
+
+    new_data = test_data.copy()
+    res2 = CollectionInfo(**new_data)
+
+    log.debug('res %s res.authors: %s', res, res.authors)
+    log.debug('res2 %s res2.authors: %s', res2, res2.authors)
+
+    assert res != res2
+    assert res2.authors == []
+    assert res2.keywords == []
+    assert res2.dependencies == []
+
+
+def test_authors_append():
+    test_data = {
+        'name': 'foo.foo',
+        # let authors go to the defualt
+        # 'authors': ['chouseknecht'],
+        'license': 'GPL-3.0-or-later',
+        'version': '1.0.0',
+        'description': 'unit testing thing',
+    }
+    res = CollectionInfo(**test_data)
+    # log.debug('res %s res.authors: %s', res, res.authors)
+
+    # append to the first objects authors.
+    # This should not change the default authors for new
+    # CollectionInfo()'s
+    res.authors.append('Faux Author')
+    log.debug('res %s res.authors: %s', res, res.authors)
+
+    new_data = test_data.copy()
+
+    # No authors provided, should default to []
+    res2 = CollectionInfo(**new_data)
+
+    res.authors.append('OnlyAuthoredResNotRes2')
+
+    log.debug('res %s res.authors: %s', res, res.authors)
+    log.debug('res2 %s res2.authors: %s', res2, res2.authors)
+
+    # Based on https://www.attrs.org/en/stable/init.html#defaults info about defaults
+    # These should not be the same value here
+    assert res != res2
+    assert res.authors != res2.authors
+    assert res2.authors == []
+    assert res.authors == ['Faux Author', 'OnlyAuthoredResNotRes2']
+    assert 'OnlyAuthoredResNotRes2' not in res2.authors
 
 
 def test_semantic_version_error():


### PR DESCRIPTION
##### SUMMARY
Use factory=list instead of default=[] for attr default.

authors = attr.ib(default=[]) makes the default value for
the 'authors' attribute of the class a mutable list. It
can be modified and later new instances will use the mutated
list as the default instead of new empty list.

Use attr.ib's factory option to specify to use an empty list
if otherwise not provided.

https://www.attrs.org/en/stable/init.html#defaults has some notes on this.

<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.3.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.12-100.fc27.x86_64, #1 SMP Thu Oct 4 16:22:17 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3-2/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3-2/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

