### PR TITLE
Split artifact manifest file info out of MANIFEST.json and into FILES.json

### DIFF
--- a/ansible_galaxy/build.py
+++ b/ansible_galaxy/build.py
@@ -9,6 +9,7 @@ import six
 
 from ansible_galaxy import collection_members
 from ansible_galaxy import collection_artifact_manifest
+from ansible_galaxy import collection_artifact_file_manifest
 from ansible_galaxy.collection_info import COLLECTION_INFO_FILENAME
 from ansible_galaxy.models.collection_artifact_manifest import \
     CollectionArtifactManifest
@@ -93,8 +94,8 @@ class Build(object):
         log.debug('INFO self.collection_info: %s', self.collection_info)
 
         col_file_names = col_members.run()
-        col_files = collection_artifact_manifest.gen_manifest_artifact_files(col_file_names,
-                                                                             self.build_context.collection_path)
+        col_files = collection_artifact_file_manifest.gen_manifest_artifact_files(col_file_names,
+                                                                                  self.build_context.collection_path)
 
         file_manifest = CollectionArtifactFileManifest(files=col_files)
         manifest = CollectionArtifactManifest(collection_info=self.collection_info,)
@@ -170,7 +171,7 @@ class Build(object):
         log.debug('archive_manifest_path: %s', archive_manifest_path)
 
         archive_file_manifest_path = os.path.join(archive_top_dir,
-                                                  collection_artifact_manifest.COLLECTION_FILE_MANIFEST_FILENAME)
+                                                  collection_artifact_file_manifest.COLLECTION_FILE_MANIFEST_FILENAME)
         log.debug('archive_file_manifest_path: %s', archive_file_manifest_path)
 
         # copy the uid/gid/perms for galaxy.yml to use on the manifes. Need sep instances for manifest and file_manifest

--- a/ansible_galaxy/collection_artifact_file_manifest.py
+++ b/ansible_galaxy/collection_artifact_file_manifest.py
@@ -1,0 +1,72 @@
+import logging
+import os
+import pprint
+
+import yaml
+
+from ansible_galaxy.utils import chksums
+from ansible_galaxy.models.collection_artifact_file import CollectionArtifactFile
+from ansible_galaxy.models.collection_artifact_file_manifest import \
+    CollectionArtifactFileManifest
+
+
+pf = pprint.pformat
+log = logging.getLogger(__name__)
+
+
+COLLECTION_FILE_MANIFEST_FILENAME = 'FILES.json'
+
+
+def load(data_or_file_object):
+    # FIXME: This file is json now, so could use the regular json.load()
+    #        (this works as well since json is subset of yaml...)
+    log.debug('loading collection artifact file manifest from %s',
+              pf(data_or_file_object))
+
+    data_dict = yaml.safe_load(data_or_file_object)
+
+    # log.debug('data: %s', pf(data_dict))
+    # log.debug('data_dict: %s', data_dict)
+
+    instance = CollectionArtifactFileManifest(**data_dict)
+
+    log.debug('%s instance from_kwargs', type(instance))
+
+    log.debug('collection_file_artifact_manifest: %r', instance)
+
+    return instance
+
+
+def gen_manifest_artifact_files(file_names, collection_path, chksum_type=None):
+    # file_names = file_names or []
+    file_names = file_names or []
+    default_chksum_type = chksum_type or 'sha256'
+
+    for file_name in file_names:
+
+        current_chksum_type = default_chksum_type
+
+        # TODO: enum
+        if os.path.isfile(file_name):
+            ftype = 'file'
+        if os.path.isdir(file_name):
+            ftype = 'dir'
+
+        chksum = None
+        if ftype == 'file':
+            chksum = chksums.sha256sum_from_path(file_name)
+        else:
+            chksum = None
+            current_chksum_type = None
+
+        dest_relative_path = os.path.relpath(file_name, collection_path)
+        arcname = dest_relative_path
+
+        artifact_file = CollectionArtifactFile(src_name=file_name,
+                                               # The path where the file will live inside the archive
+                                               name=arcname,
+                                               ftype=ftype,
+                                               chksum_type=current_chksum_type,
+                                               chksum_sha256=chksum)
+
+        yield artifact_file

--- a/ansible_galaxy/collection_artifact_manifest.py
+++ b/ansible_galaxy/collection_artifact_manifest.py
@@ -1,28 +1,22 @@
 
 import logging
 import pprint
-import os
 
 import yaml
 
