### PR TITLE
Make CollectionInfo.readme optional

### DIFF
--- a/ansible_galaxy/models/collection_info.py
+++ b/ansible_galaxy/models/collection_info.py
@@ -5,6 +5,7 @@ import re
 
 import attr
 import semantic_version
+import six
 
 from ansible_galaxy.data import spdx_licenses
 
@@ -40,7 +41,8 @@ class CollectionInfo(object):
 
     authors = attr.ib(factory=list)
     tags = attr.ib(factory=list)
-    readme = attr.ib(default='README.md')
+    readme = attr.ib(default=None,
+                     validator=attr.validators.optional(attr.validators.instance_of(six.string_types)))
 
     # Note galaxy.yml 'dependencies' field is what mazer and ansible
     # consider 'requirements'. ie, install time requirements.

--- a/tests/ansible_galaxy/test_collection_info.py
+++ b/tests/ansible_galaxy/test_collection_info.py
@@ -22,7 +22,7 @@ def test_load():
                 'description': 'something',
                 'license': 'GPL-3.0-or-later',
                 'tags': [],
-                'readme': 'README.md',
+                'readme': None,
                 'documentation': None,
                 'homepage': None,
                 'issues': None,


### PR DESCRIPTION
##### SUMMARY

Make CollectionInfo.readme optional

Based on https://github.com/ansible/galaxy/pull/1579#discussion_r260305373


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request
 

##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.3.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.16-100.fc27.x86_64, #1 SMP Sun Oct 21 09:33:00 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3-2/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3-2/bin/python3.6

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

