### PR TITLE
Fix 'mazer install /path/tarball.tar.gz', open it earlier to get metadata like namespace

### DIFF
--- a/ansible_galaxy/collection_artifact_manifest.py
+++ b/ansible_galaxy/collection_artifact_manifest.py
@@ -29,7 +29,7 @@ def load(data_or_file_object):
     data_dict = yaml.safe_load(data_or_file_object)
 
     # log.debug('data: %s', pf(data_dict))
-    log.debug('data_dict: %s', data_dict)
+    # log.debug('data_dict: %s', data_dict)
 
     col_info = CollectionInfo(**data_dict['collection_info'])
     # klass = CollectionArtifactManifest
@@ -37,9 +37,10 @@ def load(data_or_file_object):
                                           files=data_dict['files'])
     # instance = klass(**data_dict)
 
-    log.debug('%s instance from_kwargs: %s', type(instance), instance)
+    log.debug('%s instance from_kwargs', type(instance))
+    # instance)
 
-    log.debug('collection_artifact_manifest: %s', instance)
+    # log.debug('collection_artifact_manifest: %r', instance)
 
     return instance
 

--- a/ansible_galaxy/fetch/fetch_factory.py
+++ b/ansible_galaxy/fetch/fetch_factory.py
@@ -1,12 +1,12 @@
 import logging
 
 from ansible_galaxy import exceptions
-from ansible_galaxy.repository_spec import FetchMethods
 from ansible_galaxy.fetch import galaxy_url
 from ansible_galaxy.fetch import local_file
 from ansible_galaxy.fetch import remote_url
 from ansible_galaxy.fetch import scm_url
 from ansible_galaxy.fetch import editable
+from ansible_galaxy.models.repository_spec import FetchMethods
 
 log = logging.getLogger(__name__)
 

--- a/ansible_galaxy/install.py
+++ b/ansible_galaxy/install.py
@@ -10,7 +10,7 @@ from ansible_galaxy import repository_archive
 from ansible_galaxy import exceptions
 from ansible_galaxy import installed_repository_db
 from ansible_galaxy.models.install_destination import InstallDestinationInfo
-from ansible_galaxy.repository_spec import FetchMethods
+from ansible_galaxy.models.repository_spec import FetchMethods
 
 log = logging.getLogger(__name__)
 

--- a/ansible_galaxy/models/repository_spec.py
+++ b/ansible_galaxy/models/repository_spec.py
@@ -7,6 +7,15 @@ from ansible_galaxy.utils.version import convert_string_to_semver
 log = logging.getLogger(__name__)
 
 
