### PR TITLE
Better default path filter for 'list --content'

### DIFF
--- a/tests/ansible_galaxy/actions/test_list.py
+++ b/tests/ansible_galaxy/actions/test_list.py
@@ -23,7 +23,7 @@ def test__list(galaxy_context, mocker):
     mocker.patch('ansible_galaxy.repository.os.path.isdir',
                  return_value=True)
 
-    mocker.patch('ansible_galaxy.installed_content_item_db.glob_content_path_iterator',
+    mocker.patch('ansible_galaxy.installed_content_item_db.python_content_path_iterator',
                  return_value=iter(['/dev/null/content/ns_foo/n_bar/roles/role-1',
                                     '/dev/null/content/ns_blip/n_bar/roles/role-3',
                                     '/dev/null/content/ns_blip/n_baz/roles/role-2']))

--- a/tests/ansible_galaxy/test_installed_content_item_db.py
+++ b/tests/ansible_galaxy/test_installed_content_item_db.py
@@ -52,7 +52,7 @@ def test_installed_content_item_iterator_empty(galaxy_context, mocker):
     mocker.patch('ansible_galaxy.installed_repository_db.get_repository_paths',
                  return_value=iter(['bar', 'baz']))
 
-    mocker.patch('ansible_galaxy.installed_content_item_db.glob_content_path_iterator',
+    mocker.patch('ansible_galaxy.installed_content_item_db.python_content_path_iterator',
                  return_value=iter(['/dev/null/content/foo/bar/roles/role-1',
                                     '/dev/null/content/blip/baz/roles/role-2']))
 


### PR DESCRIPTION
##### SUMMARY
The iterator used for 'list --content' was not filtering/ignore __pycache__ dirs or stray __init__.py files inside of a collection, so the list output had bogus entries.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.4.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 4.18.16-100.fc27.x86_64, #1 SMP Sun Oct 21 09:33:00 UTC 2018, x86_64
executable_location = /home/adrian/venvs/mazer040test/bin/mazer
python_version = 3.6.6 (default, Jul 19 2018, 16:29:00) [GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
python_executable = /home/adrian/venvs/mazer040test/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

Example output of `mazer list --content` before
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
repo=alikins.collection_inspect, type=filter, name=__pycache__, version=0.0.20
repo=alikins.collection_inspect, type=filter, name=collection_inspect, version=0.0.20
repo=alikins.collection_inspect, type=__pycache__, name=__init__.cpython-36, version=0.0.20
repo=alikins.collection_inspect, type=module_utils, name=collection_inspect, version=0.0.20
repo=alikins.alikins-collection_reqs_test-2.1113, type=repository, version=2.1113.39

```
After:

```
repo=alikins.collection_inspect, type=filter, name=collection_inspect, version=0.0.20
repo=alikins.collection_inspect, type=module_utils, name=collection_inspect, version=0.0.20
repo=alikins.alikins-collection_reqs_test-2.1113, type=repository, version=2.1113.39
repo=alikins.alikins-collection_reqs_test-2.1113, type=roles, name=cole_role, version=2.1113.39
repo=alikins.alikins-collection_reqs_test-2.1113, type=roles, name=bole_role, version=2.1113.39
repo=alikins.alikins-collection_reqs_test-2.1113, type=roles, name=aole_role, version=2.1113.39
repo=alikins.alikins-collection_reqs_test-2.1113, type=modules, name=newmodule, version=2.1113.39
```
