### PR TITLE
Catch/log/reraise generic exceptions in main

### DIFF
--- a/ansible_galaxy_cli/cli/__init__.py
+++ b/ansible_galaxy_cli/cli/__init__.py
@@ -106,6 +106,7 @@ class CLI(six.with_metaclass(ABCMeta, object)):
         """
 
         self.args = args
+        self._orig_args_copy = self.args[:]
         self.options = None
         self.parser = None
         self.action = None

--- a/ansible_galaxy_cli/main.py
+++ b/ansible_galaxy_cli/main.py
@@ -48,6 +48,14 @@ def main(args=None):
 
         # exit with EX_SOFTWARE on generic error
         exit_code = os.EX_SOFTWARE
+    except Exception as e:
+        log.exception(e)
+        exit_code = os.EX_SOFTWARE
+
+        # let non-Galaxy exceptions bubble up and traceback
+        log.debug('Uncaught exception for invocation: %s', cli._orig_args_copy)
+        log.error('Uncaught exception, existing with exit code: %s', exit_code)
+        raise
 
     log.debug('exit code: %s', exit_code)
     # do any return code setup we need here


### PR DESCRIPTION
##### SUMMARY

Catch, log, and reraise generic exceptions in main

So that any exceptions that make it all the way to main()
get logged.

Copy the full original cli args, so we can debug log them
on fatal error (since the CLI class munges them in set_action)


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.3.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.16-100.fc27.x86_64, #1 SMP Sun Oct 21 09:33:00 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3-2/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3-2/bin/python3.6
```