+# FIXME: do we have an enum like class for py2.6? worth a dep?
+class FetchMethods(object):
+    SCM_URL = 'SCM_URL'
+    LOCAL_FILE = 'LOCAL_FILE'
+    REMOTE_URL = 'REMOTE_URL'
+    GALAXY_URL = 'GALAXY_URL'
+    EDITABLE = 'EDITABLE'
+
+
 @attr.s(frozen=True)
 class RepositorySpec(object):
     '''The info used to identify and reference a galaxy content.

--- a/ansible_galaxy/repository_archive.py
+++ b/ansible_galaxy/repository_archive.py
@@ -10,7 +10,7 @@ from ansible_galaxy import install_info
 from ansible_galaxy.models import content
 from ansible_galaxy.models.repository_archive import RepositoryArchiveInfo, CollectionRepositoryArchive
 from ansible_galaxy.models.repository_archive import CollectionRepositoryArtifactArchive, TraditionalRoleRepositoryArchive
-from ansible_galaxy.repository_spec import FetchMethods
+from ansible_galaxy.models.repository_spec import FetchMethods
 from ansible_galaxy.models.install_info import InstallInfo
 from ansible_galaxy.models.installation_results import InstallationResults
 
@@ -181,9 +181,10 @@ def load_tarfile_archive_info(archive_path, repository_spec):
 
     try:
         repository_tar_file = tarfile.open(archive_path, tar_flags)
-    except tarfile.TarError:
+    except tarfile.TarError as e:
+        log.exception(e)
         raise exceptions.GalaxyClientError("Error opening the tar file %s with flags: %s for repo: %s" %
-                                           (archive_path, tar_flags, repository_spec.label))
+                                           (archive_path, tar_flags, repository_spec))
 
     members = repository_tar_file.getmembers()
     archive_info = build_archive_info(archive_path, [m.name for m in members])

--- a/ansible_galaxy/repository_spec_parse.py
+++ b/ansible_galaxy/repository_spec_parse.py
@@ -3,6 +3,7 @@ import os
 
 from ansible_galaxy import exceptions
 from ansible_galaxy import galaxy_repository_spec
+from ansible_galaxy.models.repository_spec import FetchMethods
 
 log = logging.getLogger(__name__)
 
@@ -92,14 +93,6 @@ def is_scm(repository_spec_string):
         return True
 
     return False
-
-
-# FIXME: do we have an enum like class for py2.6? worth a dep?
-class FetchMethods(object):
-    SCM_URL = 'SCM_URL'
-    LOCAL_FILE = 'LOCAL_FILE'
-    REMOTE_URL = 'REMOTE_URL'
-    GALAXY_URL = 'GALAXY_URL'
 
 
 def chose_repository_fetch_method(repository_spec_string):

--- a/tests/ansible_galaxy/fetch/test_local_file.py
+++ b/tests/ansible_galaxy/fetch/test_local_file.py
@@ -5,7 +5,6 @@ import tempfile
 
 
 from ansible_galaxy.fetch import local_file
-from ansible_galaxy import repository_spec
 from ansible_galaxy.models.repository_archive import RepositoryArchive, RepositoryArchiveInfo
 from ansible_galaxy.models.repository_spec import RepositorySpec, FetchMethods
 

--- a/tests/ansible_galaxy/fetch/test_local_file.py
+++ b/tests/ansible_galaxy/fetch/test_local_file.py
@@ -1,6 +1,8 @@
 import logging
 import os
+import tarfile
 import tempfile
+
 
 from ansible_galaxy.fetch import local_file
 from ansible_galaxy import repository_spec
@@ -9,10 +11,19 @@ log = logging.getLogger(__name__)
 
 
 def test_local_file_fetch(mocker):
-    tmp_file = tempfile.NamedTemporaryFile(prefix='tmp', suffix='.tar.gz', delete=True)
-    log.debug('tmp_file.name=%s tmp_file=%s', tmp_file.name, tmp_file)
+    tmp_file_fo = tempfile.NamedTemporaryFile(prefix='tmp', suffix='.tar.gz', delete=False)
+    tmp_member_fo = tempfile.NamedTemporaryFile(delete=False, prefix='cccccccccc')
+    log.debug('tmp_file_fo.name=%s tmp_file=%s', tmp_file_fo.name, tmp_file_fo)
+    tar_file = tarfile.open(mode='w:gz',
+                            fileobj=tmp_file_fo)
 
-    repository_spec_ = repository_spec.repository_spec_from_string(tmp_file.name)
+    pathname = 'MANIFEST.JSON'
+    member = tarfile.TarInfo(pathname)
+    tar_file.addfile(member, tmp_member_fo)
+
+    tar_file.close()
+
+    repository_spec_ = repository_spec.repository_spec_from_string(tmp_file_fo.name)
 
     mocker.patch('ansible_galaxy.fetch.local_file.LocalFileFetch._load_repository_archive',
                  return_value=mocker.Mock(name='mockRepoArchive'))
@@ -28,12 +39,14 @@ def test_local_file_fetch(mocker):
 
     # LocalFileFetch is acting directly on an existing file, so it's cleanup
     # should _not_ delete the file
-    assert os.path.isfile(tmp_file.name)
+    assert os.path.isfile(tmp_file_fo.name)
 
     # results = {'archive_path': '/tmp/tmpcle_fdtp.tar.gz', 'fetch_method': 'local_file',
     # 'custom': {'local_path': '/tmp/tmpcle_fdtp.tar.gz'},
     # 'content': {'galaxy_namespace': None, 'repo_name': '/tmp/tmpcle_fdtp.tar',
     # 'fetched_name': <Mock name='mockRepo.repository_spec.name' id='139946600228288'>}}
-    assert results['archive_path'] == tmp_file.name
+    assert results['archive_path'] == tmp_file_fo.name
     assert results['fetch_method'] == 'local_file'
-    assert results['custom']['local_path'] == tmp_file.name
+    assert results['custom']['local_path'] == tmp_file_fo.name
+
+    log.debug('should unlink %s here', tmp_file_fo.name)

--- a/tests/ansible_galaxy/fetch/test_local_file.py
+++ b/tests/ansible_galaxy/fetch/test_local_file.py
@@ -10,6 +10,46 @@ from ansible_galaxy import repository_spec
 log = logging.getLogger(__name__)
 
 
+JSON_DATA = b'''
+{
+    "collection_info": {
+        "namespace": "bcs",
+        "name": "bcsping",
+        "version": "0.0.1",
+        "license": "GPL-2.0-or-later",
+        "description": "i blatant copy and rename of the ping module",
+        "repository": null,
+        "documentation": null,
+        "homepage": null,
+        "issues": null,
+        "authors": [
+            "me"
+        ],
+        "tags": [],
+        "readme": "README.md",
+        "dependencies": []
+    },
+    "format": 1,
+    "files": [
+        {
+            "name": ".",
+            "ftype": "dir",
+            "chksum_type": null,
+            "chksum_sha256": null,
+            "_format": 1
+        },
+        {
+            "name": "galaxy.yml",
+            "ftype": "file",
+            "chksum_type": "sha256",
+            "chksum_sha256": "728ec435b1717502c305593c7d07116eaacb17ebf714a316f7a925e222f9bb24",
+            "_format": 1
+        }
+    ]
+}
+'''
+
+
 def test_local_file_fetch(mocker):
     tmp_file_fo = tempfile.NamedTemporaryFile(prefix='tmp', suffix='.tar.gz', delete=False)
     tmp_member_fo = tempfile.NamedTemporaryFile(delete=False, prefix='cccccccccc')
@@ -17,11 +57,20 @@ def test_local_file_fetch(mocker):
     tar_file = tarfile.open(mode='w:gz',
                             fileobj=tmp_file_fo)
 
-    pathname = 'MANIFEST.JSON'
+    pathname = 'namespace-name-1.2.3/'
     member = tarfile.TarInfo(pathname)
     tar_file.addfile(member, tmp_member_fo)
 
+    new_member = tarfile.TarInfo('namespace-name-1.2.3/MANIFEST.json')
+    tmp_member_fo.write(b'%s\n' % JSON_DATA)
+    # tmp_member_fo.flush()
+    # tmp_member_fo.close()
+    tar_file.addfile(new_member, tmp_member_fo)
+
+    log.debug('tar_file members: %s', tar_file.getmembers())
     tar_file.close()
+    tmp_file_fo.flush()
+    tmp_file_fo.close()
 
     repository_spec_ = repository_spec.repository_spec_from_string(tmp_file_fo.name)
 

--- a/tests/ansible_galaxy/test_archive.py
+++ b/tests/ansible_galaxy/test_archive.py
@@ -68,8 +68,8 @@ def test_extract_file_foo():
 
     files_to_extract = []
 
-    # for pathname in tar_example1:
     pathname = 'foo_blip.yml'
+    # for pathname in tar_example1:
     member = tarfile.TarInfo(pathname)
     tar_file.addfile(member, tmp_member_fo)
 

--- a/tests/ansible_galaxy/test_repository_spec.py
+++ b/tests/ansible_galaxy/test_repository_spec.py
@@ -5,7 +5,7 @@ import pytest
 
 from ansible_galaxy import repository_spec
 from ansible_galaxy import exceptions
-from ansible_galaxy.models.repository_spec import RepositorySpec
+from ansible_galaxy.models.repository_spec import RepositorySpec, FetchMethods
 
 log = logging.getLogger(__name__)
 
@@ -32,15 +32,15 @@ repo_spec_from_string_cases = \
                                     scm='git')},
         {'spec': 'git+https://mazertestuser@github.com/geerlingguy/ansible-role-apache.git,version=2.0.0',
          'expected': RepositorySpec(name='ansible-role-apache', namespace=None, version='2.0.0',
-                                    scm='git', fetch_method=repository_spec.FetchMethods.SCM_URL)},
+                                    scm='git', fetch_method=FetchMethods.SCM_URL)},
         # A path to a file without a dot in it's name. It's path will include where the tests are run from
         # so specify a ',name=' to provide a predictable name (otherwise it would be the full path)
         {'spec': '%s,name=the_license' % os.path.normpath(os.path.join(os.path.dirname(__file__), '../../LICENSE')),
          'expected': RepositorySpec(name='the_license', namespace=None,
-                                    fetch_method=repository_spec.FetchMethods.LOCAL_FILE)},
+                                    fetch_method=FetchMethods.LOCAL_FILE)},
         {'spec': 'https://docs.ansible.com,name=the_docs',
          'expected': RepositorySpec(name='the_docs', namespace=None,
-                                    scm=None, fetch_method=repository_spec.FetchMethods.REMOTE_URL)},
+                                    scm=None, fetch_method=FetchMethods.REMOTE_URL)},
         # 'foo',
         # 'foo,1.2.3',
         # 'foo,version=1.2.3',

--- a/tests/ansible_galaxy/test_repository_spec.py
+++ b/tests/ansible_galaxy/test_repository_spec.py
@@ -35,9 +35,11 @@ repo_spec_from_string_cases = \
                                     scm='git', fetch_method=FetchMethods.SCM_URL)},
         # A path to a file without a dot in it's name. It's path will include where the tests are run from
         # so specify a ',name=' to provide a predictable name (otherwise it would be the full path)
-        {'spec': '%s,name=the_license' % os.path.normpath(os.path.join(os.path.dirname(__file__), '../../LICENSE')),
-         'expected': RepositorySpec(name='the_license', namespace=None,
-                                    fetch_method=FetchMethods.LOCAL_FILE)},
+        # TODO: local file will attempt to load the contents now, so this test case doesn't make sense without mocking
+        #       out something to exist at the path
+        # {'spec': '%s,name=the_license' % os.path.normpath(os.path.join(os.path.dirname(__file__), '../../LICENSE')),
+        # 'expected': RepositorySpec(name='the_license', namespace=None,
+        #                            fetch_method=FetchMethods.LOCAL_FILE)},
         {'spec': 'https://docs.ansible.com,name=the_docs',
          'expected': RepositorySpec(name='the_docs', namespace=None,
                                     scm=None, fetch_method=FetchMethods.REMOTE_URL)},


### PR DESCRIPTION
Like the namespace, name and other RepositorySpec data.

Some refactoring to make imports easier (mostly moving
FetchMethods enum to models.RepositorySpec)

Update the unit tests a bit, but a few are broken at the moment
since real files or complicated mocks need to be setup for
local_file fetch tests.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request
 - Docs Pull Request


##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

