### PR TITLE
[WIP] Collection artifact

### DIFF
--- a/ansible_galaxy/collection_artifact_manifest.py
+++ b/ansible_galaxy/collection_artifact_manifest.py
@@ -6,6 +6,8 @@ import os
 import yaml
 
 from ansible_galaxy.utils import chksums
+from ansible_galaxy.models.collection_info import \
+    CollectionInfo
 from ansible_galaxy.models.collection_artifact_manifest import \
     CollectionArtifactManifest
 from ansible_galaxy.models.collection_artifact_file import \
@@ -19,16 +21,21 @@ COLLECTION_MANIFEST_FILENAME = 'MANIFEST.json'
 
 # TODO: replace with a generic version for cases
 #       where SomeClass(**dict_from_yaml) works
-def load(data_or_file_object, klass=None):
+# def load(data_or_file_object, klass=None):
+def load(data_or_file_object):
     log.debug('loading collection info from %s',
               pf(data_or_file_object))
 
     data_dict = yaml.safe_load(data_or_file_object)
 
-    log.debug('data: %s', pf(data_dict))
+    # log.debug('data: %s', pf(data_dict))
+    log.debug('data_dict: %s', data_dict)
 
-    klass = CollectionArtifactManifest
-    instance = klass(**data_dict)
+    col_info = CollectionInfo(**data_dict['collection_info'])
+    # klass = CollectionArtifactManifest
+    instance = CollectionArtifactManifest(collection_info=col_info,
+                                          files=data_dict['files'])
+    # instance = klass(**data_dict)
 
     log.debug('%s instance from_kwargs: %s', type(instance), instance)
 

--- a/ansible_galaxy/collection_artifact_manifest.py
+++ b/ansible_galaxy/collection_artifact_manifest.py
@@ -14,7 +14,7 @@ from ansible_galaxy.models.collection_artifact_file import \
 log = logging.getLogger(__name__)
 pf = pprint.pformat
 
-COLLECTION_MANIFEST_FILENAME = "MANIFEST.json"
+COLLECTION_MANIFEST_FILENAME = 'MANIFEST.json'
 
 
 # TODO: replace with a generic version for cases
@@ -31,6 +31,8 @@ def load(data_or_file_object, klass=None):
     instance = klass(**data_dict)
 
     log.debug('%s instance from_kwargs: %s', type(instance), instance)
+
+    log.debug('collection_artifact_manifest: %s', instance)
 
     return instance
 

--- a/ansible_galaxy/fetch/local_file.py
+++ b/ansible_galaxy/fetch/local_file.py
@@ -1,6 +1,10 @@
 
 import logging
 
+from ansible_galaxy import repository
+from ansible_galaxy import repository_archive
+
+
 log = logging.getLogger(__name__)
 
 
@@ -25,13 +29,29 @@ class LocalFileFetch(object):
 
         log.debug('repository_archive_path=%s (inplace)', repository_archive_path)
 
+        repo_archive = self._load_repository_archive(repository_archive_path)
+
+        repo = self._load_repository(repo_archive)
+
         results = {'archive_path': repository_archive_path,
                    'fetch_method': self.fetch_method}
 
         results['custom'] = {'local_path': self.local_path}
         results['content'] = find_results['content']
+        results['content']['fetched_name'] = repo.repository_spec.name
 
         return results
+
+    def _load_repository_archive(self, archive_path):
+        repo_archive = repository_archive.load_archive(archive_path)
+        log.debug('repo_archive: %s', repo_archive)
+
+        return repo_archive
+
+    def _load_repository(self, repository_archive):
+        repo = repository.load_from_archive(repository_archive)
+        log.debug('repo: %s', repo)
+        return repo
 
     def cleanup(self):
         return None

--- a/ansible_galaxy/install.py
+++ b/ansible_galaxy/install.py
@@ -73,10 +73,9 @@ def fetch(fetcher, repository_spec, find_results):
 
 def update_repository_spec(fetch_results,
                            repository_spec=None):
-    '''Verify we got the archive we asked for, checksums, check sigs, etc
+    '''Create a new RepositorySpec with updated info from fetch_results.
 
-    At the moment, also side effect and evols repository_spec to match fetch results
-    so that needs to be extracted'''
+    Evolves repository_spec to match fetch results.'''
     # TODO: do we still need to check the fetched version against the spec version?
     #       We do, since the unspecific version is None, so fetched versions wont match
     #       so we need a new repository_spec for install.
