### PR TITLE
Update for recent version of specs

### DIFF
--- a/ansible_galaxy/models/collection_info.py
+++ b/ansible_galaxy/models/collection_info.py
@@ -23,7 +23,7 @@ class CollectionInfo(object):
     description = attr.ib(default=None)
 
     authors = attr.ib(factory=list)
-    keywords = attr.ib(factory=list)
+    tags = attr.ib(factory=list)
     readme = attr.ib(default='README.md')
 
     # Note galaxy.yml 'dependencies' field is what mazer and ansible
@@ -42,7 +42,6 @@ class CollectionInfo(object):
     @name.validator
     @version.validator
     @license.validator
-    @description.validator
     def _check_required(self, attribute, value):
         if value is None:
             self.value_error("'%s' is required" % attribute.name)
@@ -71,17 +70,17 @@ class CollectionInfo(object):
                   "deprecated." % value)
 
     @authors.validator
-    @keywords.validator
+    @tags.validator
     @dependencies.validator
     def _check_list_type(self, attribute, value):
         if not isinstance(value, list):
             self.value_error("Expecting '%s' to be a list" % attribute.name)
 
-    @keywords.validator
+    @tags.validator
     def _check_keywords(self, attribute, value):
         for k in value:
             if not re.match(TAG_REGEXP, k):
-                self.value_error("Expecting keywords to contain alphanumeric characters only, "
+                self.value_error("Expecting tags to contain alphanumeric characters only, "
                                  "instead found '%s'." % k)
 
     @name.validator


### PR DESCRIPTION
'keywords' is now called 'tags'

'description' is no longer required.

Fixes to build 
https://github.com/ansible-collections/ansible_collection_google etc

(after https://github.com/ansible-collections/ansible_collection_google/pull/1 is merged)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.3.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.16-100.fc27.x86_64, #1 SMP Sun Oct 21 09:33:00 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3-2/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3-2/bin/python


```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

