### PR TITLE
Add ansible_collections to default content_roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ $ mazer install testing.ansible_testing_content
 ```
 
 This will install all of the roles in the https://galaxy-qa.ansible.com/testing/ansible_testing_content
-to ~/.ansible/content/testing/ansible_testing_content/roles/
+to ~/.ansible/content/ansible_collections/testing/ansible_testing_content/roles/
 
 ```
-/home/adrian/.ansible/content/
+/home/adrian/.ansible/content/ansible_collections/
 └── testing
     └── ansible_testing_content
         └── roles
@@ -110,8 +110,8 @@ This will install the geerlingguy.nginx role to ~/my-ansible-content/geerlingguy
 To enable development of collections, it is possible to install a
 local checkout of a collection in 'editable' mode.
 
-Instead of copying a collection into ~/.ansible/content, this mode will
-create a symlink from ~/.ansible/content/my_namespace/my_colllection
+Instead of copying a collection into ~/.ansible/content/ansible_collections, this mode will
+create a symlink from ~/.ansible/content/ansible_collections/my_namespace/my_colllection
 to the directory where the collection being worked on lives.
 
 ie, if ~/src/collections/my_new_collection is being worked on, to install
@@ -145,7 +145,7 @@ Example playbook using mazer install roles, using fully qualified role names and
 - name: Using some mazer installed roles
   hosts: localhost
   roles:
-    # expect to load from ~/.ansible/content
+    # expect to load from ~/.ansible/content/ansible_collections
     # a traditional role, one role per repo
     #  referenced with the style namespace.reponame.rolename style
     - GROG.debug-variable.debug-variable
@@ -165,7 +165,7 @@ Example playbook using mazer install roles, using fully qualified role names and
 
     # If a traditional role is installed in multiple places like:
     #    # mazer content path
-    #    ~/.ansible/content/alikins/everywhere/roles/everywhere
+    #    ~/.ansible/content/ansible_collections/alikins/everywhere/roles/everywhere
     #
     #    # default ansible roles_path
     #    ~/.ansible/roles/everywhere
@@ -177,14 +177,14 @@ Example playbook using mazer install roles, using fully qualified role names and
     # ansible will first look in the mazer content path.
     #
     # This traditional role 'alikins.everywhere.everwhere' will be
-    # found in ~/.ansible/content/content/alikins/everywhere/roles/everywhere
+    # found in ~/.ansible/content/ansible_collections/content/alikins/everywhere/roles/everywhere
     # - alikins.everywhere.everywhere
     #
     # If the role is references with the "namespace.name" style,
     # ansible will first look in the mazer content path.
     #
     # This role 'alikins.everywhere'
-    # will be found in ~/.ansible/content/alikins/everywhere/roles/everywhere
+    # will be found in ~/.ansible/content/ansible_collections/alikins/everywhere/roles/everywhere
     # - alikins.everywhere
 
     # A role from a multi-content repo
@@ -247,9 +247,9 @@ server:
 # When installing content like ansible roles, mazer will install into
 # sub directories of this path.
 #
-# default: ~/.ansible/content
+# default: ~/.ansible/content/ansible_collections
 #
