### PR TITLE
Update references in CONTRIBUTING.rst to match current project name

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -15,7 +15,7 @@ Types of Contributions
 Report Bugs
 ~~~~~~~~~~~
 
-Report bugs at https://github.com/ansible/ansible_galaxy_cli/issues.
+Report bugs at https://github.com/ansible/mazer/issues.
 
 If you are reporting a bug, please include:
 
@@ -45,7 +45,7 @@ articles, and such.
 Submit Feedback
 ~~~~~~~~~~~~~~~
 
-The best way to send feedback is to file an issue at https://github.com/ansible/ansible_galaxy_cli/issues.
+The best way to send feedback is to file an issue at https://github.com/ansible/mazer/issues.
 
 If you are proposing a feature:
 
@@ -57,17 +57,17 @@ If you are proposing a feature:
 Get Started!
 ------------
 
-Ready to contribute? Here's how to set up `ansible_galaxy_cli` for local development.
+Ready to contribute? Here's how to set up `mazer` for local development.
 
-1. Fork the `ansible_galaxy_cli` repo on GitHub.
+1. Fork the `mazer` repo on GitHub.
 2. Clone your fork locally::
 
-    $ git clone git@github.com:your_name_here/ansible_galaxy_cli.git
+    $ git clone git@github.com:your_name_here/mazer.git
 
 3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
 
-    $ mkvirtualenv ansible_galaxy_cli
-    $ cd ansible_galaxy_cli/
+    $ mkvirtualenv mazer
+    $ cd mazer/
     $ python setup.py develop
 
 4. Create a branch for local development::
@@ -79,8 +79,8 @@ Ready to contribute? Here's how to set up `ansible_galaxy_cli` for local develop
 5. When you're done making changes, check that your changes pass flake8 and the
    tests, including testing other Python versions with tox::
 
-    $ flake8 ansible_galaxy_cli tests
-    $ python setup.py test or py.test
+    $ flake8 ansible_galaxy ansible_galaxy_cli tests
+    $ python setup.py test # or py.test
     $ tox
 
    To get flake8 and tox, just pip install them into your virtualenv.
@@ -103,7 +103,7 @@ Before you submit a pull request, check that it meets these guidelines:
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
 3. The pull request should work for Python 2.7, 3.4, 3.5 and 3.6, and for PyPy. Check
-   https://travis-ci.org/ansible/ansible_galaxy_cli/pull_requests
+   https://travis-ci.com/ansible/mazer/pull_requests
    and make sure that the tests pass for all supported Python versions.
 
 Tips


### PR DESCRIPTION
##### SUMMARY
Following the docs for local setup, I noticed some discrepencies and mismatches in names.

##### ISSUE TYPE
 - Docs Pull Request

##### MAZER VERSION
```
name = mazer
version = 0.3.0
config_file = /home/calvin/.ansible/mazer.yml
uname = Linux, willow-epsilon, 4.4.0-17134-Microsoft, #471-Microsoft Fri Dec 07 20:04:00 PST 2018, x86_64
executable_location = /mnt/c/Users/calvin/redhat/orion/.env/bin/mazer
python_version = 3.6.7 (default, Oct 22 2018, 11:32:17) [GCC 8.2.0]
python_executable = /mnt/c/Users/calvin/redhat/orion/.env/bin/python
```


##### ADDITIONAL INFORMATION
No additional information, just some straight forward doc updates.

