### PR TITLE
Rev to ver 0.4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,32 @@
 Changelog
 =========
 
+0.4.0 (2019-03-28)
+------------------
+
+* The default path for collections to be installed
+  is now '~/.ansible/collections/ansible_collections'
+  which is also the default place ansible 2.8 or higher will search
+  for collections.
+* Add the 'mazer publish' for publishing a collection artifact to Ansible Galaxy
+* `186 Implement 'migrate_role' command to convert traditional roles to collections <https://github.com/ansible/mazer/issues/186>`_.
+* galaxy.yml 'authors' field is now a list
+* galaxy.yml 'dependencies' field is now a dict where the key is the
+  collection and the value is a https://github.com/rbarrois/python-semanticversion version spec
+* galaxy.yml 'tags' field (a list of tags) added
+* galaxy.yml 'readme' field added. The value is the path to the README file.
+* galaxy.yml optional new fields 'repository', 'documentation', 'homepage', 'issues'
+* galaxy.yml optional field 'license_file' added. It's value is a path
+  to a file containing additional license information
+* collection artifacts file manifest info is now in the generated FILES.json
+* MANIFEST.json now includes path and sha256sum of new generated FILES.json
+* Dependency solving version matching now supports the python-semanticversion style version specs
+* Fixes and improvements for install of local collection artifacts.
+  ie. `mazer install my_namespace-my_collection-1.2.3.tar.gz`
+* Updates to the use Galaxy REST v2 API
+* Updates to how SPDX data is loaded and used.
+* SPDX data updated to 3.4-59-ga68ef3c
+
 0.3.0 (2018-11-06)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A new command-line tool for managing [Ansible](https://github.com/ansible/ansible) content.
 
 **Note:** Mazer is most useful when used with a version of Ansible that understands mazer installed content.
-Currently that means the ['mazer_role_loader' branch of ansible](https://github.com/ansible/ansible/tree/mazer_role_loader)
+Currently that means ansible 2.8 and later.
 
 **Note:** By default, mazer currently defaults to using the "beta" Ansible Galaxy server at https://galaxy-qa.ansible.com.
 https://galaxy-qa.ansible.com may have different data than the primary Ansible Galaxy server at https://galaxy.ansible.com
@@ -17,8 +17,8 @@ If you're installing Ansible content in a production environment, or need assist
 
 ## Proposed Features
 
-- Install content from Galaxy artifacts containing collections of Ansible roles, modules and plugins
-- Generate artifacts from local content that can then be published to the Galaxy server
+- Install content from Galaxy artifacts containing collections of Ansible roles, modules and plugins ('mazer install')
+- Generate artifacts from local content that can then be published to the Galaxy server ('mazer build')
 - Provide versioned management of installed content
 - Integrate with popular testing tools like Ansible Lint and Molecule
 
@@ -28,27 +28,7 @@ For additional documentation on mazer, view the [Mazer topic on Ansible Galaxy D
 
 ## Examples
 
-### Installing roles
-
-To install the galaxy role [geerlingguy.nginx](https://galaxy.ansible.com/geerlingguy/nginx/) via galaxy:
-
-```
-$ mazer install geerlingguy.nginx
-```
-
-To install a specific version via galaxy:
-
-```
-$ mazer install geerlingguy.nginx,2.6.0
-```
-
-To install via github:
-
-```
-$ mazer install git+https://github.com/geerlingguy/ansible-role-nginx
-```
-
-### Installing repos with multiple roles
+### Installing collection
 
 To install the galaxy repo [testing.ansible_testing_content](https://galaxy-qa.ansible.com/testing/ansible_testing_content):
 
@@ -56,54 +36,47 @@ To install the galaxy repo [testing.ansible_testing_content](https://galaxy-qa.a
 $ mazer install testing.ansible_testing_content
 ```
 
-This will install all of the roles in the https://galaxy-qa.ansible.com/testing/ansible_testing_content
-to ~/.ansible/collections/ansible_collections/testing/ansible_testing_content/roles/
+This will install the collection in the https://galaxy-qa.ansible.com/testing/ansible_testing_content
+to ~/.ansible/collections/ansible_collections/testing/ansible_testing_content/
 
 ```
-/home/adrian/.ansible/collections/ansible_collections/
-└── testing
-    └── ansible_testing_content
-        └── roles
-            ├── ansible-role-foobar
-            │   ├── defaults
-            │   │   └── main.yml
-            │   ├── handlers
-            │   │   └── main.yml
-            │   ├── meta
-            │   │   └── main.yml
-            │   ├── README.md
-            │   ├── tasks
-            │   │   └── main.yml
-            │   ├── tests
-            │   │   ├── inventory
-            │   │   └── test.yml
-            │   └── vars
-            │       └── main.yml
-            ├── ansible-test-role-1
-            │   ├── defaults
-            │   │   └── main.yml
-            │   ├── handlers
-            │   │   └── main.yml
-            │   ├── meta
-            │   │   └── main.yml
-            │   ├── README.md
-            │   ├── tasks
-            │   │   └── main.yml
-            │   ├── tests
-            │   │   ├── inventory
-            │   │   └── test.yml
-            │   └── vars
-            │       └── main.yml
-            ...
+/home/adrian/.ansible/collections/ansible_collections
+└── alikins
+    ├── ansible_testing_content
+    │   ├── FILES.json
+    │   ├── galaxy.yml
+    │   ├── galaxy.yml.new
+    │   ├── __init__.py
+    │   ├── LICENSE
+    │   ├── MANIFEST.json
+    │   ├── meta
+    │   ├── plugins
+    │   │   ├── action
+    │   │   │   └── add_host.py
+    │   │   ├── filter
+    │   │   │   ├── json_query.py
+    │   │   │   ├── mathstuff.py
+    │   │   │   └── newfilter.py
+    │   │   ├── lookup
+    │   │   │   ├── fileglob.py
+    │   │   │   ├── k8s.py
+    │   │   │   ├── newlookup.py
+    │   │   │   └── openshift.py
+    │   │   ├── modules
+    │   │   │   ├── elasticsearch_plugin.py
+    │   │   │   ├── kibana_plugin.py
+    │   │   │   ├── module_in_bash.sh
+    │   │   │   ├── mysql_db.py
+...
 ```
 
-### Install a role to a different content path
+### Install a collection to a different content path
 
 ```
-$ mazer install --content-path ~/my-ansible-content geerlingguy.nginx
+$ mazer install --content-path ~/my-ansible-content alikins.collection_inspect
 ```
 
-This will install the geerlingguy.nginx role to ~/my-ansible-content/geerlingguy/nginx/roles/nginx
+This will install the alikins.collection_inspect role to ~/my-ansible-content/alikins/collection_inspect
 
 ### Installing collections in 'editable' mode for development
 
@@ -122,81 +95,12 @@ $ mazer install --namespace my_namespace --editable ~/src/collections/my_new_col
 ```
 
 This will result in 'my_namespace.my_new_collection' being "installed".
-The above command symlinks ~/.ansble/content/my_namespace/my_new_collection to
+The above command symlinks ~/.ansble/collections/ansible_collections/my_namespace/my_new_collection to
 ~/src/collections/my_new_collection.
 
 The install option **'--editable'** or the short **'-e'** can be used.
 
 Note that **'--namespace'** option is required.
-
-
-### Using mazer installed roles in a playbook (requires 'mazer_role_loader' ansible branch)
-
-Before running this example, install the roles required via mazer. Use '--force' if some of the roles are already installed by mazer.
-
-```
-$ mazer install GROG.debug-variable testing.ansible_testing_content f500.dumpall openmicroscopy.debug-dumpallvars
-```
-
-Example playbook using mazer install roles, using fully qualified role names and older style name.
-
-``` yaml
----
-- name: Using some mazer installed roles
-  hosts: localhost
-  roles:
-    # expect to load from ~/.ansible/collections/ansible_collections
-    # a traditional role, one role per repo
-    #  referenced with the style namespace.reponame.rolename style
-    - GROG.debug-variable.debug-variable
-
-    # a traditional role referenced via the traditional name
-    # (namespace.reponame)
-    - f500.dumpall
-
-    # traditional role specified as dict with role vars provided 'json' style
-    - {role: GROG.debug-variable.debug-variable, debug_variable_dump_location: '/tmp/ansible-GROG-dict-style-debug.dump', dir: '/opt/b', app_port: 5001}
-
-    # traditional role specified as dict with role vars provided playbook yaml style
-    - role: f500.dumpall
-      tags:
-        - debug
-      dumpall_host_destination: '/tmp/ansible-f500-dumpall/'
-
-    # If a traditional role is installed in multiple places like:
-    #    # mazer content path
-    #    ~/.ansible/collections/ansible_collections/alikins/everywhere/roles/everywhere
-    #
-    #    # default ansible roles_path
-    #    ~/.ansible/roles/everywhere
-    #
-    #    # playbook local roles directoty
-    #    roles/everywhere.
-    #
-    # If the role is referenced with the full "namespace.reponame.rolename" style,
-    # ansible will first look in the mazer content path.
-    #
-    # This traditional role 'alikins.everywhere.everwhere' will be
-    # found in ~/.ansible/collections/ansible_collections/content/alikins/everywhere/roles/everywhere
-    # - alikins.everywhere.everywhere
-    #
-    # If the role is references with the "namespace.name" style,
-    # ansible will first look in the mazer content path.
-    #
-    # This role 'alikins.everywhere'
-    # will be found in ~/.ansible/collections/ansible_collections/alikins/everywhere/roles/everywhere
-    # - alikins.everywhere
-
-    # A role from a multi-content repo
-    - testing.ansible_testing_content.test-role-a
-
-    # A multi-content repo referenced only by namespace.reponame
-    # will NOT work if a role is needed since there are multiple roles
-    # in 'testing.ansible_testing_content' but none called 'ansible_testing_content'
-    # - testing.ansible_testing_content
-    #
-
-```
 
 ### Building ansible content collection artifacts with 'mazer build'
 
@@ -243,6 +147,13 @@ server:
   # default: False (https connections do verify certificates)
   #
   ignore_certs: false
+
+# When installing content like ansible collection globally (using the '-g/--global' flag),
+# mazer will install into sub directories of this path.
+#
+# default: /usr/share/ansible/collections/ansible_collections
+#
+global_content_path: /usr/share/ansible/collections/ansible_collections
 
 # When installing content like ansible roles, mazer will install into
 # sub directories of this path.
@@ -300,28 +211,17 @@ pip install mazer
 pip install -v git+ssh://git@github.com/ansible/mazer.git
 ```
 
-## Installing the companion branch of ansible
-
-### Via pip (from github ssh)
-```
-pip install -e  git+ssh://git@github.com/ansible/ansible.git@mazer_role_loader#egg=ansible
-```
-
-### Via pip (from github git)
-```
-pip install -e  git+git://github.com/ansible/ansible.git@mazer_role_loader#egg=ansible
-```
-
 ### Verifying installed version of ansible supports mazer content
 
 The versions of ansible that support mazer content have a config option for setting the content path.
 If the install ansible has this config option, mazer content will work.
 
-To verify that, run the command 'ansible-config list | grep DEFAULT_CONTENT_PATH'. If 'DEFAULT_CONFIG_PATH' is found the correct branch of ansible is installed.
+To verify that, run the command 'ansible-config list | grep COLLECTIONS_PATH'.
+If 'COLLECTIONS_PATH' is found the correct branch of ansible is installed.
 
 ```
-$ ansible-config list | grep DEFAULT_CONTENT_PATH
-DEFAULT_CONTENT_PATH:
+$ ansible-config list | grep COLLECTIONS_PATH
+COLLECTIONS_PATH:
 ```
 
 ## Testing

--- a/ansible_galaxy/data/spdx_licenses.json
+++ b/ansible_galaxy/data/spdx_licenses.json
@@ -302,6 +302,12 @@
     "CECILL-C":{
         "deprecated":false
     },
+    "CERN-OHL-1.1":{
+        "deprecated":false
+    },
+    "CERN-OHL-1.2":{
+        "deprecated":false
+    },
     "CNRI-Jython":{
         "deprecated":false
     },
@@ -512,6 +518,9 @@
     "HPND":{
         "deprecated":false
     },
+    "HPND-sell-variant":{
+        "deprecated":false
+    },
     "HaskellReport":{
         "deprecated":false
     },
@@ -549,6 +558,9 @@
         "deprecated":false
     },
     "Interbase-1.0":{
+        "deprecated":false
+    },
+    "JPNIC":{
         "deprecated":false
     },
     "JSON":{
@@ -977,6 +989,9 @@
     "SugarCRM-1.1.3":{
         "deprecated":false
     },
+    "TAPR-OHL-1.0":{
+        "deprecated":false
+    },
     "TCL":{
         "deprecated":false
     },
@@ -1119,6 +1134,9 @@
         "deprecated":false
     },
     "iMatix":{
+        "deprecated":false
+    },
+    "libpng-2.0":{
         "deprecated":false
     },
     "libtiff":{

--- a/data/spdx_licenses.json
+++ b/data/spdx_licenses.json
@@ -1,11 +1,11 @@
 {
-  "licenseListVersion": "v3.4-5-gb3d735f",
+  "licenseListVersion": "3.4-59-ga68ef3c",
   "licenses": [
     {
       "reference": "./0BSD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/0BSD.json",
-      "referenceNumber": "310",
+      "referenceNumber": "315",
       "name": "BSD Zero Clause License",
       "licenseId": "0BSD",
       "seeAlso": [
@@ -17,11 +17,11 @@
       "reference": "./AAL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AAL.json",
-      "referenceNumber": "20",
+      "referenceNumber": "21",
       "name": "Attribution Assurance License",
       "licenseId": "AAL",
       "seeAlso": [
-        "http://www.opensource.org/licenses/attribution"
+        "https://opensource.org/licenses/attribution"
       ],
       "isOsiApproved": true
     },
@@ -29,7 +29,7 @@
       "reference": "./ADSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ADSL.json",
-      "referenceNumber": "18",
+      "referenceNumber": "19",
       "name": "Amazon Digital Services License",
       "licenseId": "ADSL",
       "seeAlso": [
@@ -42,7 +42,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-1.1.json",
-      "referenceNumber": "112",
+      "referenceNumber": "115",
       "name": "Academic Free License v1.1",
       "licenseId": "AFL-1.1",
       "seeAlso": [
@@ -56,7 +56,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-1.2.json",
-      "referenceNumber": "130",
+      "referenceNumber": "133",
       "name": "Academic Free License v1.2",
       "licenseId": "AFL-1.2",
       "seeAlso": [
@@ -70,7 +70,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-2.0.json",
-      "referenceNumber": "109",
+      "referenceNumber": "112",
       "name": "Academic Free License v2.0",
       "licenseId": "AFL-2.0",
       "seeAlso": [
@@ -83,7 +83,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-2.1.json",
-      "referenceNumber": "244",
+      "referenceNumber": "248",
       "name": "Academic Free License v2.1",
       "licenseId": "AFL-2.1",
       "seeAlso": [
@@ -96,12 +96,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-3.0.json",
-      "referenceNumber": "209",
+      "referenceNumber": "213",
       "name": "Academic Free License v3.0",
       "licenseId": "AFL-3.0",
       "seeAlso": [
         "http://www.rosenlaw.com/AFL3.0.htm",
-        "http://www.opensource.org/licenses/afl-3.0"
+        "https://opensource.org/licenses/afl-3.0"
       ],
       "isOsiApproved": true
     },
@@ -110,7 +110,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AGPL-1.0.json",
-      "referenceNumber": "325",
+      "referenceNumber": "330",
       "name": "Affero General Public License v1.0",
       "licenseId": "AGPL-1.0",
       "seeAlso": [
@@ -122,7 +122,7 @@
       "reference": "./AGPL-1.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AGPL-1.0-only.json",
-      "referenceNumber": "370",
+      "referenceNumber": "376",
       "name": "Affero General Public License v1.0 only",
       "licenseId": "AGPL-1.0-only",
       "seeAlso": [
@@ -134,7 +134,7 @@
       "reference": "./AGPL-1.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AGPL-1.0-or-later.json",
-      "referenceNumber": "322",
+      "referenceNumber": "327",
       "name": "Affero General Public License v1.0 or later",
       "licenseId": "AGPL-1.0-or-later",
       "seeAlso": [
@@ -147,12 +147,12 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AGPL-3.0.json",
-      "referenceNumber": "222",
+      "referenceNumber": "226",
       "name": "GNU Affero General Public License v3.0",
       "licenseId": "AGPL-3.0",
       "seeAlso": [
-        "http://www.gnu.org/licenses/agpl.txt",
-        "http://www.opensource.org/licenses/AGPL-3.0"
+        "https://www.gnu.org/licenses/agpl.txt",
+        "https://opensource.org/licenses/AGPL-3.0"
       ],
       "isOsiApproved": true
     },
@@ -161,12 +161,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AGPL-3.0-only.json",
-      "referenceNumber": "90",
+      "referenceNumber": "92",
       "name": "GNU Affero General Public License v3.0 only",
       "licenseId": "AGPL-3.0-only",
       "seeAlso": [
-        "http://www.gnu.org/licenses/agpl.txt",
-        "http://www.opensource.org/licenses/AGPL-3.0"
+        "https://www.gnu.org/licenses/agpl.txt",
+        "https://opensource.org/licenses/AGPL-3.0"
       ],
       "isOsiApproved": true
     },
@@ -175,12 +175,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AGPL-3.0-or-later.json",
-      "referenceNumber": "148",
+      "referenceNumber": "152",
       "name": "GNU Affero General Public License v3.0 or later",
       "licenseId": "AGPL-3.0-or-later",
       "seeAlso": [
-        "http://www.gnu.org/licenses/agpl.txt",
-        "http://www.opensource.org/licenses/AGPL-3.0"
+        "https://www.gnu.org/licenses/agpl.txt",
+        "https://opensource.org/licenses/AGPL-3.0"
       ],
       "isOsiApproved": true
     },
@@ -188,7 +188,7 @@
       "reference": "./AMDPLPA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AMDPLPA.json",
-      "referenceNumber": "31",
+      "referenceNumber": "32",
       "name": "AMD\u0027s plpa_map.c License",
       "licenseId": "AMDPLPA",
       "seeAlso": [
@@ -200,7 +200,7 @@
       "reference": "./AML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AML.json",
-      "referenceNumber": "141",
+      "referenceNumber": "145",
       "name": "Apple MIT License",
       "licenseId": "AML",
       "seeAlso": [
@@ -212,7 +212,7 @@
       "reference": "./AMPAS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AMPAS.json",
-      "referenceNumber": "184",
+      "referenceNumber": "188",
       "name": "Academy of Motion Picture Arts and Sciences BSD",
       "licenseId": "AMPAS",
       "seeAlso": [
@@ -224,7 +224,7 @@
       "reference": "./ANTLR-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ANTLR-PD.json",
-      "referenceNumber": "381",
+      "referenceNumber": "387",
       "name": "ANTLR Software Rights Notice",
       "licenseId": "ANTLR-PD",
       "seeAlso": [
@@ -236,7 +236,7 @@
       "reference": "./APAFML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APAFML.json",
-      "referenceNumber": "188",
+      "referenceNumber": "192",
       "name": "Adobe Postscript AFM License",
       "licenseId": "APAFML",
       "seeAlso": [
@@ -248,11 +248,11 @@
       "reference": "./APL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APL-1.0.json",
-      "referenceNumber": "245",
+      "referenceNumber": "249",
       "name": "Adaptive Public License 1.0",
       "licenseId": "APL-1.0",
       "seeAlso": [
-        "http://www.opensource.org/licenses/APL-1.0"
+        "https://opensource.org/licenses/APL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -260,7 +260,7 @@
       "reference": "./APSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APSL-1.0.json",
-      "referenceNumber": "342",
+      "referenceNumber": "348",
       "name": "Apple Public Source License 1.0",
       "licenseId": "APSL-1.0",
       "seeAlso": [
@@ -272,7 +272,7 @@
       "reference": "./APSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APSL-1.1.json",
-      "referenceNumber": "315",
+      "referenceNumber": "320",
       "name": "Apple Public Source License 1.1",
       "licenseId": "APSL-1.1",
       "seeAlso": [
@@ -284,7 +284,7 @@
       "reference": "./APSL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APSL-1.2.json",
-      "referenceNumber": "32",
+      "referenceNumber": "33",
       "name": "Apple Public Source License 1.2",
       "licenseId": "APSL-1.2",
       "seeAlso": [
@@ -297,7 +297,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/APSL-2.0.json",
-      "referenceNumber": "103",
+      "referenceNumber": "106",
       "name": "Apple Public Source License 2.0",
       "licenseId": "APSL-2.0",
       "seeAlso": [
@@ -309,7 +309,7 @@
       "reference": "./Abstyles.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Abstyles.json",
-      "referenceNumber": "76",
+      "referenceNumber": "78",
       "name": "Abstyles License",
       "licenseId": "Abstyles",
       "seeAlso": [
@@ -321,7 +321,7 @@
       "reference": "./Adobe-2006.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Adobe-2006.json",
-      "referenceNumber": "277",
+      "referenceNumber": "282",
       "name": "Adobe Systems Incorporated Source Code License Agreement",
       "licenseId": "Adobe-2006",
       "seeAlso": [
@@ -333,7 +333,7 @@
       "reference": "./Adobe-Glyph.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Adobe-Glyph.json",
-      "referenceNumber": "101",
+      "referenceNumber": "104",
       "name": "Adobe Glyph List License",
       "licenseId": "Adobe-Glyph",
       "seeAlso": [
@@ -345,7 +345,7 @@
       "reference": "./Afmparse.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Afmparse.json",
-      "referenceNumber": "40",
+      "referenceNumber": "41",
       "name": "Afmparse License",
       "licenseId": "Afmparse",
       "seeAlso": [
@@ -357,7 +357,7 @@
       "reference": "./Aladdin.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Aladdin.json",
-      "referenceNumber": "251",
+      "referenceNumber": "255",
       "name": "Aladdin Free Public License",
       "licenseId": "Aladdin",
       "seeAlso": [
@@ -370,7 +370,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Apache-1.0.json",
-      "referenceNumber": "230",
+      "referenceNumber": "234",
       "name": "Apache License 1.0",
       "licenseId": "Apache-1.0",
       "seeAlso": [
@@ -383,12 +383,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Apache-1.1.json",
-      "referenceNumber": "80",
+      "referenceNumber": "82",
       "name": "Apache License 1.1",
       "licenseId": "Apache-1.1",
       "seeAlso": [
         "http://apache.org/licenses/LICENSE-1.1",
-        "http://opensource.org/licenses/Apache-1.1"
+        "https://opensource.org/licenses/Apache-1.1"
       ],
       "isOsiApproved": true
     },
@@ -397,12 +397,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Apache-2.0.json",
-      "referenceNumber": "24",
+      "referenceNumber": "25",
       "name": "Apache License 2.0",
       "licenseId": "Apache-2.0",
       "seeAlso": [
         "http://www.apache.org/licenses/LICENSE-2.0",
-        "http://www.opensource.org/licenses/Apache-2.0"
+        "https://opensource.org/licenses/Apache-2.0"
       ],
       "isOsiApproved": true
     },
@@ -410,11 +410,11 @@
       "reference": "./Artistic-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Artistic-1.0.json",
-      "referenceNumber": "158",
+      "referenceNumber": "162",
       "name": "Artistic License 1.0",
       "licenseId": "Artistic-1.0",
       "seeAlso": [
-        "http://opensource.org/licenses/Artistic-1.0"
+        "https://opensource.org/licenses/Artistic-1.0"
       ],
       "isOsiApproved": true
     },
@@ -422,7 +422,7 @@
       "reference": "./Artistic-1.0-Perl.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Artistic-1.0-Perl.json",
-      "referenceNumber": "363",
+      "referenceNumber": "369",
       "name": "Artistic License 1.0 (Perl)",
       "licenseId": "Artistic-1.0-Perl",
       "seeAlso": [
@@ -434,11 +434,11 @@
       "reference": "./Artistic-1.0-cl8.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Artistic-1.0-cl8.json",
-      "referenceNumber": "12",
+      "referenceNumber": "13",
       "name": "Artistic License 1.0 w/clause 8",
       "licenseId": "Artistic-1.0-cl8",
       "seeAlso": [
-        "http://opensource.org/licenses/Artistic-1.0"
+        "https://opensource.org/licenses/Artistic-1.0"
       ],
       "isOsiApproved": true
     },
@@ -447,12 +447,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Artistic-2.0.json",
-      "referenceNumber": "182",
+      "referenceNumber": "186",
       "name": "Artistic License 2.0",
       "licenseId": "Artistic-2.0",
       "seeAlso": [
         "http://www.perlfoundation.org/artistic_license_2_0",
-        "http://www.opensource.org/licenses/artistic-license-2.0"
+        "https://opensource.org/licenses/artistic-license-2.0"
       ],
       "isOsiApproved": true
     },
@@ -460,7 +460,7 @@
       "reference": "./BSD-1-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-1-Clause.json",
-      "referenceNumber": "345",
+      "referenceNumber": "351",
       "name": "BSD 1-Clause License",
       "licenseId": "BSD-1-Clause",
       "seeAlso": [
@@ -472,11 +472,11 @@
       "reference": "./BSD-2-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause.json",
-      "referenceNumber": "316",
+      "referenceNumber": "321",
       "name": "BSD 2-Clause \"Simplified\" License",
       "licenseId": "BSD-2-Clause",
       "seeAlso": [
-        "http://www.opensource.org/licenses/BSD-2-Clause"
+        "https://opensource.org/licenses/BSD-2-Clause"
       ],
       "isOsiApproved": true
     },
@@ -485,7 +485,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-FreeBSD.json",
-      "referenceNumber": "115",
+      "referenceNumber": "118",
       "name": "BSD 2-Clause FreeBSD License",
       "licenseId": "BSD-2-Clause-FreeBSD",
       "seeAlso": [
@@ -497,7 +497,7 @@
       "reference": "./BSD-2-Clause-NetBSD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-NetBSD.json",
-      "referenceNumber": "367",
+      "referenceNumber": "373",
       "name": "BSD 2-Clause NetBSD License",
       "licenseId": "BSD-2-Clause-NetBSD",
       "seeAlso": [
@@ -509,7 +509,7 @@
       "reference": "./BSD-2-Clause-Patent.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-Patent.json",
-      "referenceNumber": "162",
+      "referenceNumber": "166",
       "name": "BSD-2-Clause Plus Patent License",
       "licenseId": "BSD-2-Clause-Patent",
       "seeAlso": [
@@ -522,11 +522,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause.json",
-      "referenceNumber": "262",
+      "referenceNumber": "267",
       "name": "BSD 3-Clause \"New\" or \"Revised\" License",
       "licenseId": "BSD-3-Clause",
       "seeAlso": [
-        "http://www.opensource.org/licenses/BSD-3-Clause"
+        "https://opensource.org/licenses/BSD-3-Clause"
       ],
       "isOsiApproved": true
     },
@@ -534,7 +534,7 @@
       "reference": "./BSD-3-Clause-Attribution.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-Attribution.json",
-      "referenceNumber": "37",
+      "referenceNumber": "38",
       "name": "BSD with attribution",
       "licenseId": "BSD-3-Clause-Attribution",
       "seeAlso": [
@@ -547,7 +547,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-Clear.json",
-      "referenceNumber": "205",
+      "referenceNumber": "209",
       "name": "BSD 3-Clause Clear License",
       "licenseId": "BSD-3-Clause-Clear",
       "seeAlso": [
@@ -559,7 +559,7 @@
       "reference": "./BSD-3-Clause-LBNL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-LBNL.json",
-      "referenceNumber": "327",
+      "referenceNumber": "332",
       "name": "Lawrence Berkeley National Labs BSD variant license",
       "licenseId": "BSD-3-Clause-LBNL",
       "seeAlso": [
@@ -571,7 +571,7 @@
       "reference": "./BSD-3-Clause-No-Nuclear-License.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.json",
-      "referenceNumber": "11",
+      "referenceNumber": "12",
       "name": "BSD 3-Clause No Nuclear License",
       "licenseId": "BSD-3-Clause-No-Nuclear-License",
       "seeAlso": [
@@ -583,7 +583,7 @@
       "reference": "./BSD-3-Clause-No-Nuclear-License-2014.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.json",
-      "referenceNumber": "131",
+      "referenceNumber": "134",
       "name": "BSD 3-Clause No Nuclear License 2014",
       "licenseId": "BSD-3-Clause-No-Nuclear-License-2014",
       "seeAlso": [
@@ -595,7 +595,7 @@
       "reference": "./BSD-3-Clause-No-Nuclear-Warranty.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.json",
-      "referenceNumber": "42",
+      "referenceNumber": "43",
       "name": "BSD 3-Clause No Nuclear Warranty",
       "licenseId": "BSD-3-Clause-No-Nuclear-Warranty",
       "seeAlso": [
@@ -608,7 +608,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-4-Clause.json",
-      "referenceNumber": "155",
+      "referenceNumber": "159",
       "name": "BSD 4-Clause \"Original\" or \"Old\" License",
       "licenseId": "BSD-4-Clause",
       "seeAlso": [
@@ -620,7 +620,7 @@
       "reference": "./BSD-4-Clause-UC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-4-Clause-UC.json",
-      "referenceNumber": "196",
+      "referenceNumber": "200",
       "name": "BSD-4-Clause (University of California-Specific)",
       "licenseId": "BSD-4-Clause-UC",
       "seeAlso": [
@@ -632,7 +632,7 @@
       "reference": "./BSD-Protection.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-Protection.json",
-      "referenceNumber": "113",
+      "referenceNumber": "116",
       "name": "BSD Protection License",
       "licenseId": "BSD-Protection",
       "seeAlso": [
@@ -644,7 +644,7 @@
       "reference": "./BSD-Source-Code.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-Source-Code.json",
-      "referenceNumber": "300",
+      "referenceNumber": "305",
       "name": "BSD Source Code Attribution",
       "licenseId": "BSD-Source-Code",
       "seeAlso": [
@@ -657,12 +657,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSL-1.0.json",
-      "referenceNumber": "217",
+      "referenceNumber": "221",
       "name": "Boost Software License 1.0",
       "licenseId": "BSL-1.0",
       "seeAlso": [
         "http://www.boost.org/LICENSE_1_0.txt",
-        "http://www.opensource.org/licenses/BSL-1.0"
+        "https://opensource.org/licenses/BSL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -670,7 +670,7 @@
       "reference": "./Bahyph.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Bahyph.json",
-      "referenceNumber": "353",
+      "referenceNumber": "359",
       "name": "Bahyph License",
       "licenseId": "Bahyph",
       "seeAlso": [
@@ -682,7 +682,7 @@
       "reference": "./Barr.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Barr.json",
-      "referenceNumber": "323",
+      "referenceNumber": "328",
       "name": "Barr License",
       "licenseId": "Barr",
       "seeAlso": [
@@ -694,7 +694,7 @@
       "reference": "./Beerware.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Beerware.json",
-      "referenceNumber": "16",
+      "referenceNumber": "17",
       "name": "Beerware License",
       "licenseId": "Beerware",
       "seeAlso": [
@@ -707,7 +707,7 @@
       "reference": "./BitTorrent-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BitTorrent-1.0.json",
-      "referenceNumber": "211",
+      "referenceNumber": "215",
       "name": "BitTorrent Open Source License v1.0",
       "licenseId": "BitTorrent-1.0",
       "seeAlso": [
@@ -720,7 +720,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BitTorrent-1.1.json",
-      "referenceNumber": "172",
+      "referenceNumber": "176",
       "name": "BitTorrent Open Source License v1.1",
       "licenseId": "BitTorrent-1.1",
       "seeAlso": [
@@ -732,7 +732,7 @@
       "reference": "./Borceux.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Borceux.json",
-      "referenceNumber": "303",
+      "referenceNumber": "308",
       "name": "Borceux license",
       "licenseId": "Borceux",
       "seeAlso": [
@@ -744,11 +744,11 @@
       "reference": "./CATOSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CATOSL-1.1.json",
-      "referenceNumber": "255",
+      "referenceNumber": "259",
       "name": "Computer Associates Trusted Open Source License 1.1",
       "licenseId": "CATOSL-1.1",
       "seeAlso": [
-        "http://opensource.org/licenses/CATOSL-1.1"
+        "https://opensource.org/licenses/CATOSL-1.1"
       ],
       "isOsiApproved": true
     },
@@ -756,11 +756,11 @@
       "reference": "./CC-BY-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-1.0.json",
-      "referenceNumber": "122",
+      "referenceNumber": "125",
       "name": "Creative Commons Attribution 1.0 Generic",
       "licenseId": "CC-BY-1.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by/1.0/legalcode"
+        "https://creativecommons.org/licenses/by/1.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -768,11 +768,11 @@
       "reference": "./CC-BY-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-2.0.json",
-      "referenceNumber": "225",
+      "referenceNumber": "229",
       "name": "Creative Commons Attribution 2.0 Generic",
       "licenseId": "CC-BY-2.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by/2.0/legalcode"
+        "https://creativecommons.org/licenses/by/2.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -780,11 +780,11 @@
       "reference": "./CC-BY-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-2.5.json",
-      "referenceNumber": "123",
+      "referenceNumber": "126",
       "name": "Creative Commons Attribution 2.5 Generic",
       "licenseId": "CC-BY-2.5",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by/2.5/legalcode"
+        "https://creativecommons.org/licenses/by/2.5/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -792,11 +792,11 @@
       "reference": "./CC-BY-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-3.0.json",
-      "referenceNumber": "249",
+      "referenceNumber": "253",
       "name": "Creative Commons Attribution 3.0 Unported",
       "licenseId": "CC-BY-3.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by/3.0/legalcode"
+        "https://creativecommons.org/licenses/by/3.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -805,11 +805,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-4.0.json",
-      "referenceNumber": "321",
+      "referenceNumber": "326",
       "name": "Creative Commons Attribution 4.0 International",
       "licenseId": "CC-BY-4.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by/4.0/legalcode"
+        "https://creativecommons.org/licenses/by/4.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -817,11 +817,11 @@
       "reference": "./CC-BY-NC-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-1.0.json",
-      "referenceNumber": "124",
+      "referenceNumber": "127",
       "name": "Creative Commons Attribution Non Commercial 1.0 Generic",
       "licenseId": "CC-BY-NC-1.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc/1.0/legalcode"
+        "https://creativecommons.org/licenses/by-nc/1.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -829,11 +829,11 @@
       "reference": "./CC-BY-NC-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-2.0.json",
-      "referenceNumber": "237",
+      "referenceNumber": "241",
       "name": "Creative Commons Attribution Non Commercial 2.0 Generic",
       "licenseId": "CC-BY-NC-2.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc/2.0/legalcode"
+        "https://creativecommons.org/licenses/by-nc/2.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -845,7 +845,7 @@
       "name": "Creative Commons Attribution Non Commercial 2.5 Generic",
       "licenseId": "CC-BY-NC-2.5",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc/2.5/legalcode"
+        "https://creativecommons.org/licenses/by-nc/2.5/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -853,11 +853,11 @@
       "reference": "./CC-BY-NC-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-3.0.json",
-      "referenceNumber": "248",
+      "referenceNumber": "252",
       "name": "Creative Commons Attribution Non Commercial 3.0 Unported",
       "licenseId": "CC-BY-NC-3.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc/3.0/legalcode"
+        "https://creativecommons.org/licenses/by-nc/3.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -865,11 +865,11 @@
       "reference": "./CC-BY-NC-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-4.0.json",
-      "referenceNumber": "179",
+      "referenceNumber": "183",
       "name": "Creative Commons Attribution Non Commercial 4.0 International",
       "licenseId": "CC-BY-NC-4.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc/4.0/legalcode"
+        "https://creativecommons.org/licenses/by-nc/4.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -877,11 +877,11 @@
       "reference": "./CC-BY-NC-ND-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-1.0.json",
-      "referenceNumber": "57",
+      "referenceNumber": "58",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
       "licenseId": "CC-BY-NC-ND-1.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nd-nc/1.0/legalcode"
+        "https://creativecommons.org/licenses/by-nd-nc/1.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -889,11 +889,11 @@
       "reference": "./CC-BY-NC-ND-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-2.0.json",
-      "referenceNumber": "34",
+      "referenceNumber": "35",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
       "licenseId": "CC-BY-NC-ND-2.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-nd/2.0/legalcode"
+        "https://creativecommons.org/licenses/by-nc-nd/2.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -901,11 +901,11 @@
       "reference": "./CC-BY-NC-ND-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-2.5.json",
-      "referenceNumber": "151",
+      "referenceNumber": "155",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
       "licenseId": "CC-BY-NC-ND-2.5",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-nd/2.5/legalcode"
+        "https://creativecommons.org/licenses/by-nc-nd/2.5/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -913,11 +913,11 @@
       "reference": "./CC-BY-NC-ND-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-3.0.json",
-      "referenceNumber": "46",
+      "referenceNumber": "47",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
       "licenseId": "CC-BY-NC-ND-3.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"
+        "https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -925,11 +925,11 @@
       "reference": "./CC-BY-NC-ND-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-4.0.json",
-      "referenceNumber": "273",
+      "referenceNumber": "278",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
       "licenseId": "CC-BY-NC-ND-4.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-nd/4.0/legalcode"
+        "https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -937,11 +937,11 @@
       "reference": "./CC-BY-NC-SA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-1.0.json",
-      "referenceNumber": "171",
+      "referenceNumber": "175",
       "name": "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
       "licenseId": "CC-BY-NC-SA-1.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-sa/1.0/legalcode"
+        "https://creativecommons.org/licenses/by-nc-sa/1.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -949,11 +949,11 @@
       "reference": "./CC-BY-NC-SA-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-2.0.json",
-      "referenceNumber": "77",
+      "referenceNumber": "79",
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
       "licenseId": "CC-BY-NC-SA-2.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-sa/2.0/legalcode"
+        "https://creativecommons.org/licenses/by-nc-sa/2.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -961,11 +961,11 @@
       "reference": "./CC-BY-NC-SA-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-2.5.json",
-      "referenceNumber": "60",
+      "referenceNumber": "61",
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
       "licenseId": "CC-BY-NC-SA-2.5",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-sa/2.5/legalcode"
+        "https://creativecommons.org/licenses/by-nc-sa/2.5/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -973,11 +973,11 @@
       "reference": "./CC-BY-NC-SA-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-3.0.json",
-      "referenceNumber": "21",
+      "referenceNumber": "22",
       "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported",
       "licenseId": "CC-BY-NC-SA-3.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-sa/3.0/legalcode"
+        "https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -985,11 +985,11 @@
       "reference": "./CC-BY-NC-SA-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-4.0.json",
-      "referenceNumber": "45",
+      "referenceNumber": "46",
       "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
       "licenseId": "CC-BY-NC-SA-4.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-sa/4.0/legalcode"
+        "https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -997,11 +997,11 @@
       "reference": "./CC-BY-ND-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-1.0.json",
-      "referenceNumber": "48",
+      "referenceNumber": "49",
       "name": "Creative Commons Attribution No Derivatives 1.0 Generic",
       "licenseId": "CC-BY-ND-1.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nd/1.0/legalcode"
+        "https://creativecommons.org/licenses/by-nd/1.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -1009,7 +1009,7 @@
       "reference": "./CC-BY-ND-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-2.0.json",
-      "referenceNumber": "279",
+      "referenceNumber": "284",
       "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
       "licenseId": "CC-BY-ND-2.0",
       "seeAlso": [
@@ -1021,11 +1021,11 @@
       "reference": "./CC-BY-ND-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-2.5.json",
-      "referenceNumber": "66",
+      "referenceNumber": "67",
       "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
       "licenseId": "CC-BY-ND-2.5",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nd/2.5/legalcode"
+        "https://creativecommons.org/licenses/by-nd/2.5/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -1033,11 +1033,11 @@
       "reference": "./CC-BY-ND-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-3.0.json",
-      "referenceNumber": "379",
+      "referenceNumber": "385",
       "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
       "licenseId": "CC-BY-ND-3.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nd/3.0/legalcode"
+        "https://creativecommons.org/licenses/by-nd/3.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -1045,11 +1045,11 @@
       "reference": "./CC-BY-ND-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-4.0.json",
-      "referenceNumber": "126",
+      "referenceNumber": "129",
       "name": "Creative Commons Attribution No Derivatives 4.0 International",
       "licenseId": "CC-BY-ND-4.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nd/4.0/legalcode"
+        "https://creativecommons.org/licenses/by-nd/4.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -1057,11 +1057,11 @@
       "reference": "./CC-BY-SA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-1.0.json",
-      "referenceNumber": "313",
+      "referenceNumber": "318",
       "name": "Creative Commons Attribution Share Alike 1.0 Generic",
       "licenseId": "CC-BY-SA-1.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-sa/1.0/legalcode"
+        "https://creativecommons.org/licenses/by-sa/1.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -1069,11 +1069,11 @@
       "reference": "./CC-BY-SA-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-2.0.json",
-      "referenceNumber": "136",
+      "referenceNumber": "139",
       "name": "Creative Commons Attribution Share Alike 2.0 Generic",
       "licenseId": "CC-BY-SA-2.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-sa/2.0/legalcode"
+        "https://creativecommons.org/licenses/by-sa/2.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -1081,11 +1081,11 @@
       "reference": "./CC-BY-SA-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-2.5.json",
-      "referenceNumber": "298",
+      "referenceNumber": "303",
       "name": "Creative Commons Attribution Share Alike 2.5 Generic",
       "licenseId": "CC-BY-SA-2.5",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-sa/2.5/legalcode"
+        "https://creativecommons.org/licenses/by-sa/2.5/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -1093,11 +1093,11 @@
       "reference": "./CC-BY-SA-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-3.0.json",
-      "referenceNumber": "380",
+      "referenceNumber": "386",
       "name": "Creative Commons Attribution Share Alike 3.0 Unported",
       "licenseId": "CC-BY-SA-3.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-sa/3.0/legalcode"
+        "https://creativecommons.org/licenses/by-sa/3.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -1106,11 +1106,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-4.0.json",
-      "referenceNumber": "30",
+      "referenceNumber": "31",
       "name": "Creative Commons Attribution Share Alike 4.0 International",
       "licenseId": "CC-BY-SA-4.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-sa/4.0/legalcode"
+        "https://creativecommons.org/licenses/by-sa/4.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -1119,11 +1119,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CC0-1.0.json",
-      "referenceNumber": "206",
+      "referenceNumber": "210",
       "name": "Creative Commons Zero v1.0 Universal",
       "licenseId": "CC0-1.0",
       "seeAlso": [
-        "http://creativecommons.org/publicdomain/zero/1.0/legalcode"
+        "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -1132,11 +1132,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CDDL-1.0.json",
-      "referenceNumber": "132",
+      "referenceNumber": "135",
       "name": "Common Development and Distribution License 1.0",
       "licenseId": "CDDL-1.0",
       "seeAlso": [
-        "http://www.opensource.org/licenses/cddl1"
+        "https://opensource.org/licenses/cddl1"
       ],
       "isOsiApproved": true
     },
@@ -1144,7 +1144,7 @@
       "reference": "./CDDL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CDDL-1.1.json",
-      "referenceNumber": "362",
+      "referenceNumber": "368",
       "name": "Common Development and Distribution License 1.1",
       "licenseId": "CDDL-1.1",
       "seeAlso": [
@@ -1157,7 +1157,7 @@
       "reference": "./CDLA-Permissive-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CDLA-Permissive-1.0.json",
-      "referenceNumber": "243",
+      "referenceNumber": "247",
       "name": "Community Data License Agreement Permissive 1.0",
       "licenseId": "CDLA-Permissive-1.0",
       "seeAlso": [
@@ -1169,7 +1169,7 @@
       "reference": "./CDLA-Sharing-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CDLA-Sharing-1.0.json",
-      "referenceNumber": "302",
+      "referenceNumber": "307",
       "name": "Community Data License Agreement Sharing 1.0",
       "licenseId": "CDLA-Sharing-1.0",
       "seeAlso": [
@@ -1181,7 +1181,7 @@
       "reference": "./CECILL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CECILL-1.0.json",
-      "referenceNumber": "216",
+      "referenceNumber": "220",
       "name": "CeCILL Free Software License Agreement v1.0",
       "licenseId": "CECILL-1.0",
       "seeAlso": [
@@ -1193,7 +1193,7 @@
       "reference": "./CECILL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CECILL-1.1.json",
-      "referenceNumber": "292",
+      "referenceNumber": "297",
       "name": "CeCILL Free Software License Agreement v1.1",
       "licenseId": "CECILL-1.1",
       "seeAlso": [
@@ -1206,7 +1206,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CECILL-2.0.json",
-      "referenceNumber": "340",
+      "referenceNumber": "346",
       "name": "CeCILL Free Software License Agreement v2.0",
       "licenseId": "CECILL-2.0",
       "seeAlso": [
@@ -1218,7 +1218,7 @@
       "reference": "./CECILL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CECILL-2.1.json",
-      "referenceNumber": "114",
+      "referenceNumber": "117",
       "name": "CeCILL Free Software License Agreement v2.1",
       "licenseId": "CECILL-2.1",
       "seeAlso": [
@@ -1231,7 +1231,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CECILL-B.json",
-      "referenceNumber": "330",
+      "referenceNumber": "335",
       "name": "CeCILL-B Free Software License Agreement",
       "licenseId": "CECILL-B",
       "seeAlso": [
@@ -1244,7 +1244,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CECILL-C.json",
-      "referenceNumber": "73",
+      "referenceNumber": "75",
       "name": "CeCILL-C Free Software License Agreement",
       "licenseId": "CECILL-C",
       "seeAlso": [
@@ -1253,10 +1253,34 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./CERN-OHL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CERN-OHL-1.1.json",
+      "referenceNumber": "336",
+      "name": "CERN Open Hardware License v1.1",
+      "licenseId": "CERN-OHL-1.1",
+      "seeAlso": [
+        "\nhttps://www.ohwr.org/project/licenses/wikis/cern-ohl-v1.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CERN-OHL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CERN-OHL-1.2.json",
+      "referenceNumber": "3",
+      "name": "CERN Open Hardware Licence v1.2",
+      "licenseId": "CERN-OHL-1.2",
+      "seeAlso": [
+        "\nhttps://www.ohwr.org/project/licenses/wikis/cern-ohl-v1.2"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./CNRI-Jython.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CNRI-Jython.json",
-      "referenceNumber": "89",
+      "referenceNumber": "91",
       "name": "CNRI Jython License",
       "licenseId": "CNRI-Jython",
       "seeAlso": [
@@ -1268,11 +1292,11 @@
       "reference": "./CNRI-Python.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CNRI-Python.json",
-      "referenceNumber": "43",
+      "referenceNumber": "44",
       "name": "CNRI Python License",
       "licenseId": "CNRI-Python",
       "seeAlso": [
-        "http://www.opensource.org/licenses/CNRI-Python"
+        "https://opensource.org/licenses/CNRI-Python"
       ],
       "isOsiApproved": true
     },
@@ -1280,7 +1304,7 @@
       "reference": "./CNRI-Python-GPL-Compatible.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CNRI-Python-GPL-Compatible.json",
-      "referenceNumber": "195",
+      "referenceNumber": "199",
       "name": "CNRI Python Open Source GPL Compatible License Agreement",
       "licenseId": "CNRI-Python-GPL-Compatible",
       "seeAlso": [
@@ -1293,11 +1317,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CPAL-1.0.json",
-      "referenceNumber": "163",
+      "referenceNumber": "167",
       "name": "Common Public Attribution License 1.0",
       "licenseId": "CPAL-1.0",
       "seeAlso": [
-        "http://www.opensource.org/licenses/CPAL-1.0"
+        "https://opensource.org/licenses/CPAL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -1306,11 +1330,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CPL-1.0.json",
-      "referenceNumber": "165",
+      "referenceNumber": "169",
       "name": "Common Public License 1.0",
       "licenseId": "CPL-1.0",
       "seeAlso": [
-        "http://opensource.org/licenses/CPL-1.0"
+        "https://opensource.org/licenses/CPL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -1318,7 +1342,7 @@
       "reference": "./CPOL-1.02.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CPOL-1.02.json",
-      "referenceNumber": "26",
+      "referenceNumber": "27",
       "name": "Code Project Open License 1.02",
       "licenseId": "CPOL-1.02",
       "seeAlso": [
@@ -1330,11 +1354,11 @@
       "reference": "./CUA-OPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CUA-OPL-1.0.json",
-      "referenceNumber": "352",
+      "referenceNumber": "358",
       "name": "CUA Office Public License v1.0",
       "licenseId": "CUA-OPL-1.0",
       "seeAlso": [
-        "http://opensource.org/licenses/CUA-OPL-1.0"
+        "https://opensource.org/licenses/CUA-OPL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -1342,7 +1366,7 @@
       "reference": "./Caldera.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Caldera.json",
-      "referenceNumber": "102",
+      "referenceNumber": "105",
       "name": "Caldera License",
       "licenseId": "Caldera",
       "seeAlso": [
@@ -1355,7 +1379,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ClArtistic.json",
-      "referenceNumber": "263",
+      "referenceNumber": "268",
       "name": "Clarified Artistic License",
       "licenseId": "ClArtistic",
       "seeAlso": [
@@ -1369,7 +1393,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Condor-1.1.json",
-      "referenceNumber": "299",
+      "referenceNumber": "304",
       "name": "Condor Public License v1.1",
       "licenseId": "Condor-1.1",
       "seeAlso": [
@@ -1382,7 +1406,7 @@
       "reference": "./Crossword.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Crossword.json",
-      "referenceNumber": "350",
+      "referenceNumber": "356",
       "name": "Crossword License",
       "licenseId": "Crossword",
       "seeAlso": [
@@ -1394,7 +1418,7 @@
       "reference": "./CrystalStacker.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CrystalStacker.json",
-      "referenceNumber": "161",
+      "referenceNumber": "165",
       "name": "CrystalStacker License",
       "licenseId": "CrystalStacker",
       "seeAlso": [
@@ -1406,7 +1430,7 @@
       "reference": "./Cube.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Cube.json",
-      "referenceNumber": "357",
+      "referenceNumber": "363",
       "name": "Cube License",
       "licenseId": "Cube",
       "seeAlso": [
@@ -1418,7 +1442,7 @@
       "reference": "./D-FSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/D-FSL-1.0.json",
-      "referenceNumber": "175",
+      "referenceNumber": "179",
       "name": "Deutsche Freie Software Lizenz",
       "licenseId": "D-FSL-1.0",
       "seeAlso": [
@@ -1437,7 +1461,7 @@
       "reference": "./DOC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/DOC.json",
-      "referenceNumber": "153",
+      "referenceNumber": "157",
       "name": "DOC License",
       "licenseId": "DOC",
       "seeAlso": [
@@ -1449,7 +1473,7 @@
       "reference": "./DSDP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/DSDP.json",
-      "referenceNumber": "135",
+      "referenceNumber": "138",
       "name": "DSDP License",
       "licenseId": "DSDP",
       "seeAlso": [
@@ -1461,7 +1485,7 @@
       "reference": "./Dotseqn.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Dotseqn.json",
-      "referenceNumber": "376",
+      "referenceNumber": "382",
       "name": "Dotseqn License",
       "licenseId": "Dotseqn",
       "seeAlso": [
@@ -1473,11 +1497,11 @@
       "reference": "./ECL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ECL-1.0.json",
-      "referenceNumber": "382",
+      "referenceNumber": "388",
       "name": "Educational Community License v1.0",
       "licenseId": "ECL-1.0",
       "seeAlso": [
-        "http://opensource.org/licenses/ECL-1.0"
+        "https://opensource.org/licenses/ECL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -1486,11 +1510,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ECL-2.0.json",
-      "referenceNumber": "290",
+      "referenceNumber": "295",
       "name": "Educational Community License v2.0",
       "licenseId": "ECL-2.0",
       "seeAlso": [
-        "http://opensource.org/licenses/ECL-2.0"
+        "https://opensource.org/licenses/ECL-2.0"
       ],
       "isOsiApproved": true
     },
@@ -1498,12 +1522,12 @@
       "reference": "./EFL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/EFL-1.0.json",
-      "referenceNumber": "143",
+      "referenceNumber": "147",
       "name": "Eiffel Forum License v1.0",
       "licenseId": "EFL-1.0",
       "seeAlso": [
         "http://www.eiffel-nice.org/license/forum.txt",
-        "http://opensource.org/licenses/EFL-1.0"
+        "https://opensource.org/licenses/EFL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -1512,12 +1536,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EFL-2.0.json",
-      "referenceNumber": "154",
+      "referenceNumber": "158",
       "name": "Eiffel Forum License v2.0",
       "licenseId": "EFL-2.0",
       "seeAlso": [
         "http://www.eiffel-nice.org/license/eiffel-forum-license-2.html",
-        "http://opensource.org/licenses/EFL-2.0"
+        "https://opensource.org/licenses/EFL-2.0"
       ],
       "isOsiApproved": true
     },
@@ -1526,12 +1550,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EPL-1.0.json",
-      "referenceNumber": "207",
+      "referenceNumber": "211",
       "name": "Eclipse Public License 1.0",
       "licenseId": "EPL-1.0",
       "seeAlso": [
         "http://www.eclipse.org/legal/epl-v10.html",
-        "http://www.opensource.org/licenses/EPL-1.0"
+        "https://opensource.org/licenses/EPL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -1540,7 +1564,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EPL-2.0.json",
-      "referenceNumber": "128",
+      "referenceNumber": "131",
       "name": "Eclipse Public License 2.0",
       "licenseId": "EPL-2.0",
       "seeAlso": [
@@ -1554,12 +1578,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EUDatagrid.json",
-      "referenceNumber": "185",
+      "referenceNumber": "189",
       "name": "EU DataGrid Software License",
       "licenseId": "EUDatagrid",
       "seeAlso": [
         "http://eu-datagrid.web.cern.ch/eu-datagrid/license.html",
-        "http://www.opensource.org/licenses/EUDatagrid"
+        "https://opensource.org/licenses/EUDatagrid"
       ],
       "isOsiApproved": true
     },
@@ -1567,7 +1591,7 @@
       "reference": "./EUPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/EUPL-1.0.json",
-      "referenceNumber": "166",
+      "referenceNumber": "170",
       "name": "European Union Public License 1.0",
       "licenseId": "EUPL-1.0",
       "seeAlso": [
@@ -1581,13 +1605,13 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EUPL-1.1.json",
-      "referenceNumber": "87",
+      "referenceNumber": "89",
       "name": "European Union Public License 1.1",
       "licenseId": "EUPL-1.1",
       "seeAlso": [
         "https://joinup.ec.europa.eu/software/page/eupl/licence-eupl",
         "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl1.1.-licence-en_0.pdf",
-        "http://www.opensource.org/licenses/EUPL-1.1"
+        "https://opensource.org/licenses/EUPL-1.1"
       ],
       "isOsiApproved": true
     },
@@ -1596,7 +1620,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EUPL-1.2.json",
-      "referenceNumber": "373",
+      "referenceNumber": "379",
       "name": "European Union Public License 1.2",
       "licenseId": "EUPL-1.2",
       "seeAlso": [
@@ -1604,7 +1628,7 @@
         "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl_v1.2_en.pdf",
         "https://joinup.ec.europa.eu/sites/default/files/inline-files/EUPL%20v1_2%20EN(1).txt",
         "http://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri\u003dCELEX:32017D0863",
-        "http://www.opensource.org/licenses/EUPL-1.1"
+        "https://opensource.org/licenses/EUPL-1.1"
       ],
       "isOsiApproved": true
     },
@@ -1612,11 +1636,11 @@
       "reference": "./Entessa.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Entessa.json",
-      "referenceNumber": "94",
+      "referenceNumber": "96",
       "name": "Entessa Public License v1.0",
       "licenseId": "Entessa",
       "seeAlso": [
-        "http://opensource.org/licenses/Entessa"
+        "https://opensource.org/licenses/Entessa"
       ],
       "isOsiApproved": true
     },
@@ -1624,7 +1648,7 @@
       "reference": "./ErlPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ErlPL-1.1.json",
-      "referenceNumber": "150",
+      "referenceNumber": "154",
       "name": "Erlang Public License v1.1",
       "licenseId": "ErlPL-1.1",
       "seeAlso": [
@@ -1636,7 +1660,7 @@
       "reference": "./Eurosym.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Eurosym.json",
-      "referenceNumber": "107",
+      "referenceNumber": "110",
       "name": "Eurosym License",
       "licenseId": "Eurosym",
       "seeAlso": [
@@ -1649,11 +1673,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/FSFAP.json",
-      "referenceNumber": "108",
+      "referenceNumber": "111",
       "name": "FSF All Permissive License",
       "licenseId": "FSFAP",
       "seeAlso": [
-        "http://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html"
+        "https://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html"
       ],
       "isOsiApproved": false
     },
@@ -1661,7 +1685,7 @@
       "reference": "./FSFUL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/FSFUL.json",
-      "referenceNumber": "186",
+      "referenceNumber": "190",
       "name": "FSF Unlimited License",
       "licenseId": "FSFUL",
       "seeAlso": [
@@ -1673,7 +1697,7 @@
       "reference": "./FSFULLR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/FSFULLR.json",
-      "referenceNumber": "41",
+      "referenceNumber": "42",
       "name": "FSF Unlimited License (with License Retention)",
       "licenseId": "FSFULLR",
       "seeAlso": [
@@ -1686,7 +1710,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/FTL.json",
-      "referenceNumber": "233",
+      "referenceNumber": "237",
       "name": "Freetype Project License",
       "licenseId": "FTL",
       "seeAlso": [
@@ -1699,12 +1723,12 @@
       "reference": "./Fair.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Fair.json",
-      "referenceNumber": "289",
+      "referenceNumber": "294",
       "name": "Fair License",
       "licenseId": "Fair",
       "seeAlso": [
         "http://fairlicense.org/",
-        "http://www.opensource.org/licenses/Fair"
+        "https://opensource.org/licenses/Fair"
       ],
       "isOsiApproved": true
     },
@@ -1712,11 +1736,11 @@
       "reference": "./Frameworx-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Frameworx-1.0.json",
-      "referenceNumber": "375",
+      "referenceNumber": "381",
       "name": "Frameworx Open License 1.0",
       "licenseId": "Frameworx-1.0",
       "seeAlso": [
-        "http://www.opensource.org/licenses/Frameworx-1.0"
+        "https://opensource.org/licenses/Frameworx-1.0"
       ],
       "isOsiApproved": true
     },
@@ -1724,7 +1748,7 @@
       "reference": "./FreeImage.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/FreeImage.json",
-      "referenceNumber": "269",
+      "referenceNumber": "274",
       "name": "FreeImage Public License v1.0",
       "licenseId": "FreeImage",
       "seeAlso": [
@@ -1737,11 +1761,11 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.1.json",
-      "referenceNumber": "93",
+      "referenceNumber": "95",
       "name": "GNU Free Documentation License v1.1",
       "licenseId": "GFDL-1.1",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
       ],
       "isOsiApproved": false
     },
@@ -1750,11 +1774,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-only.json",
-      "referenceNumber": "97",
+      "referenceNumber": "99",
       "name": "GNU Free Documentation License v1.1 only",
       "licenseId": "GFDL-1.1-only",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
       ],
       "isOsiApproved": false
     },
@@ -1763,11 +1787,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-or-later.json",
-      "referenceNumber": "337",
+      "referenceNumber": "343",
       "name": "GNU Free Documentation License v1.1 or later",
       "licenseId": "GFDL-1.1-or-later",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
       ],
       "isOsiApproved": false
     },
@@ -1776,11 +1800,11 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.2.json",
-      "referenceNumber": "190",
+      "referenceNumber": "194",
       "name": "GNU Free Documentation License v1.2",
       "licenseId": "GFDL-1.2",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
       ],
       "isOsiApproved": false
     },
@@ -1789,11 +1813,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-only.json",
-      "referenceNumber": "229",
+      "referenceNumber": "233",
       "name": "GNU Free Documentation License v1.2 only",
       "licenseId": "GFDL-1.2-only",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
       ],
       "isOsiApproved": false
     },
@@ -1802,11 +1826,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-or-later.json",
-      "referenceNumber": "208",
+      "referenceNumber": "212",
       "name": "GNU Free Documentation License v1.2 or later",
       "licenseId": "GFDL-1.2-or-later",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
       ],
       "isOsiApproved": false
     },
@@ -1815,11 +1839,11 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.3.json",
-      "referenceNumber": "106",
+      "referenceNumber": "109",
       "name": "GNU Free Documentation License v1.3",
       "licenseId": "GFDL-1.3",
       "seeAlso": [
-        "http://www.gnu.org/licenses/fdl-1.3.txt"
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
       ],
       "isOsiApproved": false
     },
@@ -1828,11 +1852,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-only.json",
-      "referenceNumber": "67",
+      "referenceNumber": "68",
       "name": "GNU Free Documentation License v1.3 only",
       "licenseId": "GFDL-1.3-only",
       "seeAlso": [
-        "http://www.gnu.org/licenses/fdl-1.3.txt"
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
       ],
       "isOsiApproved": false
     },
@@ -1841,11 +1865,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-or-later.json",
-      "referenceNumber": "3",
+      "referenceNumber": "4",
       "name": "GNU Free Documentation License v1.3 or later",
       "licenseId": "GFDL-1.3-or-later",
       "seeAlso": [
-        "http://www.gnu.org/licenses/fdl-1.3.txt"
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
       ],
       "isOsiApproved": false
     },
@@ -1853,7 +1877,7 @@
       "reference": "./GL2PS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/GL2PS.json",
-      "referenceNumber": "118",
+      "referenceNumber": "121",
       "name": "GL2PS License",
       "licenseId": "GL2PS",
       "seeAlso": [
@@ -1865,11 +1889,11 @@
       "reference": "./GPL-1.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-1.0.json",
-      "referenceNumber": "75",
+      "referenceNumber": "77",
       "name": "GNU General Public License v1.0 only",
       "licenseId": "GPL-1.0",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
       ],
       "isOsiApproved": false
     },
@@ -1877,11 +1901,11 @@
       "reference": "./GPL-1.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-1.0+.json",
-      "referenceNumber": "168",
+      "referenceNumber": "172",
       "name": "GNU General Public License v1.0 or later",
       "licenseId": "GPL-1.0+",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
       ],
       "isOsiApproved": false
     },
@@ -1889,11 +1913,11 @@
       "reference": "./GPL-1.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/GPL-1.0-only.json",
-      "referenceNumber": "14",
+      "referenceNumber": "15",
       "name": "GNU General Public License v1.0 only",
       "licenseId": "GPL-1.0-only",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
       ],
       "isOsiApproved": false
     },
@@ -1901,11 +1925,11 @@
       "reference": "./GPL-1.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/GPL-1.0-or-later.json",
-      "referenceNumber": "344",
+      "referenceNumber": "350",
       "name": "GNU General Public License v1.0 or later",
       "licenseId": "GPL-1.0-or-later",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
       ],
       "isOsiApproved": false
     },
@@ -1914,12 +1938,12 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0.json",
-      "referenceNumber": "140",
+      "referenceNumber": "144",
       "name": "GNU General Public License v2.0 only",
       "licenseId": "GPL-2.0",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-2.0"
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://opensource.org/licenses/GPL-2.0"
       ],
       "isOsiApproved": true
     },
@@ -1928,12 +1952,12 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0+.json",
-      "referenceNumber": "72",
+      "referenceNumber": "73",
       "name": "GNU General Public License v2.0 or later",
       "licenseId": "GPL-2.0+",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-2.0"
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://opensource.org/licenses/GPL-2.0"
       ],
       "isOsiApproved": true
     },
@@ -1942,12 +1966,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-only.json",
-      "referenceNumber": "226",
+      "referenceNumber": "230",
       "name": "GNU General Public License v2.0 only",
       "licenseId": "GPL-2.0-only",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-2.0"
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://opensource.org/licenses/GPL-2.0"
       ],
       "isOsiApproved": true
     },
@@ -1956,12 +1980,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-or-later.json",
-      "referenceNumber": "54",
+      "referenceNumber": "55",
       "name": "GNU General Public License v2.0 or later",
       "licenseId": "GPL-2.0-or-later",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-2.0"
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://opensource.org/licenses/GPL-2.0"
       ],
       "isOsiApproved": true
     },
@@ -1969,7 +1993,7 @@
       "reference": "./GPL-2.0-with-GCC-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-GCC-exception.json",
-      "referenceNumber": "111",
+      "referenceNumber": "114",
       "name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
       "licenseId": "GPL-2.0-with-GCC-exception",
       "seeAlso": [
@@ -1981,7 +2005,7 @@
       "reference": "./GPL-2.0-with-autoconf-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-autoconf-exception.json",
-      "referenceNumber": "343",
+      "referenceNumber": "349",
       "name": "GNU General Public License v2.0 w/Autoconf exception",
       "licenseId": "GPL-2.0-with-autoconf-exception",
       "seeAlso": [
@@ -1993,7 +2017,7 @@
       "reference": "./GPL-2.0-with-bison-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-bison-exception.json",
-      "referenceNumber": "364",
+      "referenceNumber": "370",
       "name": "GNU General Public License v2.0 w/Bison exception",
       "licenseId": "GPL-2.0-with-bison-exception",
       "seeAlso": [
@@ -2005,11 +2029,11 @@
       "reference": "./GPL-2.0-with-classpath-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-classpath-exception.json",
-      "referenceNumber": "58",
+      "referenceNumber": "59",
       "name": "GNU General Public License v2.0 w/Classpath exception",
       "licenseId": "GPL-2.0-with-classpath-exception",
       "seeAlso": [
-        "http://www.gnu.org/software/classpath/license.html"
+        "https://www.gnu.org/software/classpath/license.html"
       ],
       "isOsiApproved": false
     },
@@ -2017,11 +2041,11 @@
       "reference": "./GPL-2.0-with-font-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-font-exception.json",
-      "referenceNumber": "361",
+      "referenceNumber": "367",
       "name": "GNU General Public License v2.0 w/Font exception",
       "licenseId": "GPL-2.0-with-font-exception",
       "seeAlso": [
-        "http://www.gnu.org/licenses/gpl-faq.html#FontException"
+        "https://www.gnu.org/licenses/gpl-faq.html#FontException"
       ],
       "isOsiApproved": false
     },
@@ -2030,12 +2054,12 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0.json",
-      "referenceNumber": "235",
+      "referenceNumber": "239",
       "name": "GNU General Public License v3.0 only",
       "licenseId": "GPL-3.0",
       "seeAlso": [
-        "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-3.0"
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
       ],
       "isOsiApproved": true
     },
@@ -2044,12 +2068,12 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0+.json",
-      "referenceNumber": "70",
+      "referenceNumber": "71",
       "name": "GNU General Public License v3.0 or later",
       "licenseId": "GPL-3.0+",
       "seeAlso": [
-        "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-3.0"
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
       ],
       "isOsiApproved": true
     },
@@ -2058,12 +2082,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0-only.json",
-      "referenceNumber": "199",
+      "referenceNumber": "203",
       "name": "GNU General Public License v3.0 only",
       "licenseId": "GPL-3.0-only",
       "seeAlso": [
-        "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-3.0"
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
       ],
       "isOsiApproved": true
     },
@@ -2072,12 +2096,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0-or-later.json",
-      "referenceNumber": "189",
+      "referenceNumber": "193",
       "name": "GNU General Public License v3.0 or later",
       "licenseId": "GPL-3.0-or-later",
       "seeAlso": [
-        "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-3.0"
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
       ],
       "isOsiApproved": true
     },
@@ -2085,11 +2109,11 @@
       "reference": "./GPL-3.0-with-GCC-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0-with-GCC-exception.json",
-      "referenceNumber": "214",
+      "referenceNumber": "218",
       "name": "GNU General Public License v3.0 w/GCC Runtime Library exception",
       "licenseId": "GPL-3.0-with-GCC-exception",
       "seeAlso": [
-        "http://www.gnu.org/licenses/gcc-exception-3.1.html"
+        "https://www.gnu.org/licenses/gcc-exception-3.1.html"
       ],
       "isOsiApproved": true
     },
@@ -2097,11 +2121,11 @@
       "reference": "./GPL-3.0-with-autoconf-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0-with-autoconf-exception.json",
-      "referenceNumber": "228",
+      "referenceNumber": "232",
       "name": "GNU General Public License v3.0 w/Autoconf exception",
       "licenseId": "GPL-3.0-with-autoconf-exception",
       "seeAlso": [
-        "http://www.gnu.org/licenses/autoconf-exception-3.0.html"
+        "https://www.gnu.org/licenses/autoconf-exception-3.0.html"
       ],
       "isOsiApproved": false
     },
@@ -2109,7 +2133,7 @@
       "reference": "./Giftware.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Giftware.json",
-      "referenceNumber": "356",
+      "referenceNumber": "362",
       "name": "Giftware License",
       "licenseId": "Giftware",
       "seeAlso": [
@@ -2121,7 +2145,7 @@
       "reference": "./Glide.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Glide.json",
-      "referenceNumber": "360",
+      "referenceNumber": "366",
       "name": "3dfx Glide License",
       "licenseId": "Glide",
       "seeAlso": [
@@ -2133,7 +2157,7 @@
       "reference": "./Glulxe.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Glulxe.json",
-      "referenceNumber": "88",
+      "referenceNumber": "90",
       "name": "Glulxe License",
       "licenseId": "Glulxe",
       "seeAlso": [
@@ -2146,19 +2170,31 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/HPND.json",
-      "referenceNumber": "257",
+      "referenceNumber": "261",
       "name": "Historical Permission Notice and Disclaimer",
       "licenseId": "HPND",
       "seeAlso": [
-        "http://www.opensource.org/licenses/HPND"
+        "https://opensource.org/licenses/HPND"
       ],
       "isOsiApproved": true
+    },
+    {
+      "reference": "./HPND-sell-variant.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/HPND-sell-variant.json",
+      "referenceNumber": "142",
+      "name": "Historical Permission Notice and Disclaimer - sell variant",
+      "licenseId": "HPND-sell-variant",
+      "seeAlso": [
+        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/sunrpc/auth_gss/gss_generic_token.c?h\u003dv4.19"
+      ],
+      "isOsiApproved": false
     },
     {
       "reference": "./HaskellReport.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/HaskellReport.json",
-      "referenceNumber": "116",
+      "referenceNumber": "119",
       "name": "Haskell Language Report License",
       "licenseId": "HaskellReport",
       "seeAlso": [
@@ -2170,7 +2206,7 @@
       "reference": "./IBM-pibs.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/IBM-pibs.json",
-      "referenceNumber": "200",
+      "referenceNumber": "204",
       "name": "IBM PowerPC Initialization and Boot Software",
       "licenseId": "IBM-pibs",
       "seeAlso": [
@@ -2182,7 +2218,7 @@
       "reference": "./ICU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ICU.json",
-      "referenceNumber": "187",
+      "referenceNumber": "191",
       "name": "ICU License",
       "licenseId": "ICU",
       "seeAlso": [
@@ -2195,7 +2231,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/IJG.json",
-      "referenceNumber": "53",
+      "referenceNumber": "54",
       "name": "Independent JPEG Group License",
       "licenseId": "IJG",
       "seeAlso": [
@@ -2208,11 +2244,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/IPA.json",
-      "referenceNumber": "304",
+      "referenceNumber": "309",
       "name": "IPA Font License",
       "licenseId": "IPA",
       "seeAlso": [
-        "http://www.opensource.org/licenses/IPA"
+        "https://opensource.org/licenses/IPA"
       ],
       "isOsiApproved": true
     },
@@ -2221,11 +2257,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/IPL-1.0.json",
-      "referenceNumber": "29",
+      "referenceNumber": "30",
       "name": "IBM Public License v1.0",
       "licenseId": "IPL-1.0",
       "seeAlso": [
-        "http://www.opensource.org/licenses/IPL-1.0"
+        "https://opensource.org/licenses/IPL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -2234,12 +2270,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ISC.json",
-      "referenceNumber": "104",
+      "referenceNumber": "107",
       "name": "ISC License",
       "licenseId": "ISC",
       "seeAlso": [
         "https://www.isc.org/downloads/software-support-policy/isc-license/",
-        "http://www.opensource.org/licenses/ISC"
+        "https://opensource.org/licenses/ISC"
       ],
       "isOsiApproved": true
     },
@@ -2247,7 +2283,7 @@
       "reference": "./ImageMagick.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ImageMagick.json",
-      "referenceNumber": "224",
+      "referenceNumber": "228",
       "name": "ImageMagick License",
       "licenseId": "ImageMagick",
       "seeAlso": [
@@ -2260,7 +2296,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Imlib2.json",
-      "referenceNumber": "250",
+      "referenceNumber": "254",
       "name": "Imlib2 License",
       "licenseId": "Imlib2",
       "seeAlso": [
@@ -2273,7 +2309,7 @@
       "reference": "./Info-ZIP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Info-ZIP.json",
-      "referenceNumber": "99",
+      "referenceNumber": "101",
       "name": "Info-ZIP License",
       "licenseId": "Info-ZIP",
       "seeAlso": [
@@ -2286,11 +2322,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Intel.json",
-      "referenceNumber": "160",
+      "referenceNumber": "164",
       "name": "Intel Open Source License",
       "licenseId": "Intel",
       "seeAlso": [
-        "http://opensource.org/licenses/Intel"
+        "https://opensource.org/licenses/Intel"
       ],
       "isOsiApproved": true
     },
@@ -2298,7 +2334,7 @@
       "reference": "./Intel-ACPI.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Intel-ACPI.json",
-      "referenceNumber": "84",
+      "referenceNumber": "86",
       "name": "Intel ACPI Software License Agreement",
       "licenseId": "Intel-ACPI",
       "seeAlso": [
@@ -2310,7 +2346,7 @@
       "reference": "./Interbase-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Interbase-1.0.json",
-      "referenceNumber": "79",
+      "referenceNumber": "81",
       "name": "Interbase Public License v1.0",
       "licenseId": "Interbase-1.0",
       "seeAlso": [
@@ -2319,10 +2355,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./JPNIC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/JPNIC.json",
+      "referenceNumber": "102",
+      "name": "Japan Network Information Center License",
+      "licenseId": "JPNIC",
+      "seeAlso": [
+        "https://gitlab.isc.org/isc-projects/bind9/blob/master/COPYRIGHT#L366"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./JSON.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/JSON.json",
-      "referenceNumber": "358",
+      "referenceNumber": "364",
       "name": "JSON License",
       "licenseId": "JSON",
       "seeAlso": [
@@ -2334,7 +2382,7 @@
       "reference": "./JasPer-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/JasPer-2.0.json",
-      "referenceNumber": "232",
+      "referenceNumber": "236",
       "name": "JasPer License",
       "licenseId": "JasPer-2.0",
       "seeAlso": [
@@ -2346,7 +2394,7 @@
       "reference": "./LAL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LAL-1.2.json",
-      "referenceNumber": "366",
+      "referenceNumber": "372",
       "name": "Licence Art Libre 1.2",
       "licenseId": "LAL-1.2",
       "seeAlso": [
@@ -2358,7 +2406,7 @@
       "reference": "./LAL-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LAL-1.3.json",
-      "referenceNumber": "149",
+      "referenceNumber": "153",
       "name": "Licence Art Libre 1.3",
       "licenseId": "LAL-1.3",
       "seeAlso": [
@@ -2370,11 +2418,11 @@
       "reference": "./LGPL-2.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.0.json",
-      "referenceNumber": "260",
+      "referenceNumber": "265",
       "name": "GNU Library General Public License v2 only",
       "licenseId": "LGPL-2.0",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
       ],
       "isOsiApproved": true
     },
@@ -2382,11 +2430,11 @@
       "reference": "./LGPL-2.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.0+.json",
-      "referenceNumber": "50",
+      "referenceNumber": "51",
       "name": "GNU Library General Public License v2 or later",
       "licenseId": "LGPL-2.0+",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
       ],
       "isOsiApproved": true
     },
@@ -2394,11 +2442,11 @@
       "reference": "./LGPL-2.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.0-only.json",
-      "referenceNumber": "268",
+      "referenceNumber": "273",
       "name": "GNU Library General Public License v2 only",
       "licenseId": "LGPL-2.0-only",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
       ],
       "isOsiApproved": true
     },
@@ -2406,11 +2454,11 @@
       "reference": "./LGPL-2.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.0-or-later.json",
-      "referenceNumber": "210",
+      "referenceNumber": "214",
       "name": "GNU Library General Public License v2 or later",
       "licenseId": "LGPL-2.0-or-later",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
       ],
       "isOsiApproved": true
     },
@@ -2419,12 +2467,12 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.1.json",
-      "referenceNumber": "159",
+      "referenceNumber": "163",
       "name": "GNU Lesser General Public License v2.1 only",
       "licenseId": "LGPL-2.1",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-2.1"
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "https://opensource.org/licenses/LGPL-2.1"
       ],
       "isOsiApproved": true
     },
@@ -2433,12 +2481,12 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.1+.json",
-      "referenceNumber": "62",
+      "referenceNumber": "63",
       "name": "GNU Library General Public License v2.1 or later",
       "licenseId": "LGPL-2.1+",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-2.1"
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "https://opensource.org/licenses/LGPL-2.1"
       ],
       "isOsiApproved": true
     },
@@ -2451,8 +2499,8 @@
       "name": "GNU Lesser General Public License v2.1 only",
       "licenseId": "LGPL-2.1-only",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-2.1"
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "https://opensource.org/licenses/LGPL-2.1"
       ],
       "isOsiApproved": true
     },
@@ -2461,12 +2509,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.1-or-later.json",
-      "referenceNumber": "328",
+      "referenceNumber": "333",
       "name": "GNU Lesser General Public License v2.1 or later",
       "licenseId": "LGPL-2.1-or-later",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-2.1"
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "https://opensource.org/licenses/LGPL-2.1"
       ],
       "isOsiApproved": true
     },
@@ -2475,12 +2523,12 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-3.0.json",
-      "referenceNumber": "203",
+      "referenceNumber": "207",
       "name": "GNU Lesser General Public License v3.0 only",
       "licenseId": "LGPL-3.0",
       "seeAlso": [
-        "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-3.0"
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://opensource.org/licenses/LGPL-3.0"
       ],
       "isOsiApproved": true
     },
@@ -2489,12 +2537,12 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-3.0+.json",
-      "referenceNumber": "145",
+      "referenceNumber": "149",
       "name": "GNU Lesser General Public License v3.0 or later",
       "licenseId": "LGPL-3.0+",
       "seeAlso": [
-        "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-3.0"
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://opensource.org/licenses/LGPL-3.0"
       ],
       "isOsiApproved": true
     },
@@ -2503,12 +2551,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-3.0-only.json",
-      "referenceNumber": "247",
+      "referenceNumber": "251",
       "name": "GNU Lesser General Public License v3.0 only",
       "licenseId": "LGPL-3.0-only",
       "seeAlso": [
-        "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-3.0"
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://opensource.org/licenses/LGPL-3.0"
       ],
       "isOsiApproved": true
     },
@@ -2517,12 +2565,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-3.0-or-later.json",
-      "referenceNumber": "293",
+      "referenceNumber": "298",
       "name": "GNU Lesser General Public License v3.0 or later",
       "licenseId": "LGPL-3.0-or-later",
       "seeAlso": [
-        "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-3.0"
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://opensource.org/licenses/LGPL-3.0"
       ],
       "isOsiApproved": true
     },
@@ -2530,7 +2578,7 @@
       "reference": "./LGPLLR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LGPLLR.json",
-      "referenceNumber": "98",
+      "referenceNumber": "100",
       "name": "Lesser General Public License For Linguistic Resources",
       "licenseId": "LGPLLR",
       "seeAlso": [
@@ -2542,11 +2590,11 @@
       "reference": "./LPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LPL-1.0.json",
-      "referenceNumber": "85",
+      "referenceNumber": "87",
       "name": "Lucent Public License Version 1.0",
       "licenseId": "LPL-1.0",
       "seeAlso": [
-        "http://opensource.org/licenses/LPL-1.0"
+        "https://opensource.org/licenses/LPL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -2555,12 +2603,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LPL-1.02.json",
-      "referenceNumber": "125",
+      "referenceNumber": "128",
       "name": "Lucent Public License v1.02",
       "licenseId": "LPL-1.02",
       "seeAlso": [
         "http://plan9.bell-labs.com/plan9/license.html",
-        "http://www.opensource.org/licenses/LPL-1.02"
+        "https://opensource.org/licenses/LPL-1.02"
       ],
       "isOsiApproved": true
     },
@@ -2568,7 +2616,7 @@
       "reference": "./LPPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.0.json",
-      "referenceNumber": "252",
+      "referenceNumber": "256",
       "name": "LaTeX Project Public License v1.0",
       "licenseId": "LPPL-1.0",
       "seeAlso": [
@@ -2580,7 +2628,7 @@
       "reference": "./LPPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.1.json",
-      "referenceNumber": "301",
+      "referenceNumber": "306",
       "name": "LaTeX Project Public License v1.1",
       "licenseId": "LPPL-1.1",
       "seeAlso": [
@@ -2593,7 +2641,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.2.json",
-      "referenceNumber": "378",
+      "referenceNumber": "384",
       "name": "LaTeX Project Public License v1.2",
       "licenseId": "LPPL-1.2",
       "seeAlso": [
@@ -2606,7 +2654,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.3a.json",
-      "referenceNumber": "297",
+      "referenceNumber": "302",
       "name": "LaTeX Project Public License v1.3a",
       "licenseId": "LPPL-1.3a",
       "seeAlso": [
@@ -2618,12 +2666,12 @@
       "reference": "./LPPL-1.3c.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.3c.json",
-      "referenceNumber": "317",
+      "referenceNumber": "322",
       "name": "LaTeX Project Public License v1.3c",
       "licenseId": "LPPL-1.3c",
       "seeAlso": [
         "http://www.latex-project.org/lppl/lppl-1-3c.txt",
-        "http://www.opensource.org/licenses/LPPL-1.3c"
+        "https://opensource.org/licenses/LPPL-1.3c"
       ],
       "isOsiApproved": true
     },
@@ -2631,7 +2679,7 @@
       "reference": "./Latex2e.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Latex2e.json",
-      "referenceNumber": "275",
+      "referenceNumber": "280",
       "name": "Latex2e License",
       "licenseId": "Latex2e",
       "seeAlso": [
@@ -2643,7 +2691,7 @@
       "reference": "./Leptonica.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Leptonica.json",
-      "referenceNumber": "152",
+      "referenceNumber": "156",
       "name": "Leptonica License",
       "licenseId": "Leptonica",
       "seeAlso": [
@@ -2655,7 +2703,7 @@
       "reference": "./LiLiQ-P-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LiLiQ-P-1.1.json",
-      "referenceNumber": "365",
+      "referenceNumber": "371",
       "name": "Licence Libre du Québec – Permissive version 1.1",
       "licenseId": "LiLiQ-P-1.1",
       "seeAlso": [
@@ -2668,7 +2716,7 @@
       "reference": "./LiLiQ-R-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LiLiQ-R-1.1.json",
-      "referenceNumber": "278",
+      "referenceNumber": "283",
       "name": "Licence Libre du Québec – Réciprocité version 1.1",
       "licenseId": "LiLiQ-R-1.1",
       "seeAlso": [
@@ -2681,7 +2729,7 @@
       "reference": "./LiLiQ-Rplus-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LiLiQ-Rplus-1.1.json",
-      "referenceNumber": "133",
+      "referenceNumber": "136",
       "name": "Licence Libre du Québec – Réciprocité forte version 1.1",
       "licenseId": "LiLiQ-Rplus-1.1",
       "seeAlso": [
@@ -2694,7 +2742,7 @@
       "reference": "./Libpng.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Libpng.json",
-      "referenceNumber": "96",
+      "referenceNumber": "98",
       "name": "libpng License",
       "licenseId": "Libpng",
       "seeAlso": [
@@ -2706,7 +2754,7 @@
       "reference": "./Linux-OpenIB.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Linux-OpenIB.json",
-      "referenceNumber": "4",
+      "referenceNumber": "5",
       "name": "Linux Kernel Variant of OpenIB.org license",
       "licenseId": "Linux-OpenIB",
       "seeAlso": [
@@ -2719,11 +2767,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/MIT.json",
-      "referenceNumber": "194",
+      "referenceNumber": "198",
       "name": "MIT License",
       "licenseId": "MIT",
       "seeAlso": [
-        "http://www.opensource.org/licenses/MIT"
+        "https://opensource.org/licenses/MIT"
       ],
       "isOsiApproved": true
     },
@@ -2731,7 +2779,7 @@
       "reference": "./MIT-0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MIT-0.json",
-      "referenceNumber": "5",
+      "referenceNumber": "6",
       "name": "MIT No Attribution",
       "licenseId": "MIT-0",
       "seeAlso": [
@@ -2745,11 +2793,12 @@
       "reference": "./MIT-CMU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MIT-CMU.json",
-      "referenceNumber": "8",
+      "referenceNumber": "9",
       "name": "CMU License",
       "licenseId": "MIT-CMU",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing:MIT?rd\u003dLicensing/MIT#CMU_Style"
+        "https://fedoraproject.org/wiki/Licensing:MIT?rd\u003dLicensing/MIT#CMU_Style",
+        "https://github.com/python-pillow/Pillow/blob/fffb426092c8db24a5f4b6df243a8a3c01fb63cd/LICENSE"
       ],
       "isOsiApproved": false
     },
@@ -2757,7 +2806,7 @@
       "reference": "./MIT-advertising.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MIT-advertising.json",
-      "referenceNumber": "7",
+      "referenceNumber": "8",
       "name": "Enlightenment License (e16)",
       "licenseId": "MIT-advertising",
       "seeAlso": [
@@ -2769,7 +2818,7 @@
       "reference": "./MIT-enna.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MIT-enna.json",
-      "referenceNumber": "23",
+      "referenceNumber": "24",
       "name": "enna License",
       "licenseId": "MIT-enna",
       "seeAlso": [
@@ -2781,7 +2830,7 @@
       "reference": "./MIT-feh.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MIT-feh.json",
-      "referenceNumber": "36",
+      "referenceNumber": "37",
       "name": "feh License",
       "licenseId": "MIT-feh",
       "seeAlso": [
@@ -2793,7 +2842,7 @@
       "reference": "./MITNFA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MITNFA.json",
-      "referenceNumber": "286",
+      "referenceNumber": "291",
       "name": "MIT +no-false-attribs license",
       "licenseId": "MITNFA",
       "seeAlso": [
@@ -2805,12 +2854,12 @@
       "reference": "./MPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MPL-1.0.json",
-      "referenceNumber": "47",
+      "referenceNumber": "48",
       "name": "Mozilla Public License 1.0",
       "licenseId": "MPL-1.0",
       "seeAlso": [
         "http://www.mozilla.org/MPL/MPL-1.0.html",
-        "http://opensource.org/licenses/MPL-1.0"
+        "https://opensource.org/licenses/MPL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -2819,12 +2868,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/MPL-1.1.json",
-      "referenceNumber": "296",
+      "referenceNumber": "301",
       "name": "Mozilla Public License 1.1",
       "licenseId": "MPL-1.1",
       "seeAlso": [
         "http://www.mozilla.org/MPL/MPL-1.1.html",
-        "http://www.opensource.org/licenses/MPL-1.1"
+        "https://opensource.org/licenses/MPL-1.1"
       ],
       "isOsiApproved": true
     },
@@ -2833,12 +2882,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/MPL-2.0.json",
-      "referenceNumber": "227",
+      "referenceNumber": "231",
       "name": "Mozilla Public License 2.0",
       "licenseId": "MPL-2.0",
       "seeAlso": [
         "http://www.mozilla.org/MPL/2.0/",
-        "http://opensource.org/licenses/MPL-2.0"
+        "https://opensource.org/licenses/MPL-2.0"
       ],
       "isOsiApproved": true
     },
@@ -2846,12 +2895,12 @@
       "reference": "./MPL-2.0-no-copyleft-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MPL-2.0-no-copyleft-exception.json",
-      "referenceNumber": "295",
+      "referenceNumber": "300",
       "name": "Mozilla Public License 2.0 (no copyleft exception)",
       "licenseId": "MPL-2.0-no-copyleft-exception",
       "seeAlso": [
         "http://www.mozilla.org/MPL/2.0/",
-        "http://opensource.org/licenses/MPL-2.0"
+        "https://opensource.org/licenses/MPL-2.0"
       ],
       "isOsiApproved": true
     },
@@ -2860,12 +2909,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/MS-PL.json",
-      "referenceNumber": "326",
+      "referenceNumber": "331",
       "name": "Microsoft Public License",
       "licenseId": "MS-PL",
       "seeAlso": [
         "http://www.microsoft.com/opensource/licenses.mspx",
-        "http://www.opensource.org/licenses/MS-PL"
+        "https://opensource.org/licenses/MS-PL"
       ],
       "isOsiApproved": true
     },
@@ -2874,12 +2923,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/MS-RL.json",
-      "referenceNumber": "272",
+      "referenceNumber": "277",
       "name": "Microsoft Reciprocal License",
       "licenseId": "MS-RL",
       "seeAlso": [
         "http://www.microsoft.com/opensource/licenses.mspx",
-        "http://www.opensource.org/licenses/MS-RL"
+        "https://opensource.org/licenses/MS-RL"
       ],
       "isOsiApproved": true
     },
@@ -2887,7 +2936,7 @@
       "reference": "./MTLL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MTLL.json",
-      "referenceNumber": "174",
+      "referenceNumber": "178",
       "name": "Matrix Template Library License",
       "licenseId": "MTLL",
       "seeAlso": [
@@ -2899,7 +2948,7 @@
       "reference": "./MakeIndex.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MakeIndex.json",
-      "referenceNumber": "180",
+      "referenceNumber": "184",
       "name": "MakeIndex License",
       "licenseId": "MakeIndex",
       "seeAlso": [
@@ -2911,11 +2960,11 @@
       "reference": "./MirOS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MirOS.json",
-      "referenceNumber": "291",
+      "referenceNumber": "296",
       "name": "MirOS License",
       "licenseId": "MirOS",
       "seeAlso": [
-        "http://www.opensource.org/licenses/MirOS"
+        "https://opensource.org/licenses/MirOS"
       ],
       "isOsiApproved": true
     },
@@ -2923,11 +2972,11 @@
       "reference": "./Motosoto.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Motosoto.json",
-      "referenceNumber": "308",
+      "referenceNumber": "313",
       "name": "Motosoto License",
       "licenseId": "Motosoto",
       "seeAlso": [
-        "http://www.opensource.org/licenses/Motosoto"
+        "https://opensource.org/licenses/Motosoto"
       ],
       "isOsiApproved": true
     },
@@ -2935,11 +2984,11 @@
       "reference": "./Multics.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Multics.json",
-      "referenceNumber": "61",
+      "referenceNumber": "62",
       "name": "Multics License",
       "licenseId": "Multics",
       "seeAlso": [
-        "http://www.opensource.org/licenses/Multics"
+        "https://opensource.org/licenses/Multics"
       ],
       "isOsiApproved": true
     },
@@ -2947,7 +2996,7 @@
       "reference": "./Mup.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Mup.json",
-      "referenceNumber": "341",
+      "referenceNumber": "347",
       "name": "Mup License",
       "licenseId": "Mup",
       "seeAlso": [
@@ -2959,12 +3008,12 @@
       "reference": "./NASA-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NASA-1.3.json",
-      "referenceNumber": "83",
+      "referenceNumber": "85",
       "name": "NASA Open Source Agreement 1.3",
       "licenseId": "NASA-1.3",
       "seeAlso": [
         "http://ti.arc.nasa.gov/opensource/nosa/",
-        "http://www.opensource.org/licenses/NASA-1.3"
+        "https://opensource.org/licenses/NASA-1.3"
       ],
       "isOsiApproved": true
     },
@@ -2972,7 +3021,7 @@
       "reference": "./NBPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NBPL-1.0.json",
-      "referenceNumber": "348",
+      "referenceNumber": "354",
       "name": "Net Boolean Public License v1",
       "licenseId": "NBPL-1.0",
       "seeAlso": [
@@ -2985,12 +3034,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/NCSA.json",
-      "referenceNumber": "56",
+      "referenceNumber": "57",
       "name": "University of Illinois/NCSA Open Source License",
       "licenseId": "NCSA",
       "seeAlso": [
         "http://otm.illinois.edu/uiuc_openSource",
-        "http://www.opensource.org/licenses/NCSA"
+        "https://opensource.org/licenses/NCSA"
       ],
       "isOsiApproved": true
     },
@@ -2998,11 +3047,11 @@
       "reference": "./NGPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NGPL.json",
-      "referenceNumber": "69",
+      "referenceNumber": "70",
       "name": "Nethack General Public License",
       "licenseId": "NGPL",
       "seeAlso": [
-        "http://www.opensource.org/licenses/NGPL"
+        "https://opensource.org/licenses/NGPL"
       ],
       "isOsiApproved": true
     },
@@ -3010,7 +3059,7 @@
       "reference": "./NLOD-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NLOD-1.0.json",
-      "referenceNumber": "202",
+      "referenceNumber": "206",
       "name": "Norwegian Licence for Open Government Data",
       "licenseId": "NLOD-1.0",
       "seeAlso": [
@@ -3022,7 +3071,7 @@
       "reference": "./NLPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NLPL.json",
-      "referenceNumber": "333",
+      "referenceNumber": "339",
       "name": "No Limit Public License",
       "licenseId": "NLPL",
       "seeAlso": [
@@ -3035,7 +3084,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/NOSL.json",
-      "referenceNumber": "369",
+      "referenceNumber": "375",
       "name": "Netizen Open Source License",
       "licenseId": "NOSL",
       "seeAlso": [
@@ -3048,7 +3097,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/NPL-1.0.json",
-      "referenceNumber": "319",
+      "referenceNumber": "324",
       "name": "Netscape Public License v1.0",
       "licenseId": "NPL-1.0",
       "seeAlso": [
@@ -3061,7 +3110,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/NPL-1.1.json",
-      "referenceNumber": "178",
+      "referenceNumber": "182",
       "name": "Netscape Public License v1.1",
       "licenseId": "NPL-1.1",
       "seeAlso": [
@@ -3073,11 +3122,11 @@
       "reference": "./NPOSL-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NPOSL-3.0.json",
-      "referenceNumber": "215",
+      "referenceNumber": "219",
       "name": "Non-Profit Open Software License 3.0",
       "licenseId": "NPOSL-3.0",
       "seeAlso": [
-        "http://www.opensource.org/licenses/NOSL3.0"
+        "https://opensource.org/licenses/NOSL3.0"
       ],
       "isOsiApproved": true
     },
@@ -3085,7 +3134,7 @@
       "reference": "./NRL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NRL.json",
-      "referenceNumber": "51",
+      "referenceNumber": "52",
       "name": "NRL License",
       "licenseId": "NRL",
       "seeAlso": [
@@ -3097,11 +3146,11 @@
       "reference": "./NTP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NTP.json",
-      "referenceNumber": "254",
+      "referenceNumber": "258",
       "name": "NTP License",
       "licenseId": "NTP",
       "seeAlso": [
-        "http://www.opensource.org/licenses/NTP"
+        "https://opensource.org/licenses/NTP"
       ],
       "isOsiApproved": true
     },
@@ -3109,11 +3158,11 @@
       "reference": "./Naumen.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Naumen.json",
-      "referenceNumber": "270",
+      "referenceNumber": "275",
       "name": "Naumen Public License",
       "licenseId": "Naumen",
       "seeAlso": [
-        "http://www.opensource.org/licenses/Naumen"
+        "https://opensource.org/licenses/Naumen"
       ],
       "isOsiApproved": true
     },
@@ -3121,7 +3170,7 @@
       "reference": "./Net-SNMP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Net-SNMP.json",
-      "referenceNumber": "276",
+      "referenceNumber": "281",
       "name": "Net-SNMP License",
       "licenseId": "Net-SNMP",
       "seeAlso": [
@@ -3133,7 +3182,7 @@
       "reference": "./NetCDF.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NetCDF.json",
-      "referenceNumber": "44",
+      "referenceNumber": "45",
       "name": "NetCDF license",
       "licenseId": "NetCDF",
       "seeAlso": [
@@ -3145,7 +3194,7 @@
       "reference": "./Newsletr.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Newsletr.json",
-      "referenceNumber": "271",
+      "referenceNumber": "276",
       "name": "Newsletr License",
       "licenseId": "Newsletr",
       "seeAlso": [
@@ -3158,11 +3207,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Nokia.json",
-      "referenceNumber": "318",
+      "referenceNumber": "323",
       "name": "Nokia Open Source License",
       "licenseId": "Nokia",
       "seeAlso": [
-        "http://www.opensource.org/licenses/nokia"
+        "https://opensource.org/licenses/nokia"
       ],
       "isOsiApproved": true
     },
@@ -3170,7 +3219,7 @@
       "reference": "./Noweb.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Noweb.json",
-      "referenceNumber": "351",
+      "referenceNumber": "357",
       "name": "Noweb License",
       "licenseId": "Noweb",
       "seeAlso": [
@@ -3183,7 +3232,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Nunit.json",
-      "referenceNumber": "280",
+      "referenceNumber": "285",
       "name": "Nunit License",
       "licenseId": "Nunit",
       "seeAlso": [
@@ -3195,7 +3244,7 @@
       "reference": "./OCCT-PL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OCCT-PL.json",
-      "referenceNumber": "274",
+      "referenceNumber": "279",
       "name": "Open CASCADE Technology Public License",
       "licenseId": "OCCT-PL",
       "seeAlso": [
@@ -3207,12 +3256,12 @@
       "reference": "./OCLC-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OCLC-2.0.json",
-      "referenceNumber": "105",
+      "referenceNumber": "108",
       "name": "OCLC Research Public License 2.0",
       "licenseId": "OCLC-2.0",
       "seeAlso": [
         "http://www.oclc.org/research/activities/software/license/v2final.htm",
-        "http://www.opensource.org/licenses/OCLC-2.0"
+        "https://opensource.org/licenses/OCLC-2.0"
       ],
       "isOsiApproved": true
     },
@@ -3220,7 +3269,7 @@
       "reference": "./ODC-By-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ODC-By-1.0.json",
-      "referenceNumber": "138",
+      "referenceNumber": "141",
       "name": "Open Data Commons Attribution License v1.0",
       "licenseId": "ODC-By-1.0",
       "seeAlso": [
@@ -3233,7 +3282,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ODbL-1.0.json",
-      "referenceNumber": "239",
+      "referenceNumber": "243",
       "name": "ODC Open Database License v1.0",
       "licenseId": "ODbL-1.0",
       "seeAlso": [
@@ -3246,7 +3295,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OFL-1.0.json",
-      "referenceNumber": "146",
+      "referenceNumber": "150",
       "name": "SIL Open Font License 1.0",
       "licenseId": "OFL-1.0",
       "seeAlso": [
@@ -3259,12 +3308,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OFL-1.1.json",
-      "referenceNumber": "306",
+      "referenceNumber": "311",
       "name": "SIL Open Font License 1.1",
       "licenseId": "OFL-1.1",
       "seeAlso": [
         "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL_web",
-        "http://www.opensource.org/licenses/OFL-1.1"
+        "https://opensource.org/licenses/OFL-1.1"
       ],
       "isOsiApproved": true
     },
@@ -3272,7 +3321,7 @@
       "reference": "./OGL-UK-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OGL-UK-1.0.json",
-      "referenceNumber": "110",
+      "referenceNumber": "113",
       "name": "Open Government Licence v1.0",
       "licenseId": "OGL-UK-1.0",
       "seeAlso": [
@@ -3284,7 +3333,7 @@
       "reference": "./OGL-UK-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OGL-UK-2.0.json",
-      "referenceNumber": "281",
+      "referenceNumber": "286",
       "name": "Open Government Licence v2.0",
       "licenseId": "OGL-UK-2.0",
       "seeAlso": [
@@ -3296,7 +3345,7 @@
       "reference": "./OGL-UK-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OGL-UK-3.0.json",
-      "referenceNumber": "219",
+      "referenceNumber": "223",
       "name": "Open Government Licence v3.0",
       "licenseId": "OGL-UK-3.0",
       "seeAlso": [
@@ -3308,12 +3357,12 @@
       "reference": "./OGTSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OGTSL.json",
-      "referenceNumber": "119",
+      "referenceNumber": "122",
       "name": "Open Group Test Suite License",
       "licenseId": "OGTSL",
       "seeAlso": [
         "http://www.opengroup.org/testing/downloads/The_Open_Group_TSL.txt",
-        "http://www.opensource.org/licenses/OGTSL"
+        "https://opensource.org/licenses/OGTSL"
       ],
       "isOsiApproved": true
     },
@@ -3321,7 +3370,7 @@
       "reference": "./OLDAP-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-1.1.json",
-      "referenceNumber": "92",
+      "referenceNumber": "94",
       "name": "Open LDAP Public License v1.1",
       "licenseId": "OLDAP-1.1",
       "seeAlso": [
@@ -3333,7 +3382,7 @@
       "reference": "./OLDAP-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-1.2.json",
-      "referenceNumber": "183",
+      "referenceNumber": "187",
       "name": "Open LDAP Public License v1.2",
       "licenseId": "OLDAP-1.2",
       "seeAlso": [
@@ -3345,7 +3394,7 @@
       "reference": "./OLDAP-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-1.3.json",
-      "referenceNumber": "100",
+      "referenceNumber": "103",
       "name": "Open LDAP Public License v1.3",
       "licenseId": "OLDAP-1.3",
       "seeAlso": [
@@ -3357,7 +3406,7 @@
       "reference": "./OLDAP-1.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-1.4.json",
-      "referenceNumber": "28",
+      "referenceNumber": "29",
       "name": "Open LDAP Public License v1.4",
       "licenseId": "OLDAP-1.4",
       "seeAlso": [
@@ -3369,7 +3418,7 @@
       "reference": "./OLDAP-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.0.json",
-      "referenceNumber": "259",
+      "referenceNumber": "263",
       "name": "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
       "licenseId": "OLDAP-2.0",
       "seeAlso": [
@@ -3381,7 +3430,7 @@
       "reference": "./OLDAP-2.0.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.0.1.json",
-      "referenceNumber": "338",
+      "referenceNumber": "344",
       "name": "Open LDAP Public License v2.0.1",
       "licenseId": "OLDAP-2.0.1",
       "seeAlso": [
@@ -3393,7 +3442,7 @@
       "reference": "./OLDAP-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.1.json",
-      "referenceNumber": "147",
+      "referenceNumber": "151",
       "name": "Open LDAP Public License v2.1",
       "licenseId": "OLDAP-2.1",
       "seeAlso": [
@@ -3405,7 +3454,7 @@
       "reference": "./OLDAP-2.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.json",
-      "referenceNumber": "349",
+      "referenceNumber": "355",
       "name": "Open LDAP Public License v2.2",
       "licenseId": "OLDAP-2.2",
       "seeAlso": [
@@ -3417,7 +3466,7 @@
       "reference": "./OLDAP-2.2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.1.json",
-      "referenceNumber": "329",
+      "referenceNumber": "334",
       "name": "Open LDAP Public License v2.2.1",
       "licenseId": "OLDAP-2.2.1",
       "seeAlso": [
@@ -3429,7 +3478,7 @@
       "reference": "./OLDAP-2.2.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.2.json",
-      "referenceNumber": "192",
+      "referenceNumber": "196",
       "name": "Open LDAP Public License 2.2.2",
       "licenseId": "OLDAP-2.2.2",
       "seeAlso": [
@@ -3442,7 +3491,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.3.json",
-      "referenceNumber": "157",
+      "referenceNumber": "161",
       "name": "Open LDAP Public License v2.3",
       "licenseId": "OLDAP-2.3",
       "seeAlso": [
@@ -3454,7 +3503,7 @@
       "reference": "./OLDAP-2.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.4.json",
-      "referenceNumber": "64",
+      "referenceNumber": "65",
       "name": "Open LDAP Public License v2.4",
       "licenseId": "OLDAP-2.4",
       "seeAlso": [
@@ -3466,7 +3515,7 @@
       "reference": "./OLDAP-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.5.json",
-      "referenceNumber": "176",
+      "referenceNumber": "180",
       "name": "Open LDAP Public License v2.5",
       "licenseId": "OLDAP-2.5",
       "seeAlso": [
@@ -3478,7 +3527,7 @@
       "reference": "./OLDAP-2.6.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.6.json",
-      "referenceNumber": "59",
+      "referenceNumber": "60",
       "name": "Open LDAP Public License v2.6",
       "licenseId": "OLDAP-2.6",
       "seeAlso": [
@@ -3491,7 +3540,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.7.json",
-      "referenceNumber": "117",
+      "referenceNumber": "120",
       "name": "Open LDAP Public License v2.7",
       "licenseId": "OLDAP-2.7",
       "seeAlso": [
@@ -3503,7 +3552,7 @@
       "reference": "./OLDAP-2.8.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.8.json",
-      "referenceNumber": "35",
+      "referenceNumber": "36",
       "name": "Open LDAP Public License v2.8",
       "licenseId": "OLDAP-2.8",
       "seeAlso": [
@@ -3515,7 +3564,7 @@
       "reference": "./OML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OML.json",
-      "referenceNumber": "63",
+      "referenceNumber": "64",
       "name": "Open Market License",
       "licenseId": "OML",
       "seeAlso": [
@@ -3527,7 +3576,7 @@
       "reference": "./OPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OPL-1.0.json",
-      "referenceNumber": "332",
+      "referenceNumber": "338",
       "name": "Open Public License v1.0",
       "licenseId": "OPL-1.0",
       "seeAlso": [
@@ -3540,12 +3589,12 @@
       "reference": "./OSET-PL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OSET-PL-2.1.json",
-      "referenceNumber": "283",
+      "referenceNumber": "288",
       "name": "OSET Public License version 2.1",
       "licenseId": "OSET-PL-2.1",
       "seeAlso": [
         "http://www.osetfoundation.org/public-license",
-        "http://opensource.org/licenses/OPL-2.1"
+        "https://opensource.org/licenses/OPL-2.1"
       ],
       "isOsiApproved": true
     },
@@ -3554,11 +3603,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-1.0.json",
-      "referenceNumber": "81",
+      "referenceNumber": "83",
       "name": "Open Software License 1.0",
       "licenseId": "OSL-1.0",
       "seeAlso": [
-        "http://opensource.org/licenses/OSL-1.0"
+        "https://opensource.org/licenses/OSL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -3567,7 +3616,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-1.1.json",
-      "referenceNumber": "324",
+      "referenceNumber": "329",
       "name": "Open Software License 1.1",
       "licenseId": "OSL-1.1",
       "seeAlso": [
@@ -3580,7 +3629,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-2.0.json",
-      "referenceNumber": "19",
+      "referenceNumber": "20",
       "name": "Open Software License 2.0",
       "licenseId": "OSL-2.0",
       "seeAlso": [
@@ -3593,12 +3642,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-2.1.json",
-      "referenceNumber": "22",
+      "referenceNumber": "23",
       "name": "Open Software License 2.1",
       "licenseId": "OSL-2.1",
       "seeAlso": [
         "http://web.archive.org/web/20050212003940/http://www.rosenlaw.com/osl21.htm",
-        "http://opensource.org/licenses/OSL-2.1"
+        "https://opensource.org/licenses/OSL-2.1"
       ],
       "isOsiApproved": true
     },
@@ -3607,12 +3656,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-3.0.json",
-      "referenceNumber": "95",
+      "referenceNumber": "97",
       "name": "Open Software License 3.0",
       "licenseId": "OSL-3.0",
       "seeAlso": [
         "https://web.archive.org/web/20120101081418/http://rosenlaw.com:80/OSL3.0.htm",
-        "http://www.opensource.org/licenses/OSL-3.0"
+        "https://opensource.org/licenses/OSL-3.0"
       ],
       "isOsiApproved": true
     },
@@ -3621,7 +3670,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OpenSSL.json",
-      "referenceNumber": "242",
+      "referenceNumber": "246",
       "name": "OpenSSL License",
       "licenseId": "OpenSSL",
       "seeAlso": [
@@ -3633,7 +3682,7 @@
       "reference": "./PDDL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/PDDL-1.0.json",
-      "referenceNumber": "13",
+      "referenceNumber": "14",
       "name": "ODC Public Domain Dedication \u0026 License 1.0",
       "licenseId": "PDDL-1.0",
       "seeAlso": [
@@ -3645,12 +3694,12 @@
       "reference": "./PHP-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/PHP-3.0.json",
-      "referenceNumber": "371",
+      "referenceNumber": "377",
       "name": "PHP License v3.0",
       "licenseId": "PHP-3.0",
       "seeAlso": [
         "http://www.php.net/license/3_0.txt",
-        "http://www.opensource.org/licenses/PHP-3.0"
+        "https://opensource.org/licenses/PHP-3.0"
       ],
       "isOsiApproved": true
     },
@@ -3659,7 +3708,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/PHP-3.01.json",
-      "referenceNumber": "307",
+      "referenceNumber": "312",
       "name": "PHP License v3.01",
       "licenseId": "PHP-3.01",
       "seeAlso": [
@@ -3671,7 +3720,7 @@
       "reference": "./Plexus.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Plexus.json",
-      "referenceNumber": "218",
+      "referenceNumber": "222",
       "name": "Plexus Classworlds License",
       "licenseId": "Plexus",
       "seeAlso": [
@@ -3683,12 +3732,12 @@
       "reference": "./PostgreSQL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/PostgreSQL.json",
-      "referenceNumber": "240",
+      "referenceNumber": "244",
       "name": "PostgreSQL License",
       "licenseId": "PostgreSQL",
       "seeAlso": [
         "http://www.postgresql.org/about/licence",
-        "http://www.opensource.org/licenses/PostgreSQL"
+        "https://opensource.org/licenses/PostgreSQL"
       ],
       "isOsiApproved": true
     },
@@ -3697,11 +3746,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Python-2.0.json",
-      "referenceNumber": "33",
+      "referenceNumber": "34",
       "name": "Python License 2.0",
       "licenseId": "Python-2.0",
       "seeAlso": [
-        "http://www.opensource.org/licenses/Python-2.0"
+        "https://opensource.org/licenses/Python-2.0"
       ],
       "isOsiApproved": true
     },
@@ -3710,12 +3759,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/QPL-1.0.json",
-      "referenceNumber": "25",
+      "referenceNumber": "26",
       "name": "Q Public License 1.0",
       "licenseId": "QPL-1.0",
       "seeAlso": [
         "http://doc.qt.nokia.com/3.3/license.html",
-        "http://www.opensource.org/licenses/QPL-1.0"
+        "https://opensource.org/licenses/QPL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -3723,7 +3772,7 @@
       "reference": "./Qhull.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Qhull.json",
-      "referenceNumber": "65",
+      "referenceNumber": "66",
       "name": "Qhull License",
       "licenseId": "Qhull",
       "seeAlso": [
@@ -3735,7 +3784,7 @@
       "reference": "./RHeCos-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RHeCos-1.1.json",
-      "referenceNumber": "142",
+      "referenceNumber": "146",
       "name": "Red Hat eCos Public License v1.1",
       "licenseId": "RHeCos-1.1",
       "seeAlso": [
@@ -3747,11 +3796,11 @@
       "reference": "./RPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RPL-1.1.json",
-      "referenceNumber": "261",
+      "referenceNumber": "266",
       "name": "Reciprocal Public License 1.1",
       "licenseId": "RPL-1.1",
       "seeAlso": [
-        "http://opensource.org/licenses/RPL-1.1"
+        "https://opensource.org/licenses/RPL-1.1"
       ],
       "isOsiApproved": true
     },
@@ -3759,11 +3808,11 @@
       "reference": "./RPL-1.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RPL-1.5.json",
-      "referenceNumber": "220",
+      "referenceNumber": "224",
       "name": "Reciprocal Public License 1.5",
       "licenseId": "RPL-1.5",
       "seeAlso": [
-        "http://www.opensource.org/licenses/RPL-1.5"
+        "https://opensource.org/licenses/RPL-1.5"
       ],
       "isOsiApproved": true
     },
@@ -3772,12 +3821,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/RPSL-1.0.json",
-      "referenceNumber": "265",
+      "referenceNumber": "270",
       "name": "RealNetworks Public Source License v1.0",
       "licenseId": "RPSL-1.0",
       "seeAlso": [
         "https://helixcommunity.org/content/rpsl",
-        "http://www.opensource.org/licenses/RPSL-1.0"
+        "https://opensource.org/licenses/RPSL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -3785,7 +3834,7 @@
       "reference": "./RSA-MD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RSA-MD.json",
-      "referenceNumber": "78",
+      "referenceNumber": "80",
       "name": "RSA Message-Digest License ",
       "licenseId": "RSA-MD",
       "seeAlso": [
@@ -3797,12 +3846,12 @@
       "reference": "./RSCPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RSCPL.json",
-      "referenceNumber": "204",
+      "referenceNumber": "208",
       "name": "Ricoh Source Code Public License",
       "licenseId": "RSCPL",
       "seeAlso": [
         "http://wayback.archive.org/web/20060715140826/http://www.risource.org/RPL/RPL-1.0A.shtml",
-        "http://www.opensource.org/licenses/RSCPL"
+        "https://opensource.org/licenses/RSCPL"
       ],
       "isOsiApproved": true
     },
@@ -3810,7 +3859,7 @@
       "reference": "./Rdisc.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Rdisc.json",
-      "referenceNumber": "287",
+      "referenceNumber": "292",
       "name": "Rdisc License",
       "licenseId": "Rdisc",
       "seeAlso": [
@@ -3823,7 +3872,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Ruby.json",
-      "referenceNumber": "256",
+      "referenceNumber": "260",
       "name": "Ruby License",
       "licenseId": "Ruby",
       "seeAlso": [
@@ -3835,7 +3884,7 @@
       "reference": "./SAX-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SAX-PD.json",
-      "referenceNumber": "134",
+      "referenceNumber": "137",
       "name": "Sax Public Domain Notice",
       "licenseId": "SAX-PD",
       "seeAlso": [
@@ -3847,7 +3896,7 @@
       "reference": "./SCEA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SCEA.json",
-      "referenceNumber": "15",
+      "referenceNumber": "16",
       "name": "SCEA Shared Source License",
       "licenseId": "SCEA",
       "seeAlso": [
@@ -3859,7 +3908,7 @@
       "reference": "./SGI-B-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SGI-B-1.0.json",
-      "referenceNumber": "86",
+      "referenceNumber": "88",
       "name": "SGI Free Software License B v1.0",
       "licenseId": "SGI-B-1.0",
       "seeAlso": [
@@ -3871,7 +3920,7 @@
       "reference": "./SGI-B-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SGI-B-1.1.json",
-      "referenceNumber": "234",
+      "referenceNumber": "238",
       "name": "SGI Free Software License B v1.1",
       "licenseId": "SGI-B-1.1",
       "seeAlso": [
@@ -3884,7 +3933,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/SGI-B-2.0.json",
-      "referenceNumber": "264",
+      "referenceNumber": "269",
       "name": "SGI Free Software License B v2.0",
       "licenseId": "SGI-B-2.0",
       "seeAlso": [
@@ -3897,12 +3946,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/SISSL.json",
-      "referenceNumber": "71",
+      "referenceNumber": "72",
       "name": "Sun Industry Standards Source License v1.1",
       "licenseId": "SISSL",
       "seeAlso": [
         "http://www.openoffice.org/licenses/sissl_license.html",
-        "http://opensource.org/licenses/SISSL"
+        "https://opensource.org/licenses/SISSL"
       ],
       "isOsiApproved": true
     },
@@ -3910,7 +3959,7 @@
       "reference": "./SISSL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SISSL-1.2.json",
-      "referenceNumber": "6",
+      "referenceNumber": "7",
       "name": "Sun Industry Standards Source License v1.2",
       "licenseId": "SISSL-1.2",
       "seeAlso": [
@@ -3923,7 +3972,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/SMLNJ.json",
-      "referenceNumber": "288",
+      "referenceNumber": "293",
       "name": "Standard ML of New Jersey License",
       "licenseId": "SMLNJ",
       "seeAlso": [
@@ -3935,7 +3984,7 @@
       "reference": "./SMPPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SMPPL.json",
-      "referenceNumber": "121",
+      "referenceNumber": "124",
       "name": "Secure Messaging Protocol Public License",
       "licenseId": "SMPPL",
       "seeAlso": [
@@ -3947,7 +3996,7 @@
       "reference": "./SNIA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SNIA.json",
-      "referenceNumber": "223",
+      "referenceNumber": "227",
       "name": "SNIA Public License 1.1",
       "licenseId": "SNIA",
       "seeAlso": [
@@ -3960,11 +4009,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/SPL-1.0.json",
-      "referenceNumber": "52",
+      "referenceNumber": "53",
       "name": "Sun Public License v1.0",
       "licenseId": "SPL-1.0",
       "seeAlso": [
-        "http://www.opensource.org/licenses/SPL-1.0"
+        "https://opensource.org/licenses/SPL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -3972,7 +4021,7 @@
       "reference": "./SWL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SWL.json",
-      "referenceNumber": "201",
+      "referenceNumber": "205",
       "name": "Scheme Widget Library (SWL) Software License Agreement",
       "licenseId": "SWL",
       "seeAlso": [
@@ -3984,7 +4033,7 @@
       "reference": "./Saxpath.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Saxpath.json",
-      "referenceNumber": "17",
+      "referenceNumber": "18",
       "name": "Saxpath License",
       "licenseId": "Saxpath",
       "seeAlso": [
@@ -3996,7 +4045,7 @@
       "reference": "./Sendmail.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Sendmail.json",
-      "referenceNumber": "144",
+      "referenceNumber": "148",
       "name": "Sendmail License",
       "licenseId": "Sendmail",
       "seeAlso": [
@@ -4009,7 +4058,7 @@
       "reference": "./Sendmail-8.23.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Sendmail-8.23.json",
-      "referenceNumber": "39",
+      "referenceNumber": "40",
       "name": "Sendmail License 8.23",
       "licenseId": "Sendmail-8.23",
       "seeAlso": [
@@ -4022,11 +4071,11 @@
       "reference": "./SimPL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SimPL-2.0.json",
-      "referenceNumber": "177",
+      "referenceNumber": "181",
       "name": "Simple Public License 2.0",
       "licenseId": "SimPL-2.0",
       "seeAlso": [
-        "http://www.opensource.org/licenses/SimPL-2.0"
+        "https://opensource.org/licenses/SimPL-2.0"
       ],
       "isOsiApproved": true
     },
@@ -4035,11 +4084,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Sleepycat.json",
-      "referenceNumber": "282",
+      "referenceNumber": "287",
       "name": "Sleepycat License",
       "licenseId": "Sleepycat",
       "seeAlso": [
-        "http://www.opensource.org/licenses/Sleepycat"
+        "https://opensource.org/licenses/Sleepycat"
       ],
       "isOsiApproved": true
     },
@@ -4047,7 +4096,7 @@
       "reference": "./Spencer-86.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Spencer-86.json",
-      "referenceNumber": "305",
+      "referenceNumber": "310",
       "name": "Spencer License 86",
       "licenseId": "Spencer-86",
       "seeAlso": [
@@ -4059,7 +4108,7 @@
       "reference": "./Spencer-94.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Spencer-94.json",
-      "referenceNumber": "27",
+      "referenceNumber": "28",
       "name": "Spencer License 94",
       "licenseId": "Spencer-94",
       "seeAlso": [
@@ -4071,7 +4120,7 @@
       "reference": "./Spencer-99.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Spencer-99.json",
-      "referenceNumber": "372",
+      "referenceNumber": "378",
       "name": "Spencer License 99",
       "licenseId": "Spencer-99",
       "seeAlso": [
@@ -4084,7 +4133,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/StandardML-NJ.json",
-      "referenceNumber": "212",
+      "referenceNumber": "216",
       "name": "Standard ML of New Jersey License",
       "licenseId": "StandardML-NJ",
       "seeAlso": [
@@ -4096,7 +4145,7 @@
       "reference": "./SugarCRM-1.1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SugarCRM-1.1.3.json",
-      "referenceNumber": "284",
+      "referenceNumber": "289",
       "name": "SugarCRM Public License v1.1.3",
       "licenseId": "SugarCRM-1.1.3",
       "seeAlso": [
@@ -4105,10 +4154,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./TAPR-OHL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/TAPR-OHL-1.0.json",
+      "referenceNumber": "264",
+      "name": "TAPR Open Hardware License v1.0",
+      "licenseId": "TAPR-OHL-1.0",
+      "seeAlso": [
+        "\nhttps://www.tapr.org/OHL"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./TCL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TCL.json",
-      "referenceNumber": "258",
+      "referenceNumber": "262",
       "name": "TCL/TK License",
       "licenseId": "TCL",
       "seeAlso": [
@@ -4121,7 +4182,7 @@
       "reference": "./TCP-wrappers.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TCP-wrappers.json",
-      "referenceNumber": "266",
+      "referenceNumber": "271",
       "name": "TCP Wrappers License",
       "licenseId": "TCP-wrappers",
       "seeAlso": [
@@ -4133,7 +4194,7 @@
       "reference": "./TMate.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TMate.json",
-      "referenceNumber": "246",
+      "referenceNumber": "250",
       "name": "TMate Open Source License",
       "licenseId": "TMate",
       "seeAlso": [
@@ -4145,7 +4206,7 @@
       "reference": "./TORQUE-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TORQUE-1.1.json",
-      "referenceNumber": "164",
+      "referenceNumber": "168",
       "name": "TORQUE v2.5+ Software License v1.1",
       "licenseId": "TORQUE-1.1",
       "seeAlso": [
@@ -4157,7 +4218,7 @@
       "reference": "./TOSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TOSL.json",
-      "referenceNumber": "347",
+      "referenceNumber": "353",
       "name": "Trusster Open Source License",
       "licenseId": "TOSL",
       "seeAlso": [
@@ -4169,7 +4230,7 @@
       "reference": "./TU-Berlin-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TU-Berlin-1.0.json",
-      "referenceNumber": "359",
+      "referenceNumber": "365",
       "name": "Technische Universitaet Berlin License 1.0",
       "licenseId": "TU-Berlin-1.0",
       "seeAlso": [
@@ -4181,7 +4242,7 @@
       "reference": "./TU-Berlin-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TU-Berlin-2.0.json",
-      "referenceNumber": "377",
+      "referenceNumber": "383",
       "name": "Technische Universitaet Berlin License 2.0",
       "licenseId": "TU-Berlin-2.0",
       "seeAlso": [
@@ -4194,11 +4255,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/UPL-1.0.json",
-      "referenceNumber": "198",
+      "referenceNumber": "202",
       "name": "Universal Permissive License v1.0",
       "licenseId": "UPL-1.0",
       "seeAlso": [
-        "http://opensource.org/licenses/UPL"
+        "https://opensource.org/licenses/UPL"
       ],
       "isOsiApproved": true
     },
@@ -4206,7 +4267,7 @@
       "reference": "./Unicode-DFS-2015.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Unicode-DFS-2015.json",
-      "referenceNumber": "10",
+      "referenceNumber": "11",
       "name": "Unicode License Agreement - Data Files and Software (2015)",
       "licenseId": "Unicode-DFS-2015",
       "seeAlso": [
@@ -4218,7 +4279,7 @@
       "reference": "./Unicode-DFS-2016.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Unicode-DFS-2016.json",
-      "referenceNumber": "368",
+      "referenceNumber": "374",
       "name": "Unicode License Agreement - Data Files and Software (2016)",
       "licenseId": "Unicode-DFS-2016",
       "seeAlso": [
@@ -4230,7 +4291,7 @@
       "reference": "./Unicode-TOU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Unicode-TOU.json",
-      "referenceNumber": "68",
+      "referenceNumber": "69",
       "name": "Unicode Terms of Use",
       "licenseId": "Unicode-TOU",
       "seeAlso": [
@@ -4243,7 +4304,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Unlicense.json",
-      "referenceNumber": "285",
+      "referenceNumber": "290",
       "name": "The Unlicense",
       "licenseId": "Unlicense",
       "seeAlso": [
@@ -4255,7 +4316,7 @@
       "reference": "./VOSTROM.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/VOSTROM.json",
-      "referenceNumber": "221",
+      "referenceNumber": "225",
       "name": "VOSTROM Public License for Open Source",
       "licenseId": "VOSTROM",
       "seeAlso": [
@@ -4267,11 +4328,11 @@
       "reference": "./VSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/VSL-1.0.json",
-      "referenceNumber": "173",
+      "referenceNumber": "177",
       "name": "Vovida Software License v1.0",
       "licenseId": "VSL-1.0",
       "seeAlso": [
-        "http://www.opensource.org/licenses/VSL-1.0"
+        "https://opensource.org/licenses/VSL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -4280,7 +4341,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Vim.json",
-      "referenceNumber": "127",
+      "referenceNumber": "130",
       "name": "Vim License",
       "licenseId": "Vim",
       "seeAlso": [
@@ -4293,12 +4354,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/W3C.json",
-      "referenceNumber": "339",
+      "referenceNumber": "345",
       "name": "W3C Software Notice and License (2002-12-31)",
       "licenseId": "W3C",
       "seeAlso": [
         "http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html",
-        "http://www.opensource.org/licenses/W3C"
+        "https://opensource.org/licenses/W3C"
       ],
       "isOsiApproved": true
     },
@@ -4306,7 +4367,7 @@
       "reference": "./W3C-19980720.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/W3C-19980720.json",
-      "referenceNumber": "314",
+      "referenceNumber": "319",
       "name": "W3C Software Notice and License (1998-07-20)",
       "licenseId": "W3C-19980720",
       "seeAlso": [
@@ -4318,7 +4379,7 @@
       "reference": "./W3C-20150513.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/W3C-20150513.json",
-      "referenceNumber": "49",
+      "referenceNumber": "50",
       "name": "W3C Software Notice and Document License (2015-05-13)",
       "licenseId": "W3C-20150513",
       "seeAlso": [
@@ -4331,7 +4392,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/WTFPL.json",
-      "referenceNumber": "355",
+      "referenceNumber": "361",
       "name": "Do What The F*ck You Want To Public License",
       "licenseId": "WTFPL",
       "seeAlso": [
@@ -4343,11 +4404,11 @@
       "reference": "./Watcom-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Watcom-1.0.json",
-      "referenceNumber": "170",
+      "referenceNumber": "174",
       "name": "Sybase Open Watcom Public License 1.0",
       "licenseId": "Watcom-1.0",
       "seeAlso": [
-        "http://www.opensource.org/licenses/Watcom-1.0"
+        "https://opensource.org/licenses/Watcom-1.0"
       ],
       "isOsiApproved": true
     },
@@ -4355,7 +4416,7 @@
       "reference": "./Wsuipa.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Wsuipa.json",
-      "referenceNumber": "129",
+      "referenceNumber": "132",
       "name": "Wsuipa License",
       "licenseId": "Wsuipa",
       "seeAlso": [
@@ -4368,7 +4429,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/X11.json",
-      "referenceNumber": "181",
+      "referenceNumber": "185",
       "name": "X11 License",
       "licenseId": "X11",
       "seeAlso": [
@@ -4381,7 +4442,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/XFree86-1.1.json",
-      "referenceNumber": "236",
+      "referenceNumber": "240",
       "name": "XFree86 License 1.1",
       "licenseId": "XFree86-1.1",
       "seeAlso": [
@@ -4393,7 +4454,7 @@
       "reference": "./XSkat.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/XSkat.json",
-      "referenceNumber": "91",
+      "referenceNumber": "93",
       "name": "XSkat License",
       "licenseId": "XSkat",
       "seeAlso": [
@@ -4405,7 +4466,7 @@
       "reference": "./Xerox.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Xerox.json",
-      "referenceNumber": "156",
+      "referenceNumber": "160",
       "name": "Xerox License",
       "licenseId": "Xerox",
       "seeAlso": [
@@ -4417,11 +4478,11 @@
       "reference": "./Xnet.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Xnet.json",
-      "referenceNumber": "374",
+      "referenceNumber": "380",
       "name": "X.Net License",
       "licenseId": "Xnet",
       "seeAlso": [
-        "http://opensource.org/licenses/Xnet"
+        "https://opensource.org/licenses/Xnet"
       ],
       "isOsiApproved": true
     },
@@ -4429,7 +4490,7 @@
       "reference": "./YPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/YPL-1.0.json",
-      "referenceNumber": "167",
+      "referenceNumber": "171",
       "name": "Yahoo! Public License v1.0",
       "licenseId": "YPL-1.0",
       "seeAlso": [
@@ -4442,7 +4503,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/YPL-1.1.json",
-      "referenceNumber": "55",
+      "referenceNumber": "56",
       "name": "Yahoo! Public License v1.1",
       "licenseId": "YPL-1.1",
       "seeAlso": [
@@ -4454,7 +4515,7 @@
       "reference": "./ZPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ZPL-1.1.json",
-      "referenceNumber": "346",
+      "referenceNumber": "352",
       "name": "Zope Public License 1.1",
       "licenseId": "ZPL-1.1",
       "seeAlso": [
@@ -4467,12 +4528,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ZPL-2.0.json",
-      "referenceNumber": "74",
+      "referenceNumber": "76",
       "name": "Zope Public License 2.0",
       "licenseId": "ZPL-2.0",
       "seeAlso": [
         "http://old.zope.org/Resources/License/ZPL-2.0",
-        "http://opensource.org/licenses/ZPL-2.0"
+        "https://opensource.org/licenses/ZPL-2.0"
       ],
       "isOsiApproved": true
     },
@@ -4481,7 +4542,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ZPL-2.1.json",
-      "referenceNumber": "334",
+      "referenceNumber": "340",
       "name": "Zope Public License 2.1",
       "licenseId": "ZPL-2.1",
       "seeAlso": [
@@ -4493,7 +4554,7 @@
       "reference": "./Zed.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Zed.json",
-      "referenceNumber": "241",
+      "referenceNumber": "245",
       "name": "Zed License",
       "licenseId": "Zed",
       "seeAlso": [
@@ -4506,7 +4567,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Zend-2.0.json",
-      "referenceNumber": "191",
+      "referenceNumber": "195",
       "name": "Zend License v2.0",
       "licenseId": "Zend-2.0",
       "seeAlso": [
@@ -4519,7 +4580,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Zimbra-1.3.json",
-      "referenceNumber": "38",
+      "referenceNumber": "39",
       "name": "Zimbra Public License v1.3",
       "licenseId": "Zimbra-1.3",
       "seeAlso": [
@@ -4531,7 +4592,7 @@
       "reference": "./Zimbra-1.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Zimbra-1.4.json",
-      "referenceNumber": "231",
+      "referenceNumber": "235",
       "name": "Zimbra Public License v1.4",
       "licenseId": "Zimbra-1.4",
       "seeAlso": [
@@ -4544,12 +4605,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Zlib.json",
-      "referenceNumber": "311",
+      "referenceNumber": "316",
       "name": "zlib License",
       "licenseId": "Zlib",
       "seeAlso": [
         "http://www.zlib.net/zlib_license.html",
-        "http://www.opensource.org/licenses/Zlib"
+        "https://opensource.org/licenses/Zlib"
       ],
       "isOsiApproved": true
     },
@@ -4557,7 +4618,7 @@
       "reference": "./bzip2-1.0.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/bzip2-1.0.5.json",
-      "referenceNumber": "193",
+      "referenceNumber": "197",
       "name": "bzip2 and libbzip2 License v1.0.5",
       "licenseId": "bzip2-1.0.5",
       "seeAlso": [
@@ -4569,7 +4630,7 @@
       "reference": "./bzip2-1.0.6.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/bzip2-1.0.6.json",
-      "referenceNumber": "294",
+      "referenceNumber": "299",
       "name": "bzip2 and libbzip2 License v1.0.6",
       "licenseId": "bzip2-1.0.6",
       "seeAlso": [
@@ -4581,7 +4642,7 @@
       "reference": "./copyleft-next-0.3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/copyleft-next-0.3.0.json",
-      "referenceNumber": "169",
+      "referenceNumber": "173",
       "name": "copyleft-next 0.3.0",
       "licenseId": "copyleft-next-0.3.0",
       "seeAlso": [
@@ -4593,7 +4654,7 @@
       "reference": "./copyleft-next-0.3.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/copyleft-next-0.3.1.json",
-      "referenceNumber": "336",
+      "referenceNumber": "342",
       "name": "copyleft-next 0.3.1",
       "licenseId": "copyleft-next-0.3.1",
       "seeAlso": [
@@ -4605,7 +4666,7 @@
       "reference": "./curl.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/curl.json",
-      "referenceNumber": "253",
+      "referenceNumber": "257",
       "name": "curl License",
       "licenseId": "curl",
       "seeAlso": [
@@ -4617,7 +4678,7 @@
       "reference": "./diffmark.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/diffmark.json",
-      "referenceNumber": "354",
+      "referenceNumber": "360",
       "name": "diffmark license",
       "licenseId": "diffmark",
       "seeAlso": [
@@ -4629,7 +4690,7 @@
       "reference": "./dvipdfm.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/dvipdfm.json",
-      "referenceNumber": "137",
+      "referenceNumber": "140",
       "name": "dvipdfm License",
       "licenseId": "dvipdfm",
       "seeAlso": [
@@ -4642,11 +4703,11 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/eCos-2.0.json",
-      "referenceNumber": "320",
+      "referenceNumber": "325",
       "name": "eCos license version 2.0",
       "licenseId": "eCos-2.0",
       "seeAlso": [
-        "http://www.gnu.org/licenses/ecos-license.html"
+        "https://www.gnu.org/licenses/ecos-license.html"
       ],
       "isOsiApproved": false
     },
@@ -4654,7 +4715,7 @@
       "reference": "./eGenix.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/eGenix.json",
-      "referenceNumber": "197",
+      "referenceNumber": "201",
       "name": "eGenix.com Public License 1.1.0",
       "licenseId": "eGenix",
       "seeAlso": [
@@ -4667,7 +4728,7 @@
       "reference": "./gSOAP-1.3b.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/gSOAP-1.3b.json",
-      "referenceNumber": "335",
+      "referenceNumber": "341",
       "name": "gSOAP Public License v1.3b",
       "licenseId": "gSOAP-1.3b",
       "seeAlso": [
@@ -4680,7 +4741,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/gnuplot.json",
-      "referenceNumber": "9",
+      "referenceNumber": "10",
       "name": "gnuplot License",
       "licenseId": "gnuplot",
       "seeAlso": [
@@ -4693,7 +4754,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/iMatix.json",
-      "referenceNumber": "331",
+      "referenceNumber": "337",
       "name": "iMatix Standard Function Library Agreement",
       "licenseId": "iMatix",
       "seeAlso": [
@@ -4702,10 +4763,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./libpng-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/libpng-2.0.json",
+      "referenceNumber": "74",
+      "name": "PNG Reference Library version 2",
+      "licenseId": "libpng-2.0",
+      "seeAlso": [
+        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt\n         "
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./libtiff.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/libtiff.json",
-      "referenceNumber": "213",
+      "referenceNumber": "217",
       "name": "libtiff License",
       "licenseId": "libtiff",
       "seeAlso": [
@@ -4717,7 +4790,7 @@
       "reference": "./mpich2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/mpich2.json",
-      "referenceNumber": "309",
+      "referenceNumber": "314",
       "name": "mpich2 License",
       "licenseId": "mpich2",
       "seeAlso": [
@@ -4729,7 +4802,7 @@
       "reference": "./psfrag.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/psfrag.json",
-      "referenceNumber": "238",
+      "referenceNumber": "242",
       "name": "psfrag License",
       "licenseId": "psfrag",
       "seeAlso": [
@@ -4741,7 +4814,7 @@
       "reference": "./psutils.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/psutils.json",
-      "referenceNumber": "120",
+      "referenceNumber": "123",
       "name": "psutils License",
       "licenseId": "psutils",
       "seeAlso": [
@@ -4753,11 +4826,11 @@
       "reference": "./wxWindows.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/wxWindows.json",
-      "referenceNumber": "82",
+      "referenceNumber": "84",
       "name": "wxWindows Library License",
       "licenseId": "wxWindows",
       "seeAlso": [
-        "http://www.opensource.org/licenses/WXwindows"
+        "https://opensource.org/licenses/WXwindows"
       ],
       "isOsiApproved": false
     },
@@ -4766,7 +4839,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/xinetd.json",
-      "referenceNumber": "139",
+      "referenceNumber": "143",
       "name": "xinetd License",
       "licenseId": "xinetd",
       "seeAlso": [
@@ -4778,7 +4851,7 @@
       "reference": "./xpp.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/xpp.json",
-      "referenceNumber": "267",
+      "referenceNumber": "272",
       "name": "XPP License",
       "licenseId": "xpp",
       "seeAlso": [
@@ -4790,7 +4863,7 @@
       "reference": "./zlib-acknowledgement.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/zlib-acknowledgement.json",
-      "referenceNumber": "312",
+      "referenceNumber": "317",
       "name": "zlib/libpng License with Acknowledgement",
       "licenseId": "zlib-acknowledgement",
       "seeAlso": [
@@ -4799,5 +4872,5 @@
       "isOsiApproved": false
     }
   ],
-  "releaseDate": "2019-01-16"
+  "releaseDate": "2019-03-27"
 }

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     install_requires=requirements,
     license="GPLv3",
     long_description=readme + '\n\n' + changelog,
+    long_description_content_type='text/x-rst',
     include_package_data=True,
     keywords='mazer',
     packages=find_packages(include=['ansible_galaxy', 'ansible_galaxy_cli',


### PR DESCRIPTION
##### SUMMARY

Prep for 0.4.0 release. Including:

    0.4.0 (2019-03-28)
    ------------------
    
    * The default path for collections to be installed
      is now '~/.ansible/collections/ansible_collections'
      which is also the default place ansible 2.8 or higher will search
      for collections.
    * Add the 'mazer publish' for publishing a collection artifact to Ansible Galaxy
    * 186 Implement 'migrate_role' command to convert traditional roles
       to collections <https://github.com/ansible/mazer/issues/186>
    * galaxy.yml 'authors' field is now a list
    * galaxy.yml 'dependencies' field is now a dict where the key is the
      collection and the value is a
      https://github.com/rbarrois/python-semanticversion version spec
    * galaxy.yml 'tags' field (a list of tags) added
    * galaxy.yml 'readme' field added. The value is the path to the README file.
    * galaxy.yml optional new fields 'repository',
      'documentation', 'homepage', 'issues'
    * galaxy.yml optional field 'license_file' added. It's value is a path
      to a file containing additional license information
    * collection artifacts file manifest info is now in the generated FILES.json
    * MANIFEST.json now includes path and sha256sum of new generated FILES.json
    * Dependency solving version matching now supports
      the python-semanticversion style version specs
    * Fixes and improvements for install of local collection artifacts.
      ie. `mazer install my_namespace-my_collection-1.2.3.tar.gz`
    * Updates to the use Galaxy REST v2 API
    * Updates to how SPDX data is loaded and used.
    * SPDX data updated to 3.4-59-ga68ef3c


##### ISSUE TYPE

 - Docs Pull Request


##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.3.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.16-100.fc27.x86_64, #1 SMP Sun Oct 21 09:33:00 UTC 2018, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py3-2/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/galaxy-cli-py3-2/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