-content_path: ~/.ansible/content
+content_path: ~/.ansible/content/ansible_collections
 
 options:
   # A list of file glob patterns to ignore when

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mazer 
+# Mazer
 
 A new command-line tool for managing [Ansible](https://github.com/ansible/ansible) content.
 
@@ -57,10 +57,10 @@ $ mazer install testing.ansible_testing_content
 ```
 
 This will install all of the roles in the https://galaxy-qa.ansible.com/testing/ansible_testing_content
-to ~/.ansible/content/ansible_collections/testing/ansible_testing_content/roles/
+to ~/.ansible/collections/ansible_collections/testing/ansible_testing_content/roles/
 
 ```
-/home/adrian/.ansible/content/ansible_collections/
+/home/adrian/.ansible/collections/ansible_collections/
 └── testing
     └── ansible_testing_content
         └── roles
@@ -110,8 +110,8 @@ This will install the geerlingguy.nginx role to ~/my-ansible-content/geerlingguy
 To enable development of collections, it is possible to install a
 local checkout of a collection in 'editable' mode.
 
-Instead of copying a collection into ~/.ansible/content/ansible_collections, this mode will
-create a symlink from ~/.ansible/content/ansible_collections/my_namespace/my_colllection
+Instead of copying a collection into ~/.ansible/collections/ansible_collections, this mode will
+create a symlink from ~/.ansible/collections/ansible_collections/my_namespace/my_colllection
 to the directory where the collection being worked on lives.
 
 ie, if ~/src/collections/my_new_collection is being worked on, to install
@@ -145,7 +145,7 @@ Example playbook using mazer install roles, using fully qualified role names and
 - name: Using some mazer installed roles
   hosts: localhost
   roles:
-    # expect to load from ~/.ansible/content/ansible_collections
+    # expect to load from ~/.ansible/collections/ansible_collections
     # a traditional role, one role per repo
     #  referenced with the style namespace.reponame.rolename style
     - GROG.debug-variable.debug-variable
@@ -165,7 +165,7 @@ Example playbook using mazer install roles, using fully qualified role names and
 
     # If a traditional role is installed in multiple places like:
     #    # mazer content path
-    #    ~/.ansible/content/ansible_collections/alikins/everywhere/roles/everywhere
+    #    ~/.ansible/collections/ansible_collections/alikins/everywhere/roles/everywhere
     #
     #    # default ansible roles_path
     #    ~/.ansible/roles/everywhere
@@ -177,14 +177,14 @@ Example playbook using mazer install roles, using fully qualified role names and
     # ansible will first look in the mazer content path.
     #
     # This traditional role 'alikins.everywhere.everwhere' will be
-    # found in ~/.ansible/content/ansible_collections/content/alikins/everywhere/roles/everywhere
+    # found in ~/.ansible/collections/ansible_collections/content/alikins/everywhere/roles/everywhere
     # - alikins.everywhere.everywhere
     #
     # If the role is references with the "namespace.name" style,
     # ansible will first look in the mazer content path.
     #
     # This role 'alikins.everywhere'
-    # will be found in ~/.ansible/content/ansible_collections/alikins/everywhere/roles/everywhere
+    # will be found in ~/.ansible/collections/ansible_collections/alikins/everywhere/roles/everywhere
     # - alikins.everywhere
 
     # A role from a multi-content repo
@@ -247,9 +247,9 @@ server:
 # When installing content like ansible roles, mazer will install into
 # sub directories of this path.
 #
-# default: ~/.ansible/content/ansible_collections
+# default: ~/.ansible/collections/ansible_collections
 #
-content_path: ~/.ansible/content/ansible_collections
+content_path: ~/.ansible/collections/ansible_collections
 
 options:
   # A list of file glob patterns to ignore when

--- a/ansible_galaxy/config/defaults.py
+++ b/ansible_galaxy/config/defaults.py
@@ -21,8 +21,8 @@ DEFAULTS = [
      ),
 
     # In order of priority
-    ('content_path', '~/.ansible/content'),
-    ('global_content_path', '/usr/share/ansible/content'),
+    ('content_path', '~/.ansible/content/ansible_collections'),
+    ('global_content_path', '/usr/share/ansible/content/ansible_collections'),
 
     # runtime options
     ('options',

--- a/ansible_galaxy/config/defaults.py
+++ b/ansible_galaxy/config/defaults.py
@@ -21,8 +21,8 @@ DEFAULTS = [
      ),
 
     # In order of priority
-    ('content_path', '~/.ansible/content/ansible_collections'),
-    ('global_content_path', '/usr/share/ansible/content/ansible_collections'),
+    ('content_path', '~/.ansible/collections/ansible_collections'),
+    ('global_content_path', '/usr/share/ansible/collections/ansible_collections'),
 
     # runtime options
     ('options',

--- a/config/galaxy-localhost.yml
+++ b/config/galaxy-localhost.yml
@@ -2,7 +2,7 @@ defaults: {}
 server:
   ignore_certs: false
   url: http://localhost:8000
-content_path: ~/.ansible/content/ansible_collections
+content_path: ~/.ansible/collections/ansible_collections
 options:
   role_skeleton_ignore:
     - ^.git$

--- a/config/galaxy-localhost.yml
+++ b/config/galaxy-localhost.yml
@@ -2,7 +2,7 @@ defaults: {}
 server:
   ignore_certs: false
   url: http://localhost:8000
-content_path: ~/.ansible/content
+content_path: ~/.ansible/content/ansible_collections
 options:
   role_skeleton_ignore:
     - ^.git$

--- a/config/galaxy.yml
+++ b/config/galaxy.yml
@@ -2,7 +2,7 @@ defaults: {}
 server:
   ignore_certs: false
   url: https://galaxy-qa.ansible.com
-content_path: ~/.ansible/content
+content_path: ~/.ansible/content/ansible_collections
 options:
   local_tmp: ~/.ansible/tmp
   role_skeleton_ignore:

--- a/config/galaxy.yml
+++ b/config/galaxy.yml
@@ -2,7 +2,7 @@ defaults: {}
 server:
   ignore_certs: false
   url: https://galaxy-qa.ansible.com
-content_path: ~/.ansible/content/ansible_collections
+content_path: ~/.ansible/collections/ansible_collections
 options:
   local_tmp: ~/.ansible/tmp
   role_skeleton_ignore:

--- a/tests/ansible_galaxy/config/test_config_file.py
+++ b/tests/ansible_galaxy/config/test_config_file.py
@@ -61,8 +61,8 @@ VALID_YAML = b'''
 server:
   ignore_certs: true
   url: https://someserver.example.com
-content_path: ~/.ansible/some_content_path
-global_content_path: /usr/local/share
+content_path: ~/.ansible/some_content_path/ansible_collections
+global_content_path: /usr/local/share/ansible_collections
 options:
   role_skeleton_ignore:
     - ^.git$
@@ -89,8 +89,8 @@ def test_load_valid_yaml():
 
     assert config_data['server']['url'] == 'https://someserver.example.com'
     assert config_data['server']['ignore_certs'] is True
-    assert config_data['content_path'] == '~/.ansible/some_content_path'
-    assert config_data['global_content_path'] == '/usr/local/share'
+    assert config_data['content_path'] == '~/.ansible/some_content_path/ansible_collections'
+    assert config_data['global_content_path'] == '/usr/local/share/ansible_collections'
     assert config_data['options']['role_skeleton_path'] == '~/.some_skeleton'
 
 

--- a/tests/ansible_galaxy/config/test_config_file.py
+++ b/tests/ansible_galaxy/config/test_config_file.py
@@ -61,8 +61,8 @@ VALID_YAML = b'''
 server:
   ignore_certs: true
   url: https://someserver.example.com
-content_path: ~/.ansible/some_content_path/ansible_collections
-global_content_path: /usr/local/share/ansible_collections
+content_path: ~/.ansible/some_collections_path/ansible_collections
+global_content_path: /usr/local/share/collections/ansible_collections
 options:
   role_skeleton_ignore:
     - ^.git$
@@ -89,8 +89,8 @@ def test_load_valid_yaml():
 
     assert config_data['server']['url'] == 'https://someserver.example.com'
     assert config_data['server']['ignore_certs'] is True
-    assert config_data['content_path'] == '~/.ansible/some_content_path/ansible_collections'
-    assert config_data['global_content_path'] == '/usr/local/share/ansible_collections'
+    assert config_data['content_path'] == '~/.ansible/some_collections_path/ansible_collections'
+    assert config_data['global_content_path'] == '/usr/local/share/collections/ansible_collections'
     assert config_data['options']['role_skeleton_path'] == '~/.some_skeleton'
 
 

--- a/tests/ansible_galaxy/conftest.py
+++ b/tests/ansible_galaxy/conftest.py
@@ -7,6 +7,7 @@ def galaxy_context(tmpdir):
     # FIXME: mock
     server = {'url': 'http://localhost:8000',
               'ignore_certs': False}
-    content = tmpdir.mkdir('content')
+    content_dir = tmpdir.mkdir('content')
+    collections_dir = content_dir.mkdir('ansible_collections')
     from ansible_galaxy.models.context import GalaxyContext
-    return GalaxyContext(server=server, content_path=content.strpath)
+    return GalaxyContext(server=server, content_path=collections_dir.strpath)

--- a/tests/ansible_galaxy/conftest.py
+++ b/tests/ansible_galaxy/conftest.py
@@ -7,7 +7,7 @@ def galaxy_context(tmpdir):
     # FIXME: mock
     server = {'url': 'http://localhost:8000',
               'ignore_certs': False}
-    content_dir = tmpdir.mkdir('content')
+    content_dir = tmpdir.mkdir('collections')
     collections_dir = content_dir.mkdir('ansible_collections')
     from ansible_galaxy.models.context import GalaxyContext
     return GalaxyContext(server=server, content_path=collections_dir.strpath)


### PR DESCRIPTION

##### SUMMARY

Add ansible_collections to default content_roots

The ansible collection loader requires collection name space dirs are
below a 'ansible_collections' directory. 'ansible_collections' ends up
being the root of a python namespace package where all of the python
code can be referenced (including non python code which can be loaded
via pkgutils.get_data()).

So the default install locations (aka, content roots) need to
have the 'ansible_collections' subdir added to their path.

This updates all of the config defaults, documentation, and
the paths used in tests to include 'ansible_collections'

Note: If you have existing collection namespaces in a dir like
~/.ansible/content/, they will need to be manually moved to
~/.ansible/content/ansible_collections/

See https://github.com/ansible/ansible/pull/52194 for the ansible changes.

<!--- Describe the change, including rationale and design decisions -->


##### ISSUE TYPE
 - Bugfix Pull Request



##### MAZER VERSION
```
name = mazer
version = 0.3.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.16-100.fc27.x86_64, #1 SMP Sun Oct 21 09:33:00 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3-2/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3-2/bin/python3.6

```


