### PR TITLE
Fix extraction of no-top-level artifacts

### DIFF
--- a/ansible_galaxy/repository_archive.py
+++ b/ansible_galaxy/repository_archive.py
@@ -51,11 +51,6 @@ def extract(repository_spec,
 
     tar_members = tar_file.members
 
-    # This assumes the first entry in the tar archive / tar members
-    # is the top dir of the content, ie 'my_content_name-branch' for collection
-    # or 'ansible-role-my_content-1.2.3' for a traditional role.
-    parent_dir = tar_members[0].name
-
     # self.log.debug('content_dest_root_subpath: %s', content_dest_root_subpath)
 
     # self.log.debug('content_dest_root_path1: |%s|', content_dest_root_path)
@@ -67,8 +62,7 @@ def extract(repository_spec,
     #       not in the archive
     files_to_extract = []
     for member in tar_members:
-        # rel_path ~  roles/some-role/meta/main.yml for ex
-        rel_path = member.name[len(parent_dir) + 1:]
+        rel_path = member.name
 
         extract_to_filename_path = os.path.join(extract_archive_to_dir, rel_path)
 


### PR DESCRIPTION
Fix extraction of no-top-level artifacts

The repository (nee, collection) archive extraction
code previously assumed the first char in the path
name would always be '/'.

Since collection artifact archives no longer have a top
dir, there is no leading '/'. Before this change, that
would result in the first letter of all the top level
collection items being removed on install.

ie, 'ANIFEST.json' and 'lugins' etc.



##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.3.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.16-100.fc27.x86_64, #1 SMP Sun Oct 21 09:33:00 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3-2/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3-2/bin/python3.6
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

