### PR TITLE
Update CollectionInfo model to latest spec

### DIFF
--- a/ansible_galaxy/build.py
+++ b/ansible_galaxy/build.py
@@ -16,10 +16,10 @@ from ansible_galaxy.utils.text import to_bytes
 
 log = logging.getLogger(__name__)
 
-ARCHIVE_FILENAME_TEMPLATE = 'v{version}.{extension}'
+ARCHIVE_FILENAME_TEMPLATE = '{namespace}-{name}-{version}.{extension}'
 ARCHIVE_FILENAME_EXTENSION = 'tar.gz'
 
-ARCHIVE_TOPDIR_TEMPLATE = '{collection_info.name}-{collection_info.version}'
+ARCHIVE_TOPDIR_TEMPLATE = '{collection_info.namespace}-{collection_info.name}-{collection_info.version}'
 
 
 # TODO: enum
@@ -108,7 +108,9 @@ class Build(object):
 
         # ie, 'v1.2.3.tar.gz', not full path
         archive_filename_basename = \
-            ARCHIVE_FILENAME_TEMPLATE.format(version=self.collection_info.version,
+            ARCHIVE_FILENAME_TEMPLATE.format(namespace=self.collection_info.namespace,
+                                             name=self.collection_info.name,
+                                             version=self.collection_info.version,
                                              extension=ARCHIVE_FILENAME_EXTENSION)
 
         archive_path = os.path.join(self.build_context.output_path,

--- a/ansible_galaxy/models/collection_info.py
+++ b/ansible_galaxy/models/collection_info.py
@@ -10,12 +10,13 @@ import semver
 log = logging.getLogger(__name__)
 
 TAG_REGEXP = re.compile('^[a-z0-9]+$')
-
+NAME_REGEXP = re.compile(r'^[a-z0-9_-]+$')
 # see https://github.com/ansible/galaxy/issues/957
 
 
 @attr.s(frozen=True)
 class CollectionInfo(object):
+    namespace = attr.ib(default=None)
     name = attr.ib(default=None)
     version = attr.ib(default=None)
     license = attr.ib(default=None)
@@ -30,13 +31,14 @@ class CollectionInfo(object):
     dependencies = attr.ib(factory=list)
 
     @property
-    def namespace(self):
-        return self.name.split('.', 1)[0]
+    def label(self):
+        return '%s.%s' % (self.namespace, self.name)
 
     @staticmethod
     def value_error(msg):
         raise ValueError("Invalid collection metadata. %s" % msg)
 
+    @namespace.validator
     @name.validator
     @version.validator
     @license.validator
@@ -82,7 +84,11 @@ class CollectionInfo(object):
                                  "instead found '%s'." % k)
 
     @name.validator
+    @namespace.validator
     def _check_name(self, attribute, value):
-        if len(value.split('.', 1)) != 2:
-            self.value_error("Expecting 'name' to be in Galaxy name format, <namespace>.<collection_name>, "
-                             "instead found '%s'." % value)
+        if '.' in value:
+            self.value_error("Expecting 'name' and 'namespace' to not include any '.' but '%s' has a '.'" % value)
+        if not re.match(NAME_REGEXP, value):
+            self.value_error("Expecting 'name' and 'namespace' to contain alphanumeric characters, '-', or '_' only but '%s' contains others" % value)
+        if value.startswith(('-', '_')):
+            self.value_error("Expecting 'name' and 'namespace' to not start with '-' or '_' but '%s' did" % value)

--- a/ansible_galaxy/models/collection_info.py
+++ b/ansible_galaxy/models/collection_info.py
@@ -10,7 +10,7 @@ import semver
 log = logging.getLogger(__name__)
 
 TAG_REGEXP = re.compile('^[a-z0-9]+$')
-NAME_REGEXP = re.compile(r'^[a-z0-9_-]+$')
+NAME_REGEXP = re.compile(r'^[a-z0-9_]+$')
 # see https://github.com/ansible/galaxy/issues/957
 
 

--- a/ansible_galaxy/models/collection_info.py
+++ b/ansible_galaxy/models/collection_info.py
@@ -89,6 +89,7 @@ class CollectionInfo(object):
         if '.' in value:
             self.value_error("Expecting 'name' and 'namespace' to not include any '.' but '%s' has a '.'" % value)
         if not re.match(NAME_REGEXP, value):
-            self.value_error("Expecting 'name' and 'namespace' to contain alphanumeric characters, '-', or '_' only but '%s' contains others" % value)
-        if value.startswith(('-', '_')):
-            self.value_error("Expecting 'name' and 'namespace' to not start with '-' or '_' but '%s' did" % value)
+            self.value_error("Expecting 'name' and 'namespace' to contain only alphanumeric characters or '_' only but '%s' contains others" % value)
+        # since the NAME_REGEXP catches use of hyphen '-' at all, the next check doesn't need to check for leading hyphen
+        if value.startswith(('_',)):
+            self.value_error("Expecting 'name' and 'namespace' to not start with '_' but '%s' did" % value)

--- a/ansible_galaxy/repository.py
+++ b/ansible_galaxy/repository.py
@@ -9,7 +9,6 @@ from ansible_galaxy import collection_artifact_manifest
 from ansible_galaxy import exceptions
 from ansible_galaxy import install_info
 from ansible_galaxy import role_metadata
-from ansible_galaxy import repository_spec
 from ansible_galaxy import requirements
 
 from ansible_galaxy.models.repository_spec import RepositorySpec

--- a/ansible_galaxy/repository.py
+++ b/ansible_galaxy/repository.py
@@ -82,15 +82,16 @@ def load_from_archive(repository_archive, namespace=None, installed=True):
     # FIXME: change collectionInfo to have separate name/namespace so we dont have to 'parse' the name
     # repo_spec = repository_spec.repository_spec_from_string(col_info.name, namespace_override=namespace)
     # spec_data = repository_spec_parse.parse_string(col_info.name)
-    spec_data = repository_spec.spec_data_from_string(col_info.name, namespace_override=namespace)
+    # spec_data = repository_spec.spec_data_from_string(col_info.name, namespace_override=namespace)
 
-    log.debug('spec_data: %s', spec_data)
+    # log.debug('spec_data: %s', spec_data)
     # log.debug('repo_spec: %s', repo_spec)
 
     # Build a repository_spec of the repo now so we can pass it things like requirements.load()
     # that need to know what requires something
-    repo_spec = RepositorySpec(namespace=spec_data.get('namespace', namespace),
-                               name=spec_data.get('name'),
+    # if we specify a namespace, use it otherwise use the info from galaxy.yml
+    repo_spec = RepositorySpec(namespace=namespace or col_info.namespace,
+                               name=col_info.name,
                                version=col_info.version,
                                spec_string=archive_path,
                                # fetch_method=None,

--- a/tests/ansible_galaxy/collection_examples/hello/galaxy.yml
+++ b/tests/ansible_galaxy/collection_examples/hello/galaxy.yml
@@ -1,4 +1,5 @@
-name: "greetings_namespace.hello"
+namespace: "greetings_namespace"
+name: "hello"
 version: "11.11.11"
 description: "hello world"
 authors: ["Cowboy King Buzzo Lightyear"]

--- a/tests/ansible_galaxy/example_artifact_manifest1.yml
+++ b/tests/ansible_galaxy/example_artifact_manifest1.yml
@@ -1,5 +1,6 @@
 collection_info:
-  name: "some_namespace.some_name"
+  namespace: "some_namespace"
+  name: "some_name"
   version: "1.2.3"
   authors: ["Javale McGee"]
   license: "GPL-3.0-or-later"

--- a/tests/ansible_galaxy/example_collection_info1.yml
+++ b/tests/ansible_galaxy/example_collection_info1.yml
@@ -1,4 +1,5 @@
-name: "some_namespace.some_name"
+namespace: "some_namespace"
+name: "some_name"
 version: "11.11.11"
 description: "something"
 authors: ["Carlos Boozer"]

--- a/tests/ansible_galaxy/models/test_collection_info_model.py
+++ b/tests/ansible_galaxy/models/test_collection_info_model.py
@@ -33,19 +33,57 @@ def test_required_error():
     assert 'name' in str(exc) in str(exc)
 
 
-def test_name_parse_error():
-    test_data = {
-        'namespace': 'foo',
-        'name': '1-foo',
-        'authors': ['chouseknecht'],
-        'license': 'GPL-3.0-or-later',
-        'version': '0.0.1',
-        'description': 'unit testing thing'
-    }
-    # ValueError: Invalid collection metadata. Expecting 'name' to be in Galaxy name format, <namespace>.<collection_name>, instead found 'foo'.
-    with pytest.raises(ValueError) as exc:
+def test_name_parse_error_dots_in_name():
+    test_data = {'namespace': 'foo',
+                 'name': 'foo.bar',
+                 'authors': ['chouseknecht'],
+                 'license': 'GPL-3.0-or-later',
+                 'version': '0.0.1',
+                 'description': 'unit testing thing'}
+
+    # CollectionInfo(**test_data)
+    # ValueError: Invalid collection metadata. Expecting 'name' and 'namespace' to not include any '.' but 'foo.bar' has a '.'
+    error_re = r"Invalid collection metadata. Expecting 'name' and 'namespace' to not include any '\.' but 'foo\.bar' has a '\.'"
+    with pytest.raises(ValueError,
+                       match=error_re) as exc:
         CollectionInfo(**test_data)
     assert 'name' in str(exc)
+
+
+def test_name_parse_error_other_chars_namespace():
+    test_data = {'namespace': 'foo@blip',
+                 'name': 'foo',
+                 'authors': ['chouseknecht'],
+                 'license': 'GPL-3.0-or-later',
+                 'version': '0.0.1',
+                 'description': 'unit testing thing'}
+
+    # ValueError: Invalid collection metadata. Expecting 'name' and 'namespace' to contain alphanumeric characters,
+    # '-', or '_' only but 'foo@blip' contains others"
+    error_re = r"Invalid collection metadata. Expecting 'name' and 'namespace' to contain alphanumeric characters, "
+    "'-', or '_' only but 'foo@blip' contains others"
+    with pytest.raises(ValueError,
+                       match=error_re) as exc:
+        CollectionInfo(**test_data)
+    assert 'foo@blip' in str(exc)
+
+
+def test_name_parse_error_name_leading_underscore():
+    test_data = {'namespace': 'foo',
+                 'name': '_foo',
+                 'authors': ['chouseknecht'],
+                 'license': 'GPL-3.0-or-later',
+                 'version': '0.0.1',
+                 'description': 'unit testing thing'}
+
+    # ValueError: Invalid collection metadata. Expecting 'name' and 'namespace' to not start with '-' or '_' but '_foo' did
+    error_re = r"Invalid collection metadata. Expecting 'name' and 'namespace' to contain alphanumeric characters, "
+    "'-', or '_' only but 'foo@blip' contains others"
+    error_re = r"Invalid collection metadata. Expecting 'name' and 'namespace' to not start with '-' or '_' but '_foo' did"
+    with pytest.raises(ValueError,
+                       match=error_re) as exc:
+        CollectionInfo(**test_data)
+    assert '_foo' in str(exc)
 
 
 def test_type_list_error():

--- a/tests/ansible_galaxy/models/test_collection_info_model.py
+++ b/tests/ansible_galaxy/models/test_collection_info_model.py
@@ -107,6 +107,32 @@ def test_type_authors_not_list_error(col_info):
     assert 'authors' in str(exc)
 
 
+def test_keywords_non_alpha_error(col_info):
+    bad_keyword = 'bad-keyword!'
+    col_info['keywords'] = ['goodkeyword', bad_keyword]
+
+    # ValueError: Invalid collection metadata. Expecting keywords to contain alphanumeric characters only, instead found 'bad-keyword!'.
+    error_re = r"Invalid collection metadata. Expecting keywords to contain alphanumeric characters only, instead found '.*'"
+
+    with pytest.raises(ValueError,
+                       match=error_re) as exc:
+        CollectionInfo(**col_info)
+    assert bad_keyword in str(exc)
+
+
+def test_keywords_not_a_list_error(col_info):
+    not_a_list = 'notakeywordlist'
+    col_info['keywords'] = not_a_list
+
+    # ValueError: Invalid collection metadata. Expecting 'keywords' to be a list
+    error_re = r"Invalid collection metadata. Expecting 'keywords' to be a list"
+
+    with pytest.raises(ValueError,
+                       match=error_re) as exc:
+        CollectionInfo(**col_info)
+    assert 'keywords' in str(exc)
+
+
 def test_empty():
     col_info = {}
     # ValueError: Invalid collection metadata. 'namespace' is required

--- a/tests/ansible_galaxy/models/test_collection_info_model.py
+++ b/tests/ansible_galaxy/models/test_collection_info_model.py
@@ -74,8 +74,9 @@ def test_name_parse_error_name_leading_underscore(col_info):
 def test_name_parse_error_name_leading_hyphen(col_info):
     col_info['name'] = '-foo'
 
-    # ValueError: Invalid collection metadata. Expecting 'name' and 'namespace' to not start with '-' or '_' but '_foo' did
-    error_re = r"Invalid collection metadata. Expecting 'name' and 'namespace' to not start with '-' or '_' but '-foo' did"
+    # For the case of a leading '-', the 'no dashes' check raises error first
+    error_re = r"Invalid collection metadata. Expecting 'name' and 'namespace' to contain alphanumeric characters, "
+    "'-', or '_' only but '-foo' contains others"
     with pytest.raises(ValueError,
                        match=error_re) as exc:
         CollectionInfo(**col_info)

--- a/tests/ansible_galaxy/models/test_collection_info_model.py
+++ b/tests/ansible_galaxy/models/test_collection_info_model.py
@@ -5,6 +5,9 @@ from ansible_galaxy.models.collection_info import CollectionInfo
 
 log = logging.getLogger(__name__)
 
+NON_ALPHA_ERROR_PAT = r"Invalid collection metadata. Expecting 'name' and 'namespace' to contain only alphanumeric characters "
+"or '_' only but '.*' contains others"
+
 
 @pytest.fixture
 def col_info():
@@ -50,12 +53,10 @@ def test_name_parse_error_dots_in_name(col_info):
 def test_name_parse_error_other_chars_namespace(col_info):
     col_info['namespace'] = 'foo@blip'
 
-    # ValueError: Invalid collection metadata. Expecting 'name' and 'namespace' to contain alphanumeric characters,
-    # '-', or '_' only but 'foo@blip' contains others"
-    error_re = r"Invalid collection metadata. Expecting 'name' and 'namespace' to contain alphanumeric characters, "
-    "'-', or '_' only but 'foo@blip' contains others"
+    # ValueError: Invalid collection metadata. Expecting 'name' and 'namespace' to contain only alphanumeric characters
+    # or '_' only but 'foo@blip' contains others"
     with pytest.raises(ValueError,
-                       match=error_re) as exc:
+                       match=NON_ALPHA_ERROR_PAT) as exc:
         CollectionInfo(**col_info)
     assert 'foo@blip' in str(exc)
 
@@ -63,8 +64,8 @@ def test_name_parse_error_other_chars_namespace(col_info):
 def test_name_parse_error_name_leading_underscore(col_info):
     col_info['name'] = '_foo'
 
-    # ValueError: Invalid collection metadata. Expecting 'name' and 'namespace' to not start with '-' or '_' but '_foo' did
-    error_re = r"Invalid collection metadata. Expecting 'name' and 'namespace' to not start with '-' or '_' but '_foo' did"
+    # ValueError: Invalid collection metadata. Expecting 'name' and 'namespace' to not start with '_' but '_foo' did
+    error_re = r"Invalid collection metadata. Expecting 'name' and 'namespace' to not start with '_' but '_foo' did"
     with pytest.raises(ValueError,
                        match=error_re) as exc:
         CollectionInfo(**col_info)
@@ -75,10 +76,8 @@ def test_name_parse_error_name_leading_hyphen(col_info):
     col_info['name'] = '-foo'
 
     # For the case of a leading '-', the 'no dashes' check raises error first
-    error_re = r"Invalid collection metadata. Expecting 'name' and 'namespace' to contain alphanumeric characters, "
-    "'-', or '_' only but '-foo' contains others"
     with pytest.raises(ValueError,
-                       match=error_re) as exc:
+                       match=NON_ALPHA_ERROR_PAT) as exc:
         CollectionInfo(**col_info)
     assert '-foo' in str(exc)
 
@@ -86,10 +85,8 @@ def test_name_parse_error_name_leading_hyphen(col_info):
 def test_name_has_hypen_error(col_info):
     col_info['name'] = 'foo-bar'
 
-    error_re = r"Invalid collection metadata. Expecting 'name' and 'namespace' to contain alphanumeric characters, "
-    "'-', or '_' only but 'foo-bar' contains others"
     with pytest.raises(ValueError,
-                       match=error_re) as exc:
+                       match=NON_ALPHA_ERROR_PAT) as exc:
         CollectionInfo(**col_info)
     assert 'foo-bar' in str(exc)
 
