### PR TITLE
[WIP] Use 'semantic_version' module instead of 'semver' module

### DIFF
--- a/ansible_galaxy/models/collection_info.py
+++ b/ansible_galaxy/models/collection_info.py
@@ -1,9 +1,10 @@
 from __future__ import print_function
 
-import attr
 import logging
 import re
-import semver
+
+import attr
+import semantic_version
 
 from ansible_galaxy.data import spdx_licenses
 
@@ -64,9 +65,7 @@ class CollectionInfo(object):
 
     @version.validator
     def _check_version_format(self, attribute, value):
-        try:
-            semver.parse_version_info(value)
-        except ValueError:
+        if not semantic_version.validate(value):
             self.value_error("Expecting 'version' to be in semantic version format, "
                              "instead found '%s'." % value)
 

--- a/ansible_galaxy/models/install_info.py
+++ b/ansible_galaxy/models/install_info.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 
 import attr
-import semver
+import semantic_version
 
 from ansible_galaxy.utils.version import convert_string_to_semver
 
@@ -15,7 +15,7 @@ class InstallInfo(object):
     install_date = attr.ib()
     install_date_iso = attr.ib(type=datetime.datetime)
 
-    version = attr.ib(type=semver.VersionInfo, default=None,
+    version = attr.ib(type=semantic_version.Version, default=None,
                       converter=convert_string_to_semver)
 
     @classmethod
@@ -31,8 +31,8 @@ class InstallInfo(object):
         if data.get('verison', '') is None:
             del data['version']
 
-        # semver.VersionInfo isnt yaml-able, so build a dict with
-        # the VersionInfo replaced with a str version
+        # semantic_version.Version isnt yaml-able, so build a dict with
+        # the Version replaced with a str version
         ver = data.get('version', '')
         if ver:
             data['version'] = str(ver)

--- a/ansible_galaxy/models/repository_spec.py
+++ b/ansible_galaxy/models/repository_spec.py
@@ -1,7 +1,7 @@
 import logging
 
 import attr
-import semver
+import semantic_version
 
 from ansible_galaxy.utils.version import convert_string_to_semver
 log = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ class RepositorySpec(object):
     namespace = attr.ib()
     name = attr.ib()
     # TODO: would it be worthwhile to make this a Semver type?
-    version = attr.ib(type=semver.VersionInfo, default=None,
+    version = attr.ib(type=semantic_version.Version, default=None,
                       converter=convert_string_to_semver)
 
     # only namespace/name/version are used for eq checks currently

--- a/ansible_galaxy/models/repository_spec.py
+++ b/ansible_galaxy/models/repository_spec.py
@@ -25,7 +25,6 @@ class RepositorySpec(object):
                   namespace=testing, raw=testing.ansible-testing-content)'''
     namespace = attr.ib()
     name = attr.ib()
-    # TODO: would it be worthwhile to make this a Semver type?
     version = attr.ib(type=semantic_version.Version, default=None,
                       converter=convert_string_to_semver)
 

--- a/ansible_galaxy/repository_archive.py
+++ b/ansible_galaxy/repository_archive.py
@@ -245,7 +245,7 @@ def install(repository_archive, repository_spec, destination_info, display_callb
                                                   install_datetime=install_datetime)
 
     # TODO: this save will need to be moved to a step later. after validating install?
-    # The to_dict_version_strings is to convert the un-yaml-able semver.VersionInfo to a string
+    # The to_dict_version_strings is to convert the un-yaml-able semantic_version.Version to a string
     install_info.save(install_info_.to_dict_version_strings(),
                       destination_info.install_info_path)
 

--- a/ansible_galaxy/repository_version.py
+++ b/ansible_galaxy/repository_version.py
@@ -1,6 +1,6 @@
 import logging
 
-import semver
+import semantic_version
 
 from ansible_galaxy import exceptions
 from ansible_galaxy.utils.version import normalize_version_string
@@ -12,7 +12,7 @@ def sort_versions(versions):
     # list of tuples of loose_version and original string, the sort
     # will sort based on first value of tuple, then we return just the
     # original strings
-    semver_versions = [(semver.parse_version_info(a), a) for a in versions]
+    semver_versions = [(semantic_version.Version(a), a) for a in versions]
     semver_versions.sort()
     return [v[1] for v in semver_versions]
 
@@ -62,14 +62,11 @@ def validate_versions(content_versions):
     valid_versions = []
     invalid_versions = []
     for version in content_versions:
-        try:
-            semver.parse(version)
-            valid_versions.append(version)
-        except ValueError as e:
-            log.exception(e)
-            log.warning('The version string "%s" is not valid, skipping: %s', version, e)
+        if not semantic_version.validate(version):
+            log.warning('The version string "%s" is not valid, skipping.', version)
             invalid_versions.append(version)
             continue
+        valid_versions.append(version)
 
     return (valid_versions, invalid_versions)
 

--- a/ansible_galaxy/utils/version.py
+++ b/ansible_galaxy/utils/version.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-import semver
+import semantic_version
 
 log = logging.getLogger(__name__)
 
@@ -15,10 +15,10 @@ def convert_string_to_semver(version):
     if version is None:
         return None
 
-    if isinstance(version, semver.VersionInfo):
+    if isinstance(version, semantic_version.Version):
         return version
 
-    return semver.parse_version_info(version)
+    return semantic_version.Version(version)
 
 
 def normalize_version_string(version_string):

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ requirements = ['six',
                 'PyYaml',
                 'jinja2',
                 'semver',
+                'semantic_version',
                 'yamlloader',
                 # used for data classes
                 # 18.1.0 introduces the 'factory' keyword

--- a/tests/ansible_galaxy/test_repository.py
+++ b/tests/ansible_galaxy/test_repository.py
@@ -1,7 +1,7 @@
 import logging
 import os
 
-from semver import VersionInfo
+import semantic_version
 
 from ansible_galaxy import repository
 from ansible_galaxy import repository_archive
@@ -38,7 +38,7 @@ def test_load_from_archive_artifact(galaxy_context, tmpdir):
 
     assert isinstance(res, Repository)
     assert isinstance(res.repository_spec, RepositorySpec)
-    assert isinstance(res.repository_spec.version, VersionInfo)
+    assert isinstance(res.repository_spec.version, semantic_version.Version)
 
     assert res.repository_spec.namespace == 'greetings_namespace'
     assert res.repository_spec.name == 'hello'

--- a/tests/ansible_galaxy/test_repository_archive.py
+++ b/tests/ansible_galaxy/test_repository_archive.py
@@ -3,7 +3,7 @@ import datetime
 import logging
 import os
 
-from semver import VersionInfo
+import semantic_version
 
 from ansible_galaxy import repository_archive
 from ansible_galaxy.models.repository_spec import RepositorySpec
@@ -71,7 +71,7 @@ def test_install(galaxy_context, tmpdir):
 
     assert isinstance(res, InstallationResults)
     assert isinstance(res.install_info, InstallInfo)
-    assert isinstance(res.install_info.version, VersionInfo)
+    assert isinstance(res.install_info.version, semantic_version.Version)
     assert isinstance(res.installed_datetime, datetime.datetime)
 
 

--- a/tests/ansible_galaxy/test_repository_version.py
+++ b/tests/ansible_galaxy/test_repository_version.py
@@ -225,7 +225,7 @@ def test_get_latest_version_invalid_semver():
                                               content_data={})
     except exceptions.GalaxyClientError as e:
         assert 'Unable to compare' in '%s' % e
-        assert '4.2 is not valid SemVer' in '%s' % e
+        assert "Invalid version string: '4.2'" in '%s' % e
         return
 
     assert False, 'Expected a GalaxyClientError about invalid versions here, but that did not happen.'


### PR DESCRIPTION
##### SUMMARY
WIP, replacing use of 'semver' module with 'semantic_version' because

- galaxy uses it (and 'semver')
- the 'Spec' support in semantic_version is more useful than 'semver' limited support
- the 'semantic_version' Version is a little easier to deal with than semver.VersionInfo
  (mostly the 'partial' support)

##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.3.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.16-100.fc27.x86_64, #1 SMP Sun Oct 21 09:33:00 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3-2/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3-2/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

