### PR TITLE
Remove collection artifact top level dir

### DIFF
--- a/ansible_galaxy/build.py
+++ b/ansible_galaxy/build.py
@@ -22,8 +22,6 @@ log = logging.getLogger(__name__)
 ARCHIVE_FILENAME_TEMPLATE = '{namespace}-{name}-{version}.{extension}'
 ARCHIVE_FILENAME_EXTENSION = 'tar.gz'
 
-ARCHIVE_TOPDIR_TEMPLATE = '{collection_info.namespace}-{collection_info.name}-{collection_info.version}'
-
 
 # TODO: enum
 class BuildStatuses(object):
@@ -127,11 +125,8 @@ class Build(object):
                                     archive_filename_basename)
         log.debug('Building archive into archive_path: %s', archive_path)
 
-        # The name of the top level dir in the tar file. It is
-        # in the format '{collection_name}-{version}'.
-        # NOTE: This doesnt follow convention of 'foo-bar-1.2.3.tar.gz -> foo-bar-1.2.3/*'
-        archive_top_dir = ARCHIVE_TOPDIR_TEMPLATE.format(collection_info=self.collection_info)
-
+        # The name of the top level dir in the tar file, ie, there isnt one.
+        archive_top_dir = ""
         log.debug('archive_top_dir: %s', archive_top_dir)
 
         # 'x:gz' is 'create exclusive gzipped'
@@ -145,7 +140,7 @@ class Build(object):
             rel_path = col_member_file.name or col_member_file.src_name
             if rel_path == '.':
                 rel_path = ''
-            archive_member_path = os.path.join(archive_top_dir, rel_path)
+            archive_member_path = rel_path
 
             log.debug('adding %s to %s (from %s)', archive_member_path,
                       archive_path, col_member_file.name)
@@ -166,12 +161,10 @@ class Build(object):
         b_file_manifest_buf = to_bytes(file_manifest_buf)
         b_file_manifest_buf_bytesio = six.BytesIO(b_file_manifest_buf)
 
-        archive_manifest_path = os.path.join(archive_top_dir,
-                                             collection_artifact_manifest.COLLECTION_MANIFEST_FILENAME)
+        archive_manifest_path = collection_artifact_manifest.COLLECTION_MANIFEST_FILENAME
         log.debug('archive_manifest_path: %s', archive_manifest_path)
 
-        archive_file_manifest_path = os.path.join(archive_top_dir,
-                                                  collection_artifact_file_manifest.COLLECTION_FILE_MANIFEST_FILENAME)
+        archive_file_manifest_path = collection_artifact_file_manifest.COLLECTION_FILE_MANIFEST_FILENAME
         log.debug('archive_file_manifest_path: %s', archive_file_manifest_path)
 
         # copy the uid/gid/perms for galaxy.yml to use on the manifes. Need sep instances for manifest and file_manifest

--- a/tests/ansible_galaxy/test_repository_archive.py
+++ b/tests/ansible_galaxy/test_repository_archive.py
@@ -89,5 +89,4 @@ def test_load_from_archive(galaxy_context, tmpdir):
     # CollectionRepositoryArtifactArchive(info=RepositoryArchiveInfo(archive_type='multi-content-artifact', top_dir='greetings_namespace.hello-11.11.11'
     assert res.info.archive_type == 'multi-content-artifact'
 
-    # topdir is namespace-name-version (note: not namespace.name-version)
-    assert res.info.top_dir == 'greetings_namespace-hello-11.11.11'
+    assert res.info.top_dir == ''


### PR DESCRIPTION
##### SUMMARY

artifact tar files previously had a top level dir named like namespace-name-version/

This removes the top level dir.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.3.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.16-100.fc27.x86_64, #1 SMP Sun Oct 21 09:33:00 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3-2/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3-2/bin/python3.6
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

