### PR TITLE
Add 'migrate_role' command to migrate trad roles to collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,12 @@ $ cd tests/ansible_galaxy/collection_examples/hello/
 $ mazer build
 ```
 
+### Migrating an existing traditional style role to a collection with 'mazer migrate_role'
+
+```
+$ mazer migrate_role --role roles/some_trad_role/ --output-dir collections/roles/some_trad_role --namespace some_ns --version=1.2.3
+```
+
 The above command will create an ansible content collection artifact
 at tests/ansible_galaxy/collection_examples/hello/releases/v11.11.11.tar.gz
 

--- a/ansible_galaxy/actions/migrate_role.py
+++ b/ansible_galaxy/actions/migrate_role.py
@@ -1,7 +1,10 @@
+from collections import OrderedDict
+
 import logging
 import os
 
 from ansible_galaxy import role_metadata
+from ansible_galaxy.models.collection_info import CollectionInfo
 
 log = logging.getLogger(__name__)
 
@@ -18,6 +21,27 @@ def migrate(migrate_role_context,
     # load role from migrate_role_context.role_path
     # though, that may be just loading the role_path/meta/main.yml
 
+    dir_basename = os.path.basename(os.path.normpath(migrate_role_context.role_path))
+    log.debug('dir_basename: %s', dir_basename)
+
+    name_parts = dir_basename.split('.', 1)
+    log.debug('name_parts: %s', name_parts)
+
+    role_name = name_parts[0]
+    role_namespace = None
+
+    if len(name_parts) == 2:
+        role_namespace = name_parts[0]
+        role_name = name_parts[1]
+
+    role_name = migrate_role_context.role_name or role_name
+
+    collection_name = migrate_role_context.collection_name or role_name
+    collection_namespace = migrate_role_context.collection_namespace or role_namespace
+
+    log.debug('role_name: %s mrc.role_name: %s dir_basename: %s name_parts: %s',
+              role_name, migrate_role_context.role_name, dir_basename, name_parts)
+
     role_md = role_metadata.load_from_dir(migrate_role_context.role_path,
                                           role_name=migrate_role_context.role_name)
 
@@ -32,7 +56,26 @@ def migrate(migrate_role_context,
     # create/populate dicts for collection_info
     # fill in namespace, name, version, deps, tags, etc
 
+    # FIXME: license format is different, will have to map
+    collection_info_dict = OrderedDict([
+        # TODO: namespace, name
+        ('namespace', collection_namespace),
+        ('name', collection_name),
+        ('version', migrate_role_context.collection_version),
+        ('license', role_md.license),
+        ('description', role_md.description),
+        # FIXME: verify role_md.author is a list or single
+        ('authors', [role_md.author]),
+        ('tags', role_md.galaxy_tags),
+        ('issues', role_md.issue_tracker),
+        ('dependencies', role_md.dependencies)
+    ])
+
+    log.debug('collection_info_dict: %s', collection_info_dict)
     # create a CollectionInfo
+    col_info = CollectionInfo(**collection_info_dict)
+
+    log.debug('col_info: %s', col_info)
 
     # hmmm... should probably have a Collection/Repository save()
     # support, but if not, do the equiv
@@ -53,3 +96,7 @@ def migrate(migrate_role_context,
     # display the output path, maybe some summary of the migration results
 
     return os.EX_OK  # 0:
+
+
+def _migrate(migrate_role_context, display_callback):
+    pass

--- a/ansible_galaxy/actions/migrate_role.py
+++ b/ansible_galaxy/actions/migrate_role.py
@@ -56,6 +56,13 @@ def migrate(migrate_role_context,
     # create/populate dicts for collection_info
     # fill in namespace, name, version, deps, tags, etc
 
+    # migrate role style dependencies dict to a collections style
+    # list of dicts
+    # collection_deps = OrderedDict([tuple(key, role_md.dependencies[key]) for key in role_md.dependencies])
+    collection_deps = OrderedDict([(req.requirement_spec.label, str(req.requirement_spec.version_spec)) for req in role_md.dependencies])
+
+    log.debug('collection_deps: %s', collection_deps)
+
     # FIXME: license format is different, will have to map
     collection_info_dict = OrderedDict([
         # TODO: namespace, name
@@ -68,7 +75,7 @@ def migrate(migrate_role_context,
         ('authors', [role_md.author]),
         ('tags', role_md.galaxy_tags),
         ('issues', role_md.issue_tracker),
-        ('dependencies', role_md.dependencies)
+        ('dependencies', collection_deps)
     ])
 
     log.debug('collection_info_dict: %s', collection_info_dict)

--- a/ansible_galaxy/actions/migrate_role.py
+++ b/ansible_galaxy/actions/migrate_role.py
@@ -11,4 +11,37 @@ def migrate(migrate_role_context,
 
     display_callback("migrate_role something")
 
+    # validate paths
+
+    # load role from migrate_role_context.role_path
+    # though, that may be just loading the role_path/meta/main.yml
+    #  maybe some file tree walking
+
+    # (or just let CollectionInfo construct fail...)
+    # verify/validate namespace and names are valid for collections
+    # verify version number is valid for collection
+
+    # create/populate dicts for collection_info
+    # fill in namespace, name, version, deps, tags, etc
+
+    # create a CollectionInfo
+
+    # hmmm... should probably have a Collection/Repository save()
+    # support, but if not, do the equiv
+
+    # create any needed dirs in output_path/
+
+    # persist CollectionInfo to output_path/galaxy.yml
+
+    # cp role_path/role_stuff* dirs to output_path
+    # TODO: should we migrate plugins and modules to be collection level
+    #       or just keep the role level?
+
+    # TODO: if there are modules or plugins using a bundled module_utils
+    #       just moving the plugins isnt enough since the source code itself
+    #       will need to be updated to use new plugin loader style paths
+
+    # display any collected errors or messages
+    # display the output path, maybe some summary of the migration results
+
     return os.EX_OK  # 0:

--- a/ansible_galaxy/actions/migrate_role.py
+++ b/ansible_galaxy/actions/migrate_role.py
@@ -1,6 +1,8 @@
 import logging
 import os
 
+from ansible_galaxy import role_metadata
+
 log = logging.getLogger(__name__)
 
 
@@ -15,6 +17,12 @@ def migrate(migrate_role_context,
 
     # load role from migrate_role_context.role_path
     # though, that may be just loading the role_path/meta/main.yml
+
+    role_md = role_metadata.load_from_dir(migrate_role_context.role_path,
+                                          role_name=migrate_role_context.role_name)
+
+    log.debug('role_metadata: %s', role_md)
+
     #  maybe some file tree walking
 
     # (or just let CollectionInfo construct fail...)

--- a/ansible_galaxy/actions/migrate_role.py
+++ b/ansible_galaxy/actions/migrate_role.py
@@ -30,7 +30,6 @@ def migrate(migrate_role_context,
     log.debug('dir_basename: %s', dir_basename)
 
     name_parts = dir_basename.split('.', 1)
-    log.debug('name_parts: %s', name_parts)
 
     role_name = name_parts[0]
     role_namespace = None
@@ -44,16 +43,12 @@ def migrate(migrate_role_context,
     collection_name = migrate_role_context.collection_name or role_name
     collection_namespace = migrate_role_context.collection_namespace or role_namespace
 
-    log.debug('role_name: %s mrc.role_name: %s dir_basename: %s name_parts: %s',
-              role_name, migrate_role_context.role_name, dir_basename, name_parts)
-
     role_md = role_metadata.load_from_dir(migrate_role_context.role_path,
                                           role_name=migrate_role_context.role_name)
 
     log.debug('role_metadata: %s', role_md)
 
     valid_licenses = spdx_licenses.get_spdx()
-    log.debug('valid_license.get(%s): %s', role_md.license, valid_licenses.get(role_md.license, None))
 
     # Check this here so errors can show more context
     if valid_licenses.get(role_md.license, None) is None:
@@ -108,10 +103,6 @@ def migrate(migrate_role_context,
         raise exceptions.GalaxyClientError(e)
 
     log.debug('col_info: %s', col_info)
-
-    col_info_yaml_str = yaml_persist.safe_dump(col_info)
-
-    log.debug('direct: %s', col_info_yaml_str)
 
     # write out galaxy.yml
     # persist CollectionInfo to output_path/galaxy.yml

--- a/ansible_galaxy/actions/migrate_role.py
+++ b/ansible_galaxy/actions/migrate_role.py
@@ -1,0 +1,11 @@
+import logging
+import os
+
+log = logging.getLogger(__name__)
+
+
+def migrate(collection_output_dir,
+            display_callback):
+
+    display_callback("migrate_role something")
+    return os.EX_OK  # 0

--- a/ansible_galaxy/actions/migrate_role.py
+++ b/ansible_galaxy/actions/migrate_role.py
@@ -4,8 +4,11 @@ import os
 log = logging.getLogger(__name__)
 
 
-def migrate(collection_output_dir,
+def migrate(migrate_role_context,
             display_callback):
 
+    log.debug('migrate_role_context: %s', migrate_role_context)
+
     display_callback("migrate_role something")
-    return os.EX_OK  # 0
+
+    return os.EX_OK  # 0:

--- a/ansible_galaxy/actions/migrate_role.py
+++ b/ansible_galaxy/actions/migrate_role.py
@@ -90,6 +90,10 @@ def migrate(migrate_role_context,
 
     log.debug('direct: %s', col_info_yaml_str)
 
+    # write out galaxy.yml
+    output_filename = os.path.join(migrate_role_context.output_path, 'galaxy.yml')
+    yaml_persist.save(col_info, output_filename)
+
     # hmmm... should probably have a Collection/Repository save()
     # support, but if not, do the equiv
 

--- a/ansible_galaxy/actions/migrate_role.py
+++ b/ansible_galaxy/actions/migrate_role.py
@@ -52,6 +52,8 @@ def migrate(migrate_role_context,
 
     log.debug('role_metadata: %s', role_md)
 
+    collection_license = migrate_role_context.collection_license or role_md.license
+
     #  maybe some file tree walking
 
     # (or just let CollectionInfo construct fail...)
@@ -74,7 +76,7 @@ def migrate(migrate_role_context,
         ('namespace', collection_namespace),
         ('name', collection_name),
         ('version', migrate_role_context.collection_version),
-        ('license', role_md.license),
+        ('license', collection_license),
         ('description', role_md.description),
         # FIXME: verify role_md.author is a list or single
         ('authors', [role_md.author]),

--- a/ansible_galaxy/actions/migrate_role.py
+++ b/ansible_galaxy/actions/migrate_role.py
@@ -5,6 +5,7 @@ import os
 
 from ansible_galaxy import role_metadata
 from ansible_galaxy.models.collection_info import CollectionInfo
+from ansible_galaxy import yaml_persist
 
 log = logging.getLogger(__name__)
 
@@ -79,10 +80,15 @@ def migrate(migrate_role_context,
     ])
 
     log.debug('collection_info_dict: %s', collection_info_dict)
+
     # create a CollectionInfo
     col_info = CollectionInfo(**collection_info_dict)
 
     log.debug('col_info: %s', col_info)
+
+    col_info_yaml_str = yaml_persist.safe_dump(col_info)
+
+    log.debug('direct: %s', col_info_yaml_str)
 
     # hmmm... should probably have a Collection/Repository save()
     # support, but if not, do the equiv

--- a/ansible_galaxy/collection_info.py
+++ b/ansible_galaxy/collection_info.py
@@ -17,8 +17,6 @@ COLLECTION_INFO_FILENAME = "galaxy.yml"
 def load(data_or_file_object, klass=None):
     data_dict = yaml.safe_load(data_or_file_object)
 
-    # log.debug('data: %s', pf(data_dict))
-
     try:
         collection_info = CollectionInfo(**data_dict)
     except ValueError:

--- a/ansible_galaxy/display.py
+++ b/ansible_galaxy/display.py
@@ -1,20 +1,24 @@
+from __future__ import print_function
 
 # if this looks a lot like reimplement 'logging', that is
 # true...
 
 import logging
+import sys
 
 log = logging.getLogger(__name__)
 
 INFO_LEVEL = {
     'prefix': '',
-    'log_level': logging.INFO
+    'log_level': logging.INFO,
+    'stream': sys.stdout,
 }
 
 DISPLAY_LEVEL_MAP = {
     'warning': {
         'prefix': 'WARNING| ',
-        'log_level': logging.WARNING
+        'log_level': logging.WARNING,
+        'stream': sys.stderr
     },
     'info': INFO_LEVEL
 }
@@ -23,8 +27,9 @@ DISPLAY_LEVEL_MAP = {
 def stdout_display_callback(*args, **kwargs):
     level_arg = kwargs.get('level', None)
     level_prefix = DISPLAY_LEVEL_MAP.get(level_arg, INFO_LEVEL)['prefix']
+    level_stream = DISPLAY_LEVEL_MAP.get(level_arg, INFO_LEVEL)['stream']
 
-    print('%s%s' % (level_prefix, ''.join(args)))
+    print('%s%s' % (level_prefix, ''.join(args)), file=level_stream)
 
 
 # will log whatever is display with display callback to the ansible_galaxy.display logger

--- a/ansible_galaxy/models/collection_info.py
+++ b/ansible_galaxy/models/collection_info.py
@@ -57,7 +57,6 @@ class CollectionInfo(object):
     @namespace.validator
     @name.validator
     @version.validator
-    @license.validator
     def _check_required(self, attribute, value):
         if value is None:
             self.value_error("'%s' is required" % attribute.name)
@@ -70,6 +69,10 @@ class CollectionInfo(object):
 
     @license.validator
     def _check_license(self, attribute, value):
+        if value is None:
+            self.value_error("'%s' is required and needs to be a valid SPDX license ID, instead found '%s'. "
+                             "For more info, visit https://spdx.org" % (attribute.name, value))
+
         # load or return already loaded data
         licenses = spdx_licenses.get_spdx()
 

--- a/ansible_galaxy/models/migrate_role_context.py
+++ b/ansible_galaxy/models/migrate_role_context.py
@@ -9,4 +9,11 @@ log = logging.getLogger(__name__)
 class MigrateRoleContext(object):
     role_path = attr.ib()
     output_path = attr.ib()
+
+    # roles always have a name, but not a namespace
     role_name = attr.ib(default=None)
+
+    # collections always have namespace and name
+    collection_namespace = attr.ib(default=None)
+    collection_name = attr.ib(default=None)
+    collection_version = attr.ib(default=None)

--- a/ansible_galaxy/models/migrate_role_context.py
+++ b/ansible_galaxy/models/migrate_role_context.py
@@ -1,0 +1,11 @@
+import logging
+
+import attr
+
+log = logging.getLogger(__name__)
+
+
+@attr.s(frozen=True)
+class MigrateRoleContext(object):
+    role_path = attr.ib()
+    output_path = attr.ib()

--- a/ansible_galaxy/models/migrate_role_context.py
+++ b/ansible_galaxy/models/migrate_role_context.py
@@ -7,8 +7,9 @@ log = logging.getLogger(__name__)
 
 @attr.s(frozen=True)
 class MigrateRoleContext(object):
-    role_path = attr.ib()
-    output_path = attr.ib()
+    role_path = attr.ib(validator=attr.validators.instance_of(str))
+    output_path = attr.ib(validator=attr.validators.instance_of(str))
+    output_force = attr.ib(default=False, validator=attr.validators.instance_of(bool))
 
     # roles always have a name, but not a namespace
     role_name = attr.ib(default=None)

--- a/ansible_galaxy/models/migrate_role_context.py
+++ b/ansible_galaxy/models/migrate_role_context.py
@@ -9,3 +9,4 @@ log = logging.getLogger(__name__)
 class MigrateRoleContext(object):
     role_path = attr.ib()
     output_path = attr.ib()
+    role_name = attr.ib(default=None)

--- a/ansible_galaxy/models/migrate_role_context.py
+++ b/ansible_galaxy/models/migrate_role_context.py
@@ -18,3 +18,6 @@ class MigrateRoleContext(object):
     collection_namespace = attr.ib(default=None)
     collection_name = attr.ib(default=None)
     collection_version = attr.ib(default=None)
+    # Note: Not validating this as valid spdx here, collection_info
+    #       will do that later
+    collection_license = attr.ib(default=None)

--- a/ansible_galaxy/repository.py
+++ b/ansible_galaxy/repository.py
@@ -9,6 +9,7 @@ from ansible_galaxy import collection_artifact_manifest
 from ansible_galaxy import exceptions
 from ansible_galaxy import install_info
 from ansible_galaxy import requirements
+from ansible_galaxy import role_metadata
 
 from ansible_galaxy.models.repository_spec import RepositorySpec
 from ansible_galaxy.models.repository import Repository
@@ -171,20 +172,14 @@ def load_from_dir(content_dir, namespace, name, installed=True):
     # FIXME: For a repository with one role that matches the collection name and doesn't
     #        have a galaxy.yml, that's indistinguishable from a role-as-collection
     # FIXME: But in theory, if there is more than one role in roles/, we should skip this
-    role_meta_main_filename = os.path.join(path_name, 'roles', name, 'meta', 'main.yml')
-    role_meta_main = None
+
+    role_dir_path = os.path.join(path_name, 'roles')
     role_name = '%s.%s' % (namespace, name)
 
-    try:
-        with open(role_meta_main_filename, 'r') as rmfd:
-            # FIXME: kluge to avoid circular import on py2
-            #        repository->role_metadata->dependencies->repository_spec->repository (loop)
-            #        repository->requirements->repository_spec->repository (loop)
-            from ansible_galaxy import role_metadata
-            role_meta_main = role_metadata.load(rmfd, role_name=role_name)
-    except EnvironmentError:
-        # log.debug('No meta/main.yml was loaded for repository %s.%s: %s', namespace, name, e)
-        pass
+    role_meta_main = role_metadata.load_from_dir(dirname=role_dir_path,
+                                                 role_name=role_name)
+
+    log.debug('role_meta_main: %s', role_meta_main)
 
     # Prefer version from install_info, but for a editable installed, there may be only galaxy version
     installed_version = install_info_version

--- a/ansible_galaxy/repository.py
+++ b/ansible_galaxy/repository.py
@@ -161,7 +161,8 @@ def load_from_dir(content_dir, namespace, name, installed=True):
 
     try:
         with open(galaxy_filename, 'r') as gfd:
-            collection_info_data = collection_info.load(gfd)
+            if gfd:
+                collection_info_data = collection_info.load(gfd)
     except EnvironmentError:
         # log.debug('No galaxy.yml collection info found for collection %s.%s: %s', namespace, name, e)
         pass

--- a/ansible_galaxy/role_metadata.py
+++ b/ansible_galaxy/role_metadata.py
@@ -42,6 +42,7 @@ def load(data_or_file_object, role_name=None):
                            cloud_platforms=galaxy_info.get('cloud_platforms'),
                            min_ansible_version=galaxy_info.get('min_ansible_version'),
                            min_ansible_container_version=galaxy_info.get('min_ansible_container_version'),
+                           issue_tracker=galaxy_info.get('issue_tracker_url'),
                            # from outside of galaxy_info dict
                            dependencies=deps,
                            allow_duplicates=allow_duplicates)

--- a/ansible_galaxy/role_metadata.py
+++ b/ansible_galaxy/role_metadata.py
@@ -66,3 +66,12 @@ def load_from_filename(filename, role_name=None):
         return False
     finally:
         f.close()
+
+
+def load_from_dir(dirname, role_name=None):
+    log.debug("Going to load role from dir %s %s", dirname, role_name or "")
+
+    role_meta_main_filename = os.path.join(dirname, 'meta', 'main.yml')
+    # role_name = '%s.%s' % (namespace, name)
+
+    return load_from_filename(role_meta_main_filename, role_name=role_name)

--- a/ansible_galaxy/utils/attr_utils.py
+++ b/ansible_galaxy/utils/attr_utils.py
@@ -1,0 +1,33 @@
+import logging
+import pprint
+
+import attr
+from attr.exceptions import NotAnAttrsClassError
+
+import six
+
+log = logging.getLogger(__name__)
+
+
+def is_attr(obj):
+    if isinstance(obj, six.class_types):
+        try:
+            attr.fields(obj)
+        except NotAnAttrsClassError:
+            return False
+        return False
+
+    if getattr(obj.__class__, "__attrs_attrs__", None):
+        return True
+
+    if getattr(obj, "__attrs_attrs__", None):
+        return True
+
+    return False
+
+
+def pf_attr(obj):
+    if not is_attr(obj):
+        return pprint.pformat(obj)
+
+    return pprint.pformat(attr.fields_dict(obj))

--- a/ansible_galaxy/yaml_persist.py
+++ b/ansible_galaxy/yaml_persist.py
@@ -1,10 +1,66 @@
+from collections import OrderedDict
 import logging
 import os
 
 import attr
 import yaml
 
+from ansible_galaxy.utils import attr_utils
+
 log = logging.getLogger(__name__)
+
+
+class MazerSafeDumper(yaml.SafeDumper):
+    '''A Yaml dumper that dumps more or less ansible-style
+
+    ie, two space indent on lists always, flow_style=False
+    on mappings
+
+    Also adds support for OrderedDict'''
+    def increase_indent(self, flow=False, indentless=False):
+        return super(MazerSafeDumper, self).increase_indent(flow, False)
+
+    def represent_data(self, data):
+        '''Attempt to detect attrs style objects and convert to dicts
+
+        We can't add a regular yaml_representer because attrs based objects can
+        be of any type, so we need to detect if 'data' is attrs based (with
+        attr_utils.is_attrs()) and if so, we covert it to an OrdedDict and
+        then rely on the OrderedDict representer to dump the correct yaml.
+
+        If this is anything other than an attrs based instance, we call
+        super's represent_data()
+
+        Also setup some representers with the default styles are 'ansible-style'
+        for maps/dicts/lists/tuples
+        '''
+
+        log.debug('represent_data: %r', data)
+
+        if attr_utils.is_attr(data):
+            odict = attr.asdict(data, recurse=True, dict_factory=OrderedDict)
+            # return self.represent_mapping(u'tag:yaml.org,2002:map', odict, flow_style=False)
+            return super(MazerSafeDumper, self).represent_data(odict)
+
+        return super(MazerSafeDumper, self).represent_data(data)
+
+
+def dict_representer(dumper, data):
+    return dumper.represent_mapping(u'tag:yaml.org,2002:map', data, flow_style=False)
+
+
+def list_representer(dumper, data):
+    return dumper.represent_sequence(u'tag:yaml.org,2002:seq', data, flow_style=False)
+
+
+MazerSafeDumper.add_representer(OrderedDict, dict_representer)
+MazerSafeDumper.add_representer(dict, dict_representer)
+MazerSafeDumper.add_representer(list, list_representer)
+MazerSafeDumper.add_representer(tuple, list_representer)
+
+
+def safe_dump(data, stream=None, **kwargs):
+    return yaml.dump(data, stream=stream, Dumper=MazerSafeDumper, **kwargs)
 
 
 def load_from_filename(filename, load_method):

--- a/ansible_galaxy/yaml_persist.py
+++ b/ansible_galaxy/yaml_persist.py
@@ -35,8 +35,6 @@ class MazerSafeDumper(yaml.SafeDumper):
         for maps/dicts/lists/tuples
         '''
 
-        log.debug('represent_data: %r', data)
-
         if attr_utils.is_attr(data):
             odict = attr.asdict(data, recurse=True, dict_factory=OrderedDict)
             return super(MazerSafeDumper, self).represent_data(odict)

--- a/ansible_galaxy/yaml_persist.py
+++ b/ansible_galaxy/yaml_persist.py
@@ -39,7 +39,6 @@ class MazerSafeDumper(yaml.SafeDumper):
 
         if attr_utils.is_attr(data):
             odict = attr.asdict(data, recurse=True, dict_factory=OrderedDict)
-            # return self.represent_mapping(u'tag:yaml.org,2002:map', odict, flow_style=False)
             return super(MazerSafeDumper, self).represent_data(odict)
 
         return super(MazerSafeDumper, self).represent_data(data)
@@ -49,11 +48,15 @@ def dict_representer(dumper, data):
     return dumper.represent_mapping(u'tag:yaml.org,2002:map', data, flow_style=False)
 
 
+def odict_representer(dumper, data):
+    return dumper.represent_mapping(u'tag:yaml.org,2002:map', data.items(), flow_style=False)
+
+
 def list_representer(dumper, data):
     return dumper.represent_sequence(u'tag:yaml.org,2002:seq', data, flow_style=False)
 
 
-MazerSafeDumper.add_representer(OrderedDict, dict_representer)
+MazerSafeDumper.add_representer(OrderedDict, odict_representer)
 MazerSafeDumper.add_representer(dict, dict_representer)
 MazerSafeDumper.add_representer(list, list_representer)
 MazerSafeDumper.add_representer(tuple, list_representer)
@@ -87,7 +90,7 @@ def save(data, filename):
         # FIXME: just return the install_info dict (or better, build it elsewhere and pass in)
         # FIXME: stop minging self state
         try:
-            install_info_ = yaml.safe_dump(attr.asdict(data), f, default_flow_style=False)
+            install_info_ = safe_dump(data, stream=f)
         except Exception as e:
             log.warning('unable to serialize data to filename=%s for data=%s', filename, install_info_)
             log.exception(e)

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -141,6 +141,8 @@ class GalaxyCLI(cli.CLI):
                                    help='The path to the role that will be converted to a collection')
             self.parser.add_option('--output-dir', dest='collection_output_dir',
                                    help='The path to write the new collection to')
+            self.parser.add_option('--force', dest='output_force', action='store_true', default=False,
+                                   help='Write to the output dir even if parts of it already exists')
             self.parser.add_option('--namespace', dest='collection_namespace',
                                    help='The namespace to use for the new collection')
             self.parser.add_option('--name', dest='collection_name',
@@ -353,7 +355,8 @@ class GalaxyCLI(cli.CLI):
                                                   output_path=self.options.collection_output_dir,
                                                   collection_namespace=self.options.collection_namespace,
                                                   collection_name=self.options.collection_name,
-                                                  collection_version=self.options.collection_version)
+                                                  collection_version=self.options.collection_version,
+                                                  output_force=self.options.output_force)
 
         return migrate_role.migrate(migrate_role_context=migrate_role_context,
                                     display_callback=self.display)

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -79,7 +79,7 @@ def get_config_path_from_env():
 
 class GalaxyCLI(cli.CLI):
     SKIP_INFO_KEYS = ("name", "description", "readme_html", "related", "summary_fields", "average_aw_composite", "average_aw_score", "url")
-    VALID_ACTIONS = ("build", "info", "install", "list", "publish", "remove", "migrate_role", "version")
+    VALID_ACTIONS = ("build", "info", "install", "list", "migrate_role", "publish", "remove", "version")
     VALID_ACTION_ALIASES = {'content-install': 'install'}
 
     def __init__(self, args):

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -141,6 +141,12 @@ class GalaxyCLI(cli.CLI):
                                    help='The path to the role that will be converted to a collection')
             self.parser.add_option('--output-dir', dest='collection_output_dir',
                                    help='The path to write the new collection to')
+            self.parser.add_option('--namespace', dest='collection_namespace',
+                                   help='The namespace to use for the new collection')
+            self.parser.add_option('--name', dest='collection_name',
+                                   help='The name to use for the new collection')
+            self.parser.add_option('--version', dest='collection_version',
+                                   help='The version to use for the new collection')
 
         if self.action in ("install",):
             self.parser.add_option('-f', '--force', dest='force', action='store_true', default=False, help='Force overwriting an existing collection')
@@ -342,7 +348,12 @@ class GalaxyCLI(cli.CLI):
                                display_callback=self.display)
 
     def execute_migrate_role(self):
+
         migrate_role_context = MigrateRoleContext(role_path=self.options.role_convertee_path,
-                                                  output_path=self.options.collection_output_dir)
+                                                  output_path=self.options.collection_output_dir,
+                                                  collection_namespace=self.options.collection_namespace,
+                                                  collection_name=self.options.collection_name,
+                                                  collection_version=self.options.collection_version)
+
         return migrate_role.migrate(migrate_role_context=migrate_role_context,
                                     display_callback=self.display)

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -43,6 +43,7 @@ from ansible_galaxy import rest_api
 
 from ansible_galaxy.models.context import GalaxyContext
 from ansible_galaxy.models.build_context import BuildContext
+from ansible_galaxy.models.migrate_role_context import MigrateRoleContext
 
 from ansible_galaxy_cli import cli
 from ansible_galaxy_cli import __version__ as galaxy_cli_version
@@ -136,6 +137,8 @@ class GalaxyCLI(cli.CLI):
                                         'mazer.yml file (~/.ansible/content, if not configured)', type='str')
 
         if self.action == "migrate_role":
+            self.parser.add_option('--role', dest='role_convertee_path',
+                                   help='The path to the role that will be converted to a collection')
             self.parser.add_option('--output-dir', dest='collection_output_dir',
                                    help='The path to write the new collection to')
 
@@ -339,5 +342,7 @@ class GalaxyCLI(cli.CLI):
                                display_callback=self.display)
 
     def execute_migrate_role(self):
-        return migrate_role.migrate(collection_output_dir=self.options.collection_output_dir,
+        migrate_role_context = MigrateRoleContext(role_path=self.options.role_convertee_path,
+                                                  output_path=self.options.collection_output_dir)
+        return migrate_role.migrate(migrate_role_context=migrate_role_context,
                                     display_callback=self.display)

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -149,6 +149,8 @@ class GalaxyCLI(cli.CLI):
                                    help='The name to use for the new collection')
             self.parser.add_option('--version', dest='collection_version',
                                    help='The version to use for the new collection')
+            self.parser.add_option('--license', dest='collection_license', default=None,
+                                   help='The SPDX license identifier to use for the new collection. For ex, "GPL-3.0-or-later", "MIT", "BSD-3-Clause"')
 
         if self.action in ("install",):
             self.parser.add_option('-f', '--force', dest='force', action='store_true', default=False, help='Force overwriting an existing collection')
@@ -356,6 +358,7 @@ class GalaxyCLI(cli.CLI):
                                                   collection_namespace=self.options.collection_namespace,
                                                   collection_name=self.options.collection_name,
                                                   collection_version=self.options.collection_version,
+                                                  collection_license=self.options.collection_license,
                                                   output_force=self.options.output_force)
 
         return migrate_role.migrate(migrate_role_context=migrate_role_context,

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -31,6 +31,7 @@ from ansible_galaxy.actions import build
 from ansible_galaxy.actions import info
 from ansible_galaxy.actions import install
 from ansible_galaxy.actions import list as list_action
+from ansible_galaxy.actions import migrate_role
 from ansible_galaxy.actions import remove
 from ansible_galaxy.actions import version
 from ansible_galaxy.actions import publish
@@ -77,7 +78,7 @@ def get_config_path_from_env():
 
 class GalaxyCLI(cli.CLI):
     SKIP_INFO_KEYS = ("name", "description", "readme_html", "related", "summary_fields", "average_aw_composite", "average_aw_score", "url")
-    VALID_ACTIONS = ("build", "info", "install", "list", "publish", "remove", "version")
+    VALID_ACTIONS = ("build", "info", "install", "list", "publish", "remove", "migrate_role", "version")
     VALID_ACTION_ALIASES = {'content-install': 'install'}
 
     def __init__(self, args):
@@ -133,6 +134,10 @@ class GalaxyCLI(cli.CLI):
             self.parser.add_option('-C', '--content-path', dest='content_path',
                                    help='The path to the directory containing your Galaxy content. The default is the content_path configured in your'
                                         'mazer.yml file (~/.ansible/content, if not configured)', type='str')
+
+        if self.action == "migrate_role":
+            self.parser.add_option('--output-dir', dest='collection_output_dir',
+                                   help='The path to write the new collection to')
 
         if self.action in ("install",):
             self.parser.add_option('-f', '--force', dest='force', action='store_true', default=False, help='Force overwriting an existing collection')
@@ -332,3 +337,7 @@ class GalaxyCLI(cli.CLI):
         return version.version(config_file_path=self.config_file_path,
                                cli_version=galaxy_cli_version,
                                display_callback=self.display)
+
+    def execute_migrate_role(self):
+        return migrate_role.migrate(collection_output_dir=self.options.collection_output_dir,
+                                    display_callback=self.display)

--- a/ansible_galaxy_cli/main.py
+++ b/ansible_galaxy_cli/main.py
@@ -50,6 +50,7 @@ def main(args=None):
         exit_code = os.EX_SOFTWARE
     except Exception as e:
         log.exception(e)
+        stderr_log.error(e)
         exit_code = os.EX_SOFTWARE
 
         # let non-Galaxy exceptions bubble up and traceback

--- a/tests/ansible_galaxy/actions/test_migrate_role_action.py
+++ b/tests/ansible_galaxy/actions/test_migrate_role_action.py
@@ -40,12 +40,13 @@ def _migrate_role(output_path,
 def test_migrate_role_galaxy_yml(tmpdir):
     output_path = tmpdir.mkdir('mazer_test_migrate_role_action_test_migrate_role')
 
-    res, migrate_role_context = _migrate_role(output_path=output_path)
+    res, migrate_role_context = _migrate_role(output_path=output_path.strpath)
 
     assert res == 0
-    assert os.path.isdir(output_path)
+    assert os.path.isdir(output_path.strpath)
 
-    galaxy_yml_path = os.path.join(output_path, 'galaxy.yml')
+    galaxy_yml_path = os.path.join(output_path.strpath, 'galaxy.yml')
+
     assert os.path.isfile(galaxy_yml_path)
 
     with open(galaxy_yml_path, 'r') as cfd:

--- a/tests/ansible_galaxy/actions/test_migrate_role_action.py
+++ b/tests/ansible_galaxy/actions/test_migrate_role_action.py
@@ -1,0 +1,64 @@
+import logging
+import os
+
+from ansible_galaxy.actions import migrate_role
+from ansible_galaxy import collection_info
+from ansible_galaxy.models.collection_info import CollectionInfo
+from ansible_galaxy.models.migrate_role_context import MigrateRoleContext
+
+log = logging.getLogger(__name__)
+
+
+OLD_SCHOOL_ROLE_PATH = os.path.join(os.path.dirname(__file__), '../', '../', 'data', 'roles', 'old_school_role')
+COL_NAMESPACE = 'some_namespace'
+COL_NAME = 'some_name'
+COL_VERSION = '9.1.9'
+
+
+def display_callback(msg, **kwargs):
+    log.debug(msg)
+
+
+def _migrate_role(output_path,
+                  display_callback=display_callback,
+                  role_path=OLD_SCHOOL_ROLE_PATH,
+                  collection_namespace=COL_NAMESPACE,
+                  collection_name=COL_NAME,
+                  collection_version=COL_VERSION):
+
+    migrate_role_context = MigrateRoleContext(role_path=role_path,
+                                              output_path=output_path,
+                                              collection_namespace=collection_namespace,
+                                              collection_name=collection_name,
+                                              collection_version=collection_version)
+    res = migrate_role.migrate(migrate_role_context=migrate_role_context,
+                               display_callback=display_callback)
+
+    return res, migrate_role_context
+
+
+def test_migrate_role_galaxy_yml(tmpdir):
+    output_path = tmpdir.mkdir('mazer_test_migrate_role_action_test_migrate_role')
+
+    res, migrate_role_context = _migrate_role(output_path=output_path)
+
+    assert res == 0
+    assert os.path.isdir(output_path)
+
+    galaxy_yml_path = os.path.join(output_path, 'galaxy.yml')
+    assert os.path.isfile(galaxy_yml_path)
+
+    with open(galaxy_yml_path, 'r') as cfd:
+        col_info = collection_info.load(cfd)
+
+    log.debug('col_info: %s', col_info)
+
+    assert isinstance(col_info, CollectionInfo)
+    assert col_info.namespace == COL_NAMESPACE
+    assert col_info.name == COL_NAME
+    assert col_info.version == COL_VERSION
+    assert isinstance(col_info.authors, list)
+    assert isinstance(col_info.dependencies, dict)
+
+# TODO: test missing role_path, output_path doesnt exist,
+#       role loading errors, collection_info validation errors

--- a/tests/ansible_galaxy/models/test_migrate_role_context_model.py
+++ b/tests/ansible_galaxy/models/test_migrate_role_context_model.py
@@ -1,0 +1,26 @@
+import logging
+
+from ansible_galaxy.models import migrate_role_context
+
+log = logging.getLogger(__name__)
+
+
+def test_init():
+    role_path = "/dev/null/faux_role_path"
+    output_path = "/dev/null/faux_output_path"
+    mrc = migrate_role_context.MigrateRoleContext(role_path=role_path,
+                                                  output_path=output_path)
+    assert isinstance(mrc, migrate_role_context.MigrateRoleContext)
+    assert mrc.role_path == role_path
+    assert mrc.output_path == output_path
+
+
+def test_repr():
+    role_path = "/dev/null/faux_role_path"
+    output_path = "/dev/null/faux_output_path"
+    mrc = migrate_role_context.MigrateRoleContext(role_path=role_path,
+                                                  output_path=output_path)
+
+    r_mrc = repr(mrc)
+    assert role_path in r_mrc
+    assert output_path in r_mrc

--- a/tests/ansible_galaxy/test_yaml_persist.py
+++ b/tests/ansible_galaxy/test_yaml_persist.py
@@ -1,0 +1,49 @@
+from collections import OrderedDict
+import logging
+
+from ansible_galaxy import yaml_persist
+from ansible_galaxy.models.collection_info import CollectionInfo
+
+log = logging.getLogger(__name__)
+
+
+test_dict = {'blip': 1,
+             'bar': [{'a': 'A', 'b': 'B', 'cc': [None, 1, 2.3, ('blip', 'foo')]},
+                     {'other': 'stuff'}],
+             'somelists': [
+                 [11, 12, 13, 14],
+                 [555, 1.1, ['x', 't', 'z']],
+             ],
+             'somedicts': {'some_o_dict': OrderedDict({'3a': '3A', '3b': '3B'}),
+                           'level2': {'ccvb': 'bcvvvv'},
+                           'level3': {'hfgfg': '4e56'},
+                           },
+             'a_tuple': ('j', 'k', 'l', 'm'),
+             }
+
+
+def test_safe_dump():
+    yaml_str = yaml_persist.safe_dump(test_dict)
+    log.debug('yaml_str:\n%s', yaml_str)
+
+    assert yaml_str is not None
+    assert 'somedicts' in yaml_str
+
+
+def test_safe_dump_attr():
+    col_info = CollectionInfo(namespace='some_ns',
+                              name='some_name',
+                              version='1.2.3',
+                              license='MIT',
+                              description='stuff',
+                              authors=['Charles Oakley'],
+                              tags=['sometag', 'anothertag'],
+                              dependencies=OrderedDict([('foo.bar', '*'),
+                                                        ('blip.bar', '>=1.1.0')]))
+
+    log.debug('col_info: %s', col_info)
+    yaml_str = yaml_persist.safe_dump(col_info)
+    log.debug('yaml_str:\n%s', yaml_str)
+
+    assert yaml_str is not None
+    assert 'blip.bar' in yaml_str

--- a/tests/ansible_galaxy_cli/cli/test_galaxy_upstream.py
+++ b/tests/ansible_galaxy_cli/cli/test_galaxy_upstream.py
@@ -196,7 +196,7 @@ class TestGalaxy(unittest.TestCase):
                 'version': 'usage: %prog version',
             }
 
-            first_call = 'usage: %prog [build|info|install|list|publish|remove|version] [--help] [options] ...'
+            first_call = 'usage: %prog [build|info|install|list|migrate_role|publish|remove|version] [--help] [options] ...'
             second_call = formatted_call[action]
             calls = [call(first_call), call(second_call)]
             mocked_usage.assert_has_calls(calls)

--- a/tests/data/roles/old_school_role/.travis.yml
+++ b/tests/data/roles/old_school_role/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/tests/data/roles/old_school_role/README.md
+++ b/tests/data/roles/old_school_role/README.md
@@ -1,0 +1,28 @@
+Old School Role
+=========
+
+This role will be matriculated to a collection
+
+Role Variables
+--------------
+
+old_school_level: plaid
+
+Dependencies
+------------
+
+geerlingguy.repo-epel
+
+Example Playbook
+----------------
+
+``` yaml
+    - hosts: proxies
+      roles:
+         - { role: some_namespace.old_school_role, old_school_level: charlotte_hornets_starter_jacket }
+
+License
+-------
+
+MIT
+