-from ansible_galaxy.utils import chksums
 from ansible_galaxy.models.collection_info import \
     CollectionInfo
 from ansible_galaxy.models.collection_artifact_manifest import \
     CollectionArtifactManifest
-from ansible_galaxy.models.collection_artifact_file import \
-    CollectionArtifactFile
 
 log = logging.getLogger(__name__)
 pf = pprint.pformat
 
 COLLECTION_MANIFEST_FILENAME = 'MANIFEST.json'
-COLLECTION_FILE_MANIFEST_FILENAME = 'FILES.json'
 
 
 # TODO: replace with a generic version for cases
 #       where SomeClass(**dict_from_yaml) works
-# def load(data_or_file_object, klass=None):
 def load(data_or_file_object):
 
     # FIXME: This file is json now, so could use the regular json.load()
@@ -36,49 +30,10 @@ def load(data_or_file_object):
     # log.debug('data_dict: %s', data_dict)
 
     col_info = CollectionInfo(**data_dict['collection_info'])
-    # klass = CollectionArtifactManifest
-    instance = CollectionArtifactManifest(collection_info=col_info,
-                                          files=data_dict['files'])
-    # instance = klass(**data_dict)
+    instance = CollectionArtifactManifest(collection_info=col_info)
 
     log.debug('%s instance from_kwargs', type(instance))
-    # instance)
 
-    # log.debug('collection_artifact_manifest: %r', instance)
+    log.debug('collection_artifact_manifest: %r', instance)
 
     return instance
-
-
-def gen_manifest_artifact_files(file_names, collection_path, chksum_type=None):
-    # file_names = file_names or []
-    file_names = file_names or []
-    default_chksum_type = chksum_type or 'sha256'
-
-    for file_name in file_names:
-
-        current_chksum_type = default_chksum_type
-
-        # TODO: enum
-        if os.path.isfile(file_name):
-            ftype = 'file'
-        if os.path.isdir(file_name):
-            ftype = 'dir'
-
-        chksum = None
-        if ftype == 'file':
-            chksum = chksums.sha256sum_from_path(file_name)
-        else:
-            chksum = None
-            current_chksum_type = None
-
-        dest_relative_path = os.path.relpath(file_name, collection_path)
-        arcname = dest_relative_path
-
-        artifact_file = CollectionArtifactFile(src_name=file_name,
-                                               # The path where the file will live inside the archive
-                                               name=arcname,
-                                               ftype=ftype,
-                                               chksum_type=current_chksum_type,
-                                               chksum_sha256=chksum)
-
-        yield artifact_file

--- a/ansible_galaxy/collection_artifact_manifest.py
+++ b/ansible_galaxy/collection_artifact_manifest.py
@@ -17,12 +17,16 @@ log = logging.getLogger(__name__)
 pf = pprint.pformat
 
 COLLECTION_MANIFEST_FILENAME = 'MANIFEST.json'
+COLLECTION_FILE_MANIFEST_FILENAME = 'FILES.json'
 
 
 # TODO: replace with a generic version for cases
 #       where SomeClass(**dict_from_yaml) works
 # def load(data_or_file_object, klass=None):
 def load(data_or_file_object):
+
+    # FIXME: This file is json now, so could use the regular json.load()
+    #        (this works as well since json is subset of yaml...)
     log.debug('loading collection info from %s',
               pf(data_or_file_object))
 

--- a/ansible_galaxy/fetch/local_file.py
+++ b/ansible_galaxy/fetch/local_file.py
@@ -16,8 +16,15 @@ class LocalFileFetch(object):
         self.local_path = self.requirement_spec.src
 
     def find(self):
+        vspec = self.requirement_spec.version_spec.specs[0].spec
+
         results = {'content': {'galaxy_namespace': self.requirement_spec.namespace,
-                               'repo_name': self.requirement_spec.name},
+                               'repo_name': self.requirement_spec.name,
+                               # For a local file, we created the version_spec to match
+                               # exactly the version from the file, so dig into the version_spec
+                               # a bit to pull that out.
+                               # TODO/FIXME: helper method/wrapper for making this less coupled
+                               'version': str(vspec)},
                    }
         return results
 

