### PR TITLE
Use collection artifact url, raise exceptions on error, multipart uuid

### DIFF
--- a/ansible_galaxy/actions/publish.py
+++ b/ansible_galaxy/actions/publish.py
@@ -23,6 +23,7 @@ def _get_file_checksum(file_path):
 
 def _publish(galaxy_context,
              archive_path,
+             publish_api_key=None,
              display_callback=None):
 
     results = {
@@ -49,26 +50,25 @@ def _publish(galaxy_context,
     api = GalaxyAPI(galaxy_context)
 
     collection_name = manifest.collection_info.name
-    namespace_name = manifest.collection_info.namespace
 
-    log.debug("Attempting to fetch Galaxy namespace %s" % namespace_name)
-    namespace = api.fetch_namespace(namespace_name)
-
-    namespace_id = namespace.get('id')
     data = {
         'sha256': _get_file_checksum(archive_path),
         'name': collection_name,
         'version': manifest.collection_info.version
     }
+
     log.debug("Publishing file %s with data: %s" % (archive_path, json.dumps(data)))
-    api.publish_file(namespace_id, data, archive_path)
+
+    api.publish_file(data, archive_path, publish_api_key)
+
     return results
 
 
-def publish(galaxy_context, archive_path, display_callback):
+def publish(galaxy_context, archive_path, publish_api_key, display_callback):
 
     results = _publish(galaxy_context,
                        archive_path,
+                       publish_api_key=publish_api_key,
                        display_callback=display_callback)
 
     log.debug('cli publish action results: %s', json.dumps(results))

--- a/ansible_galaxy/collection_artifact.py
+++ b/ansible_galaxy/collection_artifact.py
@@ -1,0 +1,30 @@
+import logging
+
+import attr
+
+from ansible_galaxy import repository
+from ansible_galaxy import repository_archive
+
+log = logging.getLogger(__name__)
+
+
+def load_data_from_collection_artifact(repository_spec_string):
+    log.debug('repo_spec_string: %s', repository_spec_string)
+
+    # TODO: may need some name/path sanitations here
+    archive_file_name = repository_spec_string
+
+    repo_archive = repository_archive.load_archive(archive_file_name,
+                                                   repository_spec=None)
+
+    log.debug('repo_archive: %s', repo_archive)
+
+    repo = repository.load_from_archive(repo_archive)
+
+    # TODO: asdict?
+    spec_data = repo.repository_spec
+    log.debug('spec_data: %s', spec_data)
+
+    # FIXME: we already have a valid RepositorySpec, but we dict'ify it here
+    #        so existing code that assumes a dict continues to work
+    return attr.asdict(spec_data)

--- a/ansible_galaxy/multipart_form.py
+++ b/ansible_galaxy/multipart_form.py
@@ -1,5 +1,6 @@
 import mimetypes
 import io
+import uuid
 
 
 class MultiPartForm(object):
@@ -11,7 +12,7 @@ class MultiPartForm(object):
     def __init__(self):
         self.form_fields = []
         self.files = []
-        self.boundary = 'FORM-BOUNDRY'
+        self.boundary = '--------------------------%s' % uuid.uuid4().hex
         return
 
     def get_content_type(self):

--- a/ansible_galaxy/repository.py
+++ b/ansible_galaxy/repository.py
@@ -8,7 +8,6 @@ from ansible_galaxy import collection_info
 from ansible_galaxy import collection_artifact_manifest
 from ansible_galaxy import exceptions
 from ansible_galaxy import install_info
-from ansible_galaxy import role_metadata
 from ansible_galaxy import requirements
 
 from ansible_galaxy.models.repository_spec import RepositorySpec
@@ -81,7 +80,6 @@ def load_from_archive(repository_archive, namespace=None, installed=True):
     # FIXME: change collectionInfo to have separate name/namespace so we dont have to 'parse' the name
     # repo_spec = repository_spec.repository_spec_from_string(col_info.name, namespace_override=namespace)
     # spec_data = repository_spec_parse.parse_string(col_info.name)
-    # spec_data = repository_spec.spec_data_from_string(col_info.name, namespace_override=namespace)
 
     # log.debug('spec_data: %s', spec_data)
     # log.debug('repo_spec: %s', repo_spec)
@@ -178,6 +176,10 @@ def load_from_dir(content_dir, namespace, name, installed=True):
 
     try:
         with open(role_meta_main_filename, 'r') as rmfd:
+            # FIXME: kluge to avoid circular import on py2
+            #        repository->role_metadata->dependencies->repository_spec->repository (loop)
+            #        repository->requirements->repository_spec->repository (loop)
+            from ansible_galaxy import role_metadata
             role_meta_main = role_metadata.load(rmfd, role_name=role_name)
     except EnvironmentError:
         # log.debug('No meta/main.yml was loaded for repository %s.%s: %s', namespace, name, e)

--- a/ansible_galaxy/repository_spec.py
+++ b/ansible_galaxy/repository_spec.py
@@ -1,11 +1,7 @@
 import logging
 import os
 
-import attr
-
 from ansible_galaxy import galaxy_repository_spec
-from ansible_galaxy import repository
-from ansible_galaxy import repository_archive
 from ansible_galaxy import repository_spec_parse
 from ansible_galaxy import exceptions
 
@@ -22,7 +18,7 @@ def is_scm(repository_spec_string):
     return False
 
 
-def chose_repository_fetch_method(repository_spec_string, editable=False):
+def choose_repository_fetch_method(repository_spec_string, editable=False):
     log.debug('repository_spec_string: %s', repository_spec_string)
 
     if is_scm(repository_spec_string):
@@ -87,40 +83,11 @@ def editable_resolve(data):
     return data
 
 
-def load_data_from_repository_archive(repository_spec_string):
-    log.debug('repo_spec_string: %s', repository_spec_string)
-
-    # TODO: may need some name/path sanitations here
-    archive_file_name = repository_spec_string
-
-    repo_archive = repository_archive.load_archive(archive_file_name,
-                                                   repository_spec=None)
-
-    repo = repository.load_from_archive(repo_archive)
-
-    # TODO: asdict?
-    spec_data = repo.repository_spec
-    log.debug('spec_data: %s', spec_data)
-
-    # FIXME: we already have a valid RepositorySpec, but we dict'ify it here
-    #        so existing code that assumes a dict continues to work
-    return attr.asdict(spec_data)
-
-
 def spec_data_from_string(repository_spec_string, namespace_override=None, fetch_method=None, editable=False):
-    fetch_method = chose_repository_fetch_method(repository_spec_string, editable=editable)
+    fetch_method = choose_repository_fetch_method(repository_spec_string, editable=editable)
 
-    log.debug('fetch_method: %s', fetch_method)
-
-    if fetch_method == FetchMethods.LOCAL_FILE:
-        # Since only know this is a local file we vaguely recognize, we have to
-        # open it up to get any more details. We _could_ attempt to parse the file
-        # name, but that rarely ends well...
-        spec_data = load_data_from_repository_archive(repository_spec_string)
-        spec_data['fetch_method'] = fetch_method
-    else:
-        spec_data = repository_spec_parse.parse_string(repository_spec_string)
-        spec_data['fetch_method'] = fetch_method
+    spec_data = repository_spec_parse.parse_string(repository_spec_string)
+    spec_data['fetch_method'] = fetch_method
 
     log.debug('spec_data: %s', spec_data)
 

--- a/ansible_galaxy/rest_api.py
+++ b/ansible_galaxy/rest_api.py
@@ -293,7 +293,9 @@ class GalaxyAPI(object):
         except socket.error as exc:
             log.exception(exc)
             raise exceptions.GalaxyPublishError(
-                'Error transferring file "%s" to Galaxy server: %s' % (archive_path, str(exc))
+                'Network error while transferring file "%s" to Galaxy server (%s): %s' %
+                (archive_path, self.galaxy.server['url'], str(exc)),
+                archive_path=archive_path
             )
 
         r = http.getresponse()
@@ -310,5 +312,7 @@ class GalaxyAPI(object):
             return response_body
         else:
             raise exceptions.GalaxyPublishError(
-                'Error transferring file "%s" to Galaxy server: %s - %s' % (archive_path, r.status, r.reason)
+                'Error transferring file "%s" to Galaxy server (%s): %s - %s' %
+                (archive_path, self.galaxy.server['url'], r.status, r.reason),
+                archive_path=archive_path
             )

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -96,7 +96,10 @@ class GalaxyCLI(cli.CLI):
                                    help='The path in which the collection artifact will be created. The default is ./releases/.')
         if self.action == "publish":
             self.parser.set_usage("usage: %prog publish [options] archive_path")
-
+            # TODO: Include the url for the pref page where the API key can be found, however, that
+            #       needs to know the server url which isn't known until after cli args are parsed.
+            self.parser.add_option('--api-key', dest='publish_api_key', action='store', default=None,
+                                   help='The Galaxy API key.')
         if self.action == "info":
             self.parser.set_usage("usage: %prog info [options] repo_name[,version]")
         elif self.action == "install":
@@ -287,6 +290,7 @@ class GalaxyCLI(cli.CLI):
 
         return publish.publish(galaxy_context,
                                self.args[0],
+                               self.options.publish_api_key,
                                display_callback=self.display)
 
     def execute_remove(self):

--- a/tests/ansible_galaxy/fetch/test_local_file.py
+++ b/tests/ansible_galaxy/fetch/test_local_file.py
@@ -1,11 +1,9 @@
 import logging
 import os
-import tarfile
 import tempfile
 
 
 from ansible_galaxy.fetch import local_file
-from ansible_galaxy.models.repository_archive import RepositoryArchive, RepositoryArchiveInfo
 from ansible_galaxy.models.repository_spec import RepositorySpec, FetchMethods
 
 log = logging.getLogger(__name__)
@@ -54,17 +52,6 @@ JSON_DATA = b'''
 def test_local_file_fetch(mocker):
     tmp_file_fo = tempfile.NamedTemporaryFile(prefix='tmp', suffix='.tar.gz', delete=True)
     log.debug('tmp_file_fo.name=%s tmp_file=%s', tmp_file_fo.name, tmp_file_fo)
-
-    tar_file = tarfile.open(mode='w:gz',
-                            fileobj=tmp_file_fo)
-
-    _repo_archive_info = RepositoryArchiveInfo(archive_type='foo',
-                                               top_dir='namespace-name-1.2.3',
-                                               archive_path=tmp_file_fo.name)
-    _repo_archive = RepositoryArchive(info=_repo_archive_info,
-                                      tar_file=tar_file)
-    mocker.patch('ansible_galaxy.repository_spec.repository_archive.load_archive',
-                 return_value=_repo_archive)
 
     repository_spec_ = RepositorySpec(namespace='namespace', name='name', version='1.2.3',
                                       fetch_method=FetchMethods.LOCAL_FILE,


### PR DESCRIPTION
##### SUMMARY

Use collection artifact url, raise exceptions on error
Use hex uuid for multipart-form boundary marker.
Add Token based auth for 'publish'
Add a '--api-token' option to 'mazer publish'
Update errors handling and success messages.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.3.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.16-100.fc27.x86_64, #1 SMP Sun Oct 21 09:33:00 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3-2/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3-2/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