--- a/tests/data/roles/old_school_role/defaults/main.yml
+++ b/tests/data/roles/old_school_role/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# defaults file for old_school_role
+old_school_level: "plaid"

--- a/tests/data/roles/old_school_role/handlers/main.yml
+++ b/tests/data/roles/old_school_role/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for old_school_role

--- a/tests/data/roles/old_school_role/meta/main.yml
+++ b/tests/data/roles/old_school_role/meta/main.yml
@@ -1,0 +1,41 @@
+galaxy_info:
+  author: Tater Tot
+  description: A role that will be converted to a collection
+  company: Red Hat, Inc.
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: MIT
+
+  min_ansible_version: 2.4
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: EL
+      versions:
+        - all
+    - name: AwesomeOS
+      versions:
+        - all
+        - 2.1
+
+  galaxy_tags:
+    - oldschool
+    - whippersnapper
+
+dependencies:
+  - geerlingguy.repo-epel

--- a/tests/data/roles/old_school_role/meta/main.yml
+++ b/tests/data/roles/old_school_role/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
 
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
-  # issue_tracker_url: http://example.com/issue/tracker
+  issue_tracker_url: http://example.com/issue/tracker
 
   # Some suggested licenses:
   # - BSD (default)

--- a/tests/data/roles/old_school_role/tasks/main.yml
+++ b/tests/data/roles/old_school_role/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+# tasks file for old_school_role

--- a/tests/data/roles/old_school_role/tests/inventory
+++ b/tests/data/roles/old_school_role/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/tests/data/roles/old_school_role/tests/test.yml
+++ b/tests/data/roles/old_school_role/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - old_school_role

--- a/tests/data/roles/old_school_role/vars/main.yml
+++ b/tests/data/roles/old_school_role/vars/main.yml
@@ -1,0 +1,3 @@
+---
+# vars file for old_school_role
+old_school_level: "buffalo_plaid"


### PR DESCRIPTION
##### SUMMARY
Add a subcommand 'migrate_role' for migrating a traditional style ansible role into a 'collection'

Sample invocation:

`mazer migrate_role --role tests/data/roles/middle_school_role/ --output-dir /tmp/migrated_old_school --namespace some_ns --version 2.3.0`

Fixes #186

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.3.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.16-100.fc27.x86_64, #1 SMP Sun Oct 21 09:33:00 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3-2/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3-2/bin/python3.6

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

