### PR TITLE
Fix errors about missing HTTPResponse.getcode()

### DIFF
--- a/ansible_galaxy/rest_api.py
+++ b/ansible_galaxy/rest_api.py
@@ -312,10 +312,6 @@ class GalaxyAPI(object):
 
         r = http.getresponse()
 
-        log.debug('code: %s', r.getcode())
-        log.debug('info: %s', r.info())
-        log.debug('reason: %s', r.reason)
-
         response_body = r.read()
         log.debug('response_body: %s', response_body)
 


### PR DESCRIPTION
py27 doesn't have a getcode() method on it's HTTPResponse.