--- a/ansible_galaxy/models/collection_artifact_file_manifest.py
+++ b/ansible_galaxy/models/collection_artifact_file_manifest.py
@@ -1,0 +1,32 @@
+import logging
+
+import attr
+
+from ansible_galaxy.models.collection_artifact_file import CollectionArtifactFile
+
+log = logging.getLogger(__name__)
+
+
+def convert_list_to_artifact_file_list(val):
+    '''Convert a list of dicts with file info into list of CollectionArtifactFile'''
+
+    new_list = []
+    for file_item in val:
+        if isinstance(file_item, CollectionArtifactFile):
+            new_list.append(file_item)
+        else:
+            artifact_file = CollectionArtifactFile(name=file_item['name'],
+                                                   ftype=file_item['ftype'],
+                                                   chksum_type=file_item.get('chksum_type'),
+                                                   chksum_sha256=file_item.get('chksum_sha256'))
+            new_list.append(artifact_file)
+
+    return new_list
+
+
+@attr.s(frozen=True)
+class CollectionArtifactFileManifest(object):
+    files = attr.ib(factory=list, converter=convert_list_to_artifact_file_list)
+
+    format = attr.ib(default=1,
+                     validator=attr.validators.instance_of(int))

--- a/ansible_galaxy/models/collection_artifact_manifest.py
+++ b/ansible_galaxy/models/collection_artifact_manifest.py
@@ -5,26 +5,8 @@ import logging
 import attr
 
 from ansible_galaxy.models.collection_info import CollectionInfo
-from ansible_galaxy.models.collection_artifact_file import CollectionArtifactFile
 
 log = logging.getLogger(__name__)
-
-
-def convert_list_to_artifact_file_list(val):
-    '''Convert a list of dicts with file info into list of CollectionArtifactFile'''
-
-    new_list = []
-    for file_item in val:
-        if isinstance(file_item, CollectionArtifactFile):
-            new_list.append(file_item)
-        else:
-            artifact_file = CollectionArtifactFile(name=file_item['name'],
-                                                   ftype=file_item['ftype'],
-                                                   chksum_type=file_item.get('chksum_type'),
-                                                   chksum_sha256=file_item.get('chksum_sha256'))
-            new_list.append(artifact_file)
-
-    return new_list
 
 
 # see https://github.com/ansible/galaxy/issues/957
@@ -33,9 +15,15 @@ class CollectionArtifactManifest(object):
     collection_info = attr.ib(type=CollectionInfo)
     format = attr.ib(default=1)
 
-    files = attr.ib(factory=list, converter=convert_list_to_artifact_file_list)
+    # TODO: add a attr with info about the FILES.* file,
+    #       files_info_path, files_info_chksum
+    #       We need a chksum here, so a signed/verified MANIFEST.json
+    #       can be used to verified chksum of FILES.JSON and it can
+    #       verify chksums of the rest of the bundled files
 
-    # a build_info = attr.ib(type=CollectionArtifactBuildInfo)
+    # maybe 'contents' in the future
+    #
+    # maybe build_info = attr.ib(type=CollectionArtifactBuildInfo)
     #   CollectionArtifactBuildInfo has 'build_date', 'build_tool'
     # created_with =
     # when/build_date =

--- a/ansible_galaxy/models/requirement_spec.py
+++ b/ansible_galaxy/models/requirement_spec.py
@@ -45,7 +45,7 @@ class RequirementSpec(object):
                 ver = data['version']
 
                 # try to handle matching 'v1.0.0' etc
-                if version_needs_aka(ver):
+                if version_needs_aka(str(ver)):
                     data['version'] = normalize_version_string(ver)
                     data['version_aka'] = ver
                 version_spec_str = '==%s' % data['version']

--- a/ansible_galaxy/repository.py
+++ b/ansible_galaxy/repository.py
@@ -6,6 +6,7 @@ import yaml
 
 from ansible_galaxy import collection_info
 from ansible_galaxy import collection_artifact_manifest
+# from ansible_galaxy import collection_artifact_file_manifest
 from ansible_galaxy import exceptions
 from ansible_galaxy import install_info
 from ansible_galaxy import requirements
@@ -154,6 +155,17 @@ def load_from_dir(content_dir, namespace, name, installed=True):
         # log.debug('No galaxy.yml collection info found for collection %s.%s: %s', namespace, name, e)
         pass
 
+    # # TODO/FIXME: do we even need to load file_manifest here?
+    # file_manifest_filename = os.path.join(path_name, collection_artifact_file_manifest.COLLECTION_FILE_MANIFEST_FILENAME)
+    # file_manifest_data = None
+
+    # try:
+    #     with open(file_manifest_filename, 'r') as mfd:
+    #         file_manifest_data = collection_artifact_file_manifest.load(mfd)
+    # except EnvironmentError:
+    #     # log.debug('No galaxy.yml collection info found for collection %s.%s: %s', namespace, name, e)
+    #     pass
+
     # load galaxy.yml
     galaxy_filename = os.path.join(path_name, collection_info.COLLECTION_INFO_FILENAME)
 