@@ -97,10 +94,8 @@ def test_name_has_hypen_error(col_info):
 def test_namespace_has_hypen_error(col_info):
     col_info['namespace'] = 'foo-namespace'
 
-    error_re = r"Invalid collection metadata. Expecting 'name' and 'namespace' to contain alphanumeric characters, "
-    "'-', or '_' only but 'foo-namespace' contains others"
     with pytest.raises(ValueError,
-                       match=error_re) as exc:
+                       match=NON_ALPHA_ERROR_PAT) as exc:
         CollectionInfo(**col_info)
     assert 'foo-namespace' in str(exc)
 

--- a/tests/ansible_galaxy/models/test_collection_info_model.py
+++ b/tests/ansible_galaxy/models/test_collection_info_model.py
@@ -8,7 +8,8 @@ log = logging.getLogger(__name__)
 
 def test_license_error():
     test_data = {
-        'name': 'foo.foo',
+        'namespace': 'foo',
+        'name': 'foo',
         'authors': ['chouseknecht'],
         'license': 'GPLv2',
         'version': '0.0.1',
@@ -21,6 +22,7 @@ def test_license_error():
 
 def test_required_error():
     test_data = {
+        'namespace': 'foo',
         'authors': ['chouseknecht'],
         'license': 'GPL-3.0-or-later',
         'version': '0.0.1',
@@ -33,7 +35,8 @@ def test_required_error():
 
 def test_name_parse_error():
     test_data = {
-        'name': 'foo',
+        'namespace': 'foo',
+        'name': '1-foo',
         'authors': ['chouseknecht'],
         'license': 'GPL-3.0-or-later',
         'version': '0.0.1',
@@ -47,7 +50,8 @@ def test_name_parse_error():
 
 def test_type_list_error():
     test_data = {
-        'name': 'foo.foo',
+        'namespace': 'foo',
+        'name': 'foo',
         'authors': 'chouseknecht',
         'license': 'GPL-3.0-or-later',
         'version': '0.0.1',
@@ -60,14 +64,15 @@ def test_type_list_error():
 
 def test_empty():
     test_data = {}
-    # ValueError: Invalid collection metadata. 'name' is required
-    with pytest.raises(ValueError, match=".*'name'.*"):
+    # ValueError: Invalid collection metadata. 'namespace' is required
+    with pytest.raises(ValueError, match=".*'namespace'.*"):
         CollectionInfo(**test_data)
 
 
 def test_minimal():
     test_data = {
-        'name': 'foo.foo',
+        'namespace': 'foo',
+        'name': 'foo',
         'license': 'GPL-3.0-or-later',
         'version': '1.0.0',
         'description': 'unit testing thing',
@@ -94,7 +99,8 @@ def test_minimal():
 
 def test_authors_append():
     test_data = {
-        'name': 'foo.foo',
+        'namespace': 'foo',
+        'name': 'foo',
         # let authors go to the defualt
         # 'authors': ['chouseknecht'],
         'license': 'GPL-3.0-or-later',
@@ -131,7 +137,8 @@ def test_authors_append():
 
 def test_semantic_version_error():
     test_data = {
-        'name': 'foo.foo',
+        'namespace': 'foo',
+        'name': 'foo',
         'authors': ['chouseknecht'],
         'license': 'GPL-3.0-or-later',
         'version': 'foo',
@@ -144,7 +151,8 @@ def test_semantic_version_error():
 
 def test_namespace_property():
     test_data = {
-        'name': 'foo.foo',
+        'namespace': 'foo',
+        'name': 'foo',
         'authors': ['chouseknecht'],
         'license': 'GPL-3.0-or-later',
         'version': '1.0.0',

--- a/tests/ansible_galaxy/test_build.py
+++ b/tests/ansible_galaxy/test_build.py
@@ -27,13 +27,15 @@ def _build_context(collection_path=None, output_path=None):
 
 
 def _collection_info(namespace=None, name=None, version=None, authors=None):
-    name = name or 'some_namespace.some_name'
+    # name = name or 'some_namespace.some_name'
+    namespace = namespace or 'some_namespace'
+    name = name or 'some_name'
     version = version or '1.2.3'
     authors = authors or ['Rex Chapman']
     description = "Unit testing thing"
     test_license = 'GPL-3.0-or-later'
 
-    return CollectionInfo(name=name, version=version, authors=authors, description=description,
+    return CollectionInfo(namespace=namespace, name=name, version=version, authors=authors, description=description,
                           license=test_license)
 
 

--- a/tests/ansible_galaxy/test_collection_info.py
+++ b/tests/ansible_galaxy/test_collection_info.py
@@ -15,7 +15,8 @@ log = logging.getLogger(__name__)
 def test_load():
     file_name = "example_collection_info1.yml"
     test_data_path = os.path.join(os.path.dirname(__file__), '%s' % file_name)
-    expected = {'name': 'some_namespace.some_name',
+    expected = {'namespace': 'some_namespace',
+                'name': 'some_name',
                 'version': '11.11.11',
                 'authors': ['Carlos Boozer'],
                 'description': 'something',

--- a/tests/ansible_galaxy/test_repository_archive.py
+++ b/tests/ansible_galaxy/test_repository_archive.py
@@ -88,4 +88,6 @@ def test_load_from_archive(galaxy_context, tmpdir):
 
     # CollectionRepositoryArtifactArchive(info=RepositoryArchiveInfo(archive_type='multi-content-artifact', top_dir='greetings_namespace.hello-11.11.11'
     assert res.info.archive_type == 'multi-content-artifact'
-    assert res.info.top_dir == 'greetings_namespace.hello-11.11.11'
+
+    # topdir is namespace-name-version (note: not namespace.name-version)
+    assert res.info.top_dir == 'greetings_namespace-hello-11.11.11'


### PR DESCRIPTION
ie, now support distinct namespace and name
attributes in galaxy.yml

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.3.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.16-100.fc27.x86_64, #1 SMP Sun Oct 21 09:33:00 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3-2/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3-2/bin/python

```


