### PR TITLE
Stop requiring plugin dirs to have __init__ for list.

### DIFF
--- a/ansible_galaxy/installed_content_item_db.py
+++ b/ansible_galaxy/installed_content_item_db.py
@@ -22,15 +22,14 @@ def glob_content_path_iterator(repository, content_item_sub_dir):
 
 
 def is_plugin_dir(plugin_dir_path):
-    '''Check plugins/ items to see if a dir with a __init__.py in it'''
+    '''Check plugins/ items to see if a potential plugin dir is a dir
+
+    No other checks are used to determine if plugin_dir_path is actually a plugin dir'''
     log.debug('plugin_dir_path: %s', plugin_dir_path)
 
     if os.path.isdir(plugin_dir_path):
-        if os.path.isfile(os.path.join(plugin_dir_path, '__init__.py')):
-            return True
+        return True
 
-        log.warning('There is a directory in "%s" that has no __init__.py and does not appear to be a plugin dir',
-                    plugin_dir_path)
     return False
 
 


### PR DESCRIPTION

##### SUMMARY

Stop requiring plugin dirs to have __init__ for `mazer list --content`.

The is_plugin_dir() method used by installed_content_item_db
which is used by 'mazer list' was excluding potential content_items
if their plugin dir did not contain an __init__.py.

Before this change, 'mazer list --content' would not list info
about any content items that did not have an __init__.py.

Remove the the __init__.py check so all plugin dirs are considered
content items so list does the right thing now.

<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.3.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.16-100.fc27.x86_64, #1 SMP Sun Oct 21 09:33:00 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3-2/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3-2/bin/python3.6

```


