### PR TITLE
Add 'v2' to api SUPPORTED_VERSIONS list, use v2 collections api

### DIFF
--- a/ansible_galaxy/rest_api.py
+++ b/ansible_galaxy/rest_api.py
@@ -85,7 +85,7 @@ def g_connect(method):
 class GalaxyAPI(object):
     ''' This class is meant to be used as a API client for an Ansible Galaxy server '''
 
-    SUPPORTED_VERSIONS = ['v1']
+    SUPPORTED_VERSIONS = ['v1', 'v2']
 
     # FIXME: just pass in server_url
     def __init__(self, galaxy):

--- a/ansible_galaxy/rest_api.py
+++ b/ansible_galaxy/rest_api.py
@@ -272,7 +272,15 @@ class GalaxyAPI(object):
                       fileHandle=codecs.open(archive_path, "rb"),
                       mimetype='application/octet-stream')
 
-        url = '%s/collections/' % self.baseurl
+        # FIXME: override api version in POST to collections/ as 'v2' for now, as
+        #        self.baseurl will automatically choose v1 based on 'GET /api'
+        #        results, but collections/ api endpoints are v2 only.
+        # TODO: figure out how to track API versions finer grained? Ideally
+        #       simple enough to not end up with adhoc HATEAOS imp
+        #       Maybe just hardcode api ver in calls?
+        collection_url_ver = 'v2'
+        url = '%s/api/%s/collections/' % (self._api_server, collection_url_ver)
+
         log.debug('url: %s', url)
 
         _, netloc, url, _, _, _ = urlparse(url)


### PR DESCRIPTION
##### SUMMARY
Add 'v2' to the list of api SUPPORTED_VERSIONS

Use POST /api/v2/collections for 'publish'

Override the default GalaxyAPI api version value
when publishing collections, since the API endpoints
live under the /api/v2 level.

Related: https://github.com/ansible/galaxy/pull/1639

##### ISSUE TYPE
- Feature Pull Request
 - Bugfix Pull Request


##### MAZER VERSION
```
name = mazer
version = 0.3.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.16-100.fc27.x86_64, #1 SMP Sun Oct 21 09:33:00 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3-2/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3-2/bin/python3.6

```


##### ADDITIONAL INFORMATION