@@ -212,6 +224,7 @@ def load_from_dir(content_dir, namespace, name, installed=True):
                                                                   repository_spec=repository_spec)
         requirements_list.extend(collection_requires)
 
+    # TODO: add reqs from MANIFEST.json
     # TODO: add requirements loaded from galaxy.yml
     # TODO: should the requirements in galaxy.yml be plain strings or dicts?
     # TODO: should there be requirements in galaxy.yml at all? in liue of requirements.yml
@@ -228,6 +241,9 @@ def load_from_dir(content_dir, namespace, name, installed=True):
 
     # TODO: if there are other places to load dependencies (ie, runtime deps) we will need
     #       to load them and combine them with role_depenency_specs
+
+    # TODO/FIXME: load deps from MANIFEST.json if it exists (and prefer it over galaxy.yml)
+
     role_dependency_specs = []
     if role_meta_main:
         role_dependency_specs = role_meta_main.dependencies

--- a/tests/ansible_galaxy/example_artifact_file_manifest1.yml
+++ b/tests/ansible_galaxy/example_artifact_file_manifest1.yml
@@ -1,0 +1,10 @@
+files:
+  - name: "roles/some_role/defaults/main.yml"
+    chksum_type: "sha256"
+    chksum_sha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    ftype: "file"
+  - name: "callback_plugins/some_callback.py"
+    chksum_type: "sha256"
+    chksum_sha256: "bc7c8f9fd65865bcd3998107c119e39d1cd26935436fa965ddb8058beabbafc3"
+    ftype: "file"
+format: 1

--- a/tests/ansible_galaxy/example_artifact_manifest1.yml
+++ b/tests/ansible_galaxy/example_artifact_manifest1.yml
@@ -6,12 +6,3 @@ collection_info:
   license: "GPL-3.0-or-later"
   description: "An example artifact manifest for unit tests"
 format: 1
-files:
-  - name: "roles/some_role/defaults/main.yml"
-    chksum_type: "sha256"
-    chksum_sha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-    ftype: "file"
-  - name: "callback_plugins/some_callback.py"
-    chksum_type: "sha256"
-    chksum_sha256: "bc7c8f9fd65865bcd3998107c119e39d1cd26935436fa965ddb8058beabbafc3"
-    ftype: "file"

--- a/tests/ansible_galaxy/models/test_collection_artifact_file_manifest_model.py
+++ b/tests/ansible_galaxy/models/test_collection_artifact_file_manifest_model.py
@@ -1,0 +1,39 @@
+import logging
+
+import pytest
+
+from ansible_galaxy.models.collection_artifact_file_manifest import CollectionArtifactFileManifest
+
+log = logging.getLogger(__name__)
+
+
+def test_example():
+    files = [{'name': 'roles/some_role/defaults/main.yml',
+              'chksum_type': 'sha256',
+              'chksum_sha256': 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+              'ftype': 'file'}]
+
+    file_manifest = CollectionArtifactFileManifest(files=files)
+
+    log.debug('file_manifest: %s', file_manifest)
+
+    assert isinstance(file_manifest, CollectionArtifactFileManifest)
+    assert len(file_manifest.files) == 1
+
+
+def test_init_no_files():
+    files = []
+    file_manifest = CollectionArtifactFileManifest(files=files)
+
+    log.debug('file_manifest: %s', file_manifest)
+
+    assert isinstance(file_manifest, CollectionArtifactFileManifest)
+    assert len(file_manifest.files) == 0
+
+
+def test_init_one_empty_file_item():
+    files = [{}]
+
+    # Note; KeyError from the converter, not a ValueError from init
+    with pytest.raises(KeyError):
+        CollectionArtifactFileManifest(files=files)

--- a/tests/ansible_galaxy/test_build.py
+++ b/tests/ansible_galaxy/test_build.py
@@ -61,16 +61,16 @@ def test_build_run(tmpdir):
     assert isinstance(res, build.BuildResult)
     assert isinstance(res.manifest, CollectionArtifactManifest)
     assert isinstance(res.manifest.collection_info, CollectionInfo)
-    assert isinstance(res.manifest.files, list)
+    assert isinstance(res.file_manifest.files, list)
 
     assert res.manifest.collection_info == collection_info
 