@@ -90,6 +89,12 @@ def update_repository_spec(fetch_results,
                   content_data.get('fetched_version', repository_spec.version))
 
         repository_spec = attr.evolve(repository_spec, version=content_data['fetched_version'])
+
+    if content_data.get('fetched_name', repository_spec.name) != repository_spec.name:
+        log.debug('Repository %s was requested but fetch found %s',
+                  repository_spec.name,
+                  content_data.get('fetched_name', repository_spec.name))
+        repository_spec = attr.evolve(repository_spec, name=content_data['fetched_name'])
 
     if content_data.get('content_namespace', repository_spec.namespace) != repository_spec.namespace:
         log.warning('Namespace "%s" for %s was requested but fetch found namespace "%s"',

--- a/ansible_galaxy/models/repository_archive.py
+++ b/ansible_galaxy/models/repository_archive.py
@@ -29,12 +29,12 @@ class RepositoryArchive(object):
         '''The relative path inside the installed content where extract should consider the root
 
         A collection archive for 'my_namespace.my_content' will typically be extracted to
-        '~/.ansible/content/my_namespace/my_content' in which case the content_dest_root_subpath
+        '~/.ansible/content/my_namespace/my_content' in which case the repository_dest_root_subpath
         should return just '/'.
 
         But Role archives will be extracted into a 'roles' sub dir of the typical path.
         ie, a 'my_namespace.my_role' role archive will need to be extracted to
-        '~/.ansible/content/my_namespace/roles/my_role/' in which case the content_dest_root_subpatch
+        '~/.ansible/content/my_namespace/roles/my_role/' in which case the repository_dest_root_subpatch
         should return 'roles/my_roles' (ie, 'roles/%s' % content_name)
         '''
         return ''
@@ -51,4 +51,9 @@ class TraditionalRoleRepositoryArchive(RepositoryArchive):
 
 @attr.s(frozen=True)
 class CollectionRepositoryArchive(RepositoryArchive):
+    pass
+
+
+@attr.s(frozen=True)
+class CollectionRepositoryArtifactArchive(RepositoryArchive):
     pass

--- a/ansible_galaxy/repository.py
+++ b/ansible_galaxy/repository.py
@@ -5,13 +5,13 @@ import shutil
 import yaml
 
 from ansible_galaxy import collection_info
+from ansible_galaxy import collection_artifact_manifest
 from ansible_galaxy import install_info
 from ansible_galaxy import role_metadata
 from ansible_galaxy import requirements
 
 from ansible_galaxy.models.repository_spec import RepositorySpec
 from ansible_galaxy.models.repository import Repository
-
 
 log = logging.getLogger(__name__)
 
@@ -55,6 +55,18 @@ def load_from_dir(content_dir, namespace, name, installed=True):
     # TODO: figure out what to do if the version from install_info conflicts with version
     #       from galaxy.yml etc.
     install_info_version = getattr(install_info_data, 'version', None)
+
+    # Try to load a MANIFEST.json if we have one
+
+    manifest_filename = os.path.join(path_name, collection_artifact_manifest.COLLECTION_MANIFEST_FILENAME)
+    manifest_data = None
+
+    try:
+        with open(manifest_filename, 'r') as mfd:
+            manifest_data = collection_artifact_manifest.load(mfd)
+    except EnvironmentError:
+        # log.debug('No galaxy.yml collection info found for collection %s.%s: %s', namespace, name, e)
+        pass
 
     # load galaxy.yml
     galaxy_filename = os.path.join(path_name, collection_info.COLLECTION_INFO_FILENAME)

--- a/ansible_galaxy/repository_archive.py
+++ b/ansible_galaxy/repository_archive.py
@@ -171,13 +171,19 @@ def load_editable_archive_info(archive_path, repository_spec):
 
 def load_tarfile_archive_info(archive_path, repository_spec):
 
-    if not tarfile.is_tarfile(archive_path):
-        raise exceptions.GalaxyClientError("the file downloaded was not a tar.gz")
+    # if not tarfile.is_tarfile(archive_path):
+    #    raise exceptions.GalaxyClientError("the file downloaded was not a tar.gz")
 
     if archive_path.endswith('.gz'):
-        repository_tar_file = tarfile.open(archive_path, "r:gz")
+        tar_flags = "r:gz"
     else:
-        repository_tar_file = tarfile.open(archive_path, "r")
+        tar_flags = "r"
+
+    try:
+        repository_tar_file = tarfile.open(archive_path, tar_flags)
+    except tarfile.TarError:
+        raise exceptions.GalaxyClientError("Error opening the tar file %s with flags: %s for repo: %s" %
+                                           (archive_path, tar_flags, repository_spec.label))
 
     members = repository_tar_file.getmembers()
     archive_info = build_archive_info(archive_path, [m.name for m in members])

--- a/ansible_galaxy/repository_spec.py
+++ b/ansible_galaxy/repository_spec.py
@@ -90,7 +90,7 @@ def editable_resolve(data):
     return data
 
 
-def spec_data_from_string(repository_spec_string, namespace_override=None, editable=False):
+def spec_data_from_string(repository_spec_string, namespace_override=None, fetch_method=None, editable=False):
     fetch_method = chose_repository_fetch_method(repository_spec_string, editable=editable)
 
     log.debug('fetch_method: %s', fetch_method)
@@ -101,6 +101,7 @@ def spec_data_from_string(repository_spec_string, namespace_override=None, edita
     log.debug('spec_data: %s', spec_data)
 
     resolver = resolve
+    # FIXME need local_file artifact resolver?
     if fetch_method == FetchMethods.GALAXY_URL:
         resolver = galaxy_repository_spec.resolve
 

--- a/tests/ansible_galaxy/example_artifact_manifest1.yml
+++ b/tests/ansible_galaxy/example_artifact_manifest1.yml
@@ -1,9 +1,9 @@
 collection_info:
-  namespace: "some_namespace"
-  name: "some_name"
+  name: "some_namespace.some_name"
   version: "1.2.3"
   authors: ["Javale McGee"]
   license: "GPL-3.0-or-later"
+  description: "An example artifact manifest for unit tests"
 format: 1
 files:
   - name: "roles/some_role/defaults/main.yml"

--- a/tests/ansible_galaxy/fetch/test_local_file.py
+++ b/tests/ansible_galaxy/fetch/test_local_file.py
@@ -8,12 +8,16 @@ from ansible_galaxy import repository_spec
 log = logging.getLogger(__name__)
 
 
-def test_local_file_fetch():
-    tmp_file = tempfile.NamedTemporaryFile(prefix='tmp', delete=True)
+def test_local_file_fetch(mocker):
+    tmp_file = tempfile.NamedTemporaryFile(prefix='tmp', suffix='.tar.gz', delete=True)
     log.debug('tmp_file.name=%s tmp_file=%s', tmp_file.name, tmp_file)
 
     repository_spec_ = repository_spec.repository_spec_from_string(tmp_file.name)
 
+    mocker.patch('ansible_galaxy.fetch.local_file.LocalFileFetch._load_repository_archive',
+                 return_value=mocker.Mock(name='mockRepoArchive'))
+    mocker.patch('ansible_galaxy.fetch.local_file.LocalFileFetch._load_repository',
+                 return_value=mocker.Mock(name='mockRepo'))
     local_fetch = local_file.LocalFileFetch(repository_spec_)
 
     find_results = local_fetch.find()
@@ -25,3 +29,11 @@ def test_local_file_fetch():
     # LocalFileFetch is acting directly on an existing file, so it's cleanup
     # should _not_ delete the file
     assert os.path.isfile(tmp_file.name)
+
+    # results = {'archive_path': '/tmp/tmpcle_fdtp.tar.gz', 'fetch_method': 'local_file',
+    # 'custom': {'local_path': '/tmp/tmpcle_fdtp.tar.gz'},
+    # 'content': {'galaxy_namespace': None, 'repo_name': '/tmp/tmpcle_fdtp.tar',
+    # 'fetched_name': <Mock name='mockRepo.repository_spec.name' id='139946600228288'>}}
+    assert results['archive_path'] == tmp_file.name
+    assert results['fetch_method'] == 'local_file'
+    assert results['custom']['local_path'] == tmp_file.name


### PR DESCRIPTION
##### SUMMARY

Support install of collection archive artifacts.
Assorted fixes for 'local_file' installs. 
  - for non-built collection archives (ie, a tar up of a collection, 'mazer install path/to/alikins.collection_reqs_test-1.2.3.tar.gz')
  - for built collection archive artifacts ( cd ~/path/to/collection; mazer build; mazer install releases/

 - Feature Pull Request


##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.3.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.16-100.fc27.x86_64, #1 SMP Sun Oct 21 09:33:00 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-py27/bin/mazer
python_version = 2.7.15 (default, Oct 15 2018, 18:36:25) [GCC 7.3.1 20180712 (Red Hat 7.3.1-6)]
python_executable = /home/adrian/venvs/galaxy-py27/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

