### PR TITLE
(tmp) Fix 'publish' to galaxy-dev (and any https api)

### DIFF
--- a/ansible_galaxy/rest_api.py
+++ b/ansible_galaxy/rest_api.py
@@ -283,11 +283,15 @@ class GalaxyAPI(object):
 
         log.debug('url: %s', url)
 
-        _, netloc, url, _, _, _ = urlparse(url)
+        scheme, netloc, url, _, _, _ = urlparse(url)
 
         try:
             form_buffer = form.get_binary().getvalue()
-            http = http_client.HTTPConnection(netloc)
+            if scheme == 'http':
+                http = http_client.HTTPConnection(netloc)
+            else:
+                http = http_client.HTTPSConnection(netloc)
+
             http.connect()
             http.putrequest("POST", url)
             http.putheader('Content-type', form.get_content_type())


### PR DESCRIPTION
The publish_file() method was ignoring the galaxy
server url scheme and always using 'http' connections
(even for https:// urls like https://galaxy-dev.ansible.com)
And for https only server (like galaxy-dev) that redirect
http requests to https urls, this would fail because of
an unhandled '302 Found' redirect response.

publish_file() uses a http client based
on 'http.client', while the rest of mazer uses the
flat_rest_api.urls.open_url() method. So the incorrect
use of http only affects publish_file()

This is a tmp fix until this and ansible_galaxy.rest_api
is ported to `requests`.