-    for manifest_file in res.manifest.files:
+    for manifest_file in res.file_manifest.files:
         if manifest_file.ftype == 'file':
             assert manifest_file.chksum_type == 'sha256'
 
-    file_names = [x.name for x in res.manifest.files if x.ftype == 'file']
-    dir_names = [x.name for x in res.manifest.files if x.ftype == 'dir']
+    file_names = [x.name for x in res.file_manifest.files if x.ftype == 'file']
+    dir_names = [x.name for x in res.file_manifest.files if x.ftype == 'dir']
 
     log.debug('file_names: %s', file_names)
     log.debug('dir_names: %s', dir_names)

--- a/tests/ansible_galaxy/test_collection_artifact_file_manifest.py
+++ b/tests/ansible_galaxy/test_collection_artifact_file_manifest.py
@@ -1,0 +1,58 @@
+import logging
+import os
+
+from ansible_galaxy import collection_artifact_file_manifest
+from ansible_galaxy import yaml_persist
+from ansible_galaxy.models.collection_artifact_file import CollectionArtifactFile
+from ansible_galaxy.models.collection_artifact_file_manifest import \
+    CollectionArtifactFileManifest
+
+log = logging.getLogger(__name__)
+
+
+def test_load():
+    file_name = "example_artifact_file_manifest1.yml"
+    test_data_path = os.path.join(os.path.dirname(__file__), '%s' % file_name)
+
+    with open(test_data_path, 'r') as data_fd:
+        res = collection_artifact_file_manifest.load(data_fd)
+        log.debug('res: %s', res)
+
+        assert isinstance(res, CollectionArtifactFileManifest)
+        assert isinstance(res.files, list)
+        assert isinstance(res.files[0], CollectionArtifactFile)
+
+        assert res.files[0].name == 'roles/some_role/defaults/main.yml'
+        assert res.files[0].ftype == 'file'
+        assert res.files[0].chksum_type == 'sha256'
+        assert res.files[0].chksum_sha256 == 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+
+
+def test_save(tmpdir):
+    temp_dir = tmpdir.mkdir('mazer_collection_archive_file_manifest_unit_test')
+
+    file_name = "example_artifact_file_manifest1.yml"
+
+    temp_file = temp_dir.join(file_name)
+
+    test_data_path = os.path.join(os.path.dirname(__file__), '%s' % file_name)
+    with open(test_data_path, 'r') as data_fd:
+        res = collection_artifact_file_manifest.load(data_fd)
+
+        log.debug('temp_file.strpath: %s', temp_file.strpath)
+        yaml_persist.save(res, temp_file.strpath)
+
+        # open the save()'ed file and load a new collection_artifact_manifest from it
+        with open(temp_file.strpath, 'r') as read_fd:
+            reloaded = collection_artifact_file_manifest.load(read_fd)
+
+            log.debug('reloaded: %s', reloaded)
+
+            # verify the object loaded from known example matches the example after
+            # a save()/load() cycle
+            assert reloaded == res
+
+            # read the file again and log the file contents
+            read_fd.seek(0)
+            buf = read_fd.read()
+            log.debug('buf: %s', buf)

--- a/tests/ansible_galaxy/test_collection_artifact_manifest.py
+++ b/tests/ansible_galaxy/test_collection_artifact_manifest.py
@@ -3,7 +3,6 @@ import os
 
 from ansible_galaxy import collection_artifact_manifest
 from ansible_galaxy.models.collection_artifact_manifest import CollectionArtifactManifest
-from ansible_galaxy.models.collection_artifact_file import CollectionArtifactFile
 from ansible_galaxy import yaml_persist
 
 log = logging.getLogger(__name__)
@@ -17,13 +16,6 @@ def test_load():
         log.debug('res: %s', res)
 
         assert isinstance(res, CollectionArtifactManifest)
-        assert isinstance(res.files, list)
-        assert isinstance(res.files[0], CollectionArtifactFile)
-
-        assert res.files[0].name == 'roles/some_role/defaults/main.yml'
-        assert res.files[0].ftype == 'file'
-        assert res.files[0].chksum_type == 'sha256'
-        assert res.files[0].chksum_sha256 == 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 
 
 def test_save(tmpdir):


### PR DESCRIPTION
##### SUMMARY
Splitting the 'files' info out of MANIFEST.json into FILES.json.

Will likely change the format of the FILES data later, but it's json for now.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.3.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.16-100.fc27.x86_64, #1 SMP Sun Oct 21 09:33:00 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3-2/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3-2/bin/python3.6

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

