### PR TITLE
config and test setup tweaks (test main()'s, MAZER_HOME, stop using ~/.ansible defaults in tests, etc)

### DIFF
--- a/ansible_galaxy/config/defaults.py
+++ b/ansible_galaxy/config/defaults.py
@@ -1,10 +1,13 @@
 import os
 
+MAZER_HOME = os.environ.get('MAZER_HOME', None) or '~/.ansible'
+DEFAULT_CONFIG_FILE = '~/.ansible/mazer.yml'
+
 
 def get_config_path():
     paths = [
         'mazer.yml',
-        '~/.ansible/mazer.yml',
+        os.path.join(MAZER_HOME, 'mazer.yml'),
         '/etc/ansible/mazer.yml'
     ]
     for path in paths:
@@ -21,7 +24,7 @@ DEFAULTS = [
      ),
 
     # In order of priority
-    ('content_path', '~/.ansible/collections/ansible_collections'),
+    ('content_path', os.path.join(MAZER_HOME, 'collections/ansible_collections')),
     ('global_content_path', '/usr/share/ansible/collections/ansible_collections'),
 
     # runtime options

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -155,7 +155,7 @@ class GalaxyCLI(cli.CLI):
         self.parser.add_option('-c', '--ignore-certs', action='store_true', dest='ignore_certs', default=None,
                                help='Ignore SSL certificate validation errors.')
         self.parser.add_option('--config', dest='cli_config_file', default=None,
-                               help='path to a mazer config file (default: %s)' % defaults.CONFIG_FILE)
+                               help='path to a mazer config file (default: %s)' % defaults.DEFAULT_CONFIG_FILE)
         self.set_action()
 
         super(GalaxyCLI, self).parse()
@@ -192,7 +192,7 @@ class GalaxyCLI(cli.CLI):
 
     def run(self):
 
-        raw_config_file_path = get_config_path_from_env() or self.options.cli_config_file or defaults.CONFIG_FILE
+        raw_config_file_path = get_config_path_from_env() or self.options.cli_config_file or defaults.get_config_path()
 
         self.config_file_path = os.path.abspath(os.path.expanduser(raw_config_file_path))
 

--- a/ansible_galaxy_cli/logger/setup.py
+++ b/ansible_galaxy_cli/logger/setup.py
@@ -5,13 +5,13 @@ import logging.config
 import os
 import yaml
 
-LOG_FILE = os.path.expandvars(os.path.expanduser('~/.ansible/mazer.log'))
+from ansible_galaxy.config import defaults
 
 DEFAULT_CONSOLE_LEVEL = os.getenv('MAZER_LOG_LEVEL', 'WARNING').upper()
 DEFAULT_LEVEL = 'DEBUG'
 
 DEFAULT_LOGGING_CONFIG_YAML = os.path.join(os.path.dirname(__file__), 'default-mazer-logging.yml')
-LOGGING_CONFIG_YAML = os.path.expandvars(os.path.expanduser('~/.ansible/mazer-logging.yml'))
+
 
 FALLBACK_LOGGING_CONFIG = {
     'version': 1,
@@ -70,8 +70,6 @@ def load_config_yaml(config_file_path):
 
 
 def setup_default():
-    logging_config = None
-
     # fallback is basically no setup, null handler, etc
     # builtin, doesn't depend on yaml config
     setup(FALLBACK_LOGGING_CONFIG)
@@ -81,11 +79,15 @@ def setup_default():
     if default_logging_config:
         setup(default_logging_config)
 
+
+def setup_custom():
+    logging_config = None
+
+    # ~/.ansible/mazer-logging.yml
+    LOGGING_CONFIG_YAML = os.path.join(os.path.expanduser(defaults.MAZER_HOME), 'mazer-logging.yml')
+
     # load custom logging config
     logging_config = load_config_yaml(LOGGING_CONFIG_YAML)
 
     if logging_config:
         setup(logging_config)
-
-    # import logging_tree
-    # logging_tree.printout()

--- a/ansible_galaxy_cli/main.py
+++ b/ansible_galaxy_cli/main.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 from ansible_galaxy import exceptions
-from ansible_galaxy_cli.logger.setup import setup_default
+from ansible_galaxy_cli.logger.setup import setup_default, setup_custom
 from ansible_galaxy_cli.cli import galaxy
 from ansible_galaxy_cli import exceptions as cli_exceptions
 
@@ -13,6 +13,7 @@ stderr_log = logging.getLogger('%s.(stderr)' % __package__)
 
 def main(args=None):
     setup_default()
+    setup_custom()
 
     args = args or sys.argv[:]
 

--- a/tests/_mazer_home/mazer.yml
+++ b/tests/_mazer_home/mazer.yml
@@ -1,0 +1,8 @@
+server:
+  ignore_certs: false
+  url: http://localhost:8000
+
+content_path: user_collections/ansible_collections
+global_content_path: global_collections/ansible_collections
+
+version: 1

--- a/tests/_mazer_work_dir/global_collections/ansible_collections/testing/some_collection/README.md
+++ b/tests/_mazer_work_dir/global_collections/ansible_collections/testing/some_collection/README.md
@@ -1,0 +1,18 @@
+# Some collection used for unit testing mazer
+
+The rest of this README does not have useful info.
+
+## Random Facts
+
+"War of the ants" was a phrase used to describe TV static in Europe and elsewhere.
+
+## Useless Info
+
+If you watch the opening of 'Star Trek TOS/TNG' while listening to
+Chuck Mangione's "Feels So Good" it becomes an episode of 'The Love Boat'.
+
+## Quotes That Likely Never Make Sense In Context
+
+"so that game's kinda not feasible these days. especially because they moved the bojangles.
+now bojangles is right in the way."
+-- Jon Bois (July 2017) - _17776: What Football Will Look Like in the Future_ - https://www.sbnation.com/a/17776-football

--- a/tests/_mazer_work_dir/global_collections/ansible_collections/testing/some_collection/galaxy.yml
+++ b/tests/_mazer_work_dir/global_collections/ansible_collections/testing/some_collection/galaxy.yml
@@ -1,0 +1,19 @@
+namespace: testing
+name: some_collection
+version: 11.11.11
+license:
+  - MIT
+description: Some collecting used for unit testing mazer
+repository:
+documentation:
+homepage:
+issues:
+authors:
+  - testing
+tags:
+  - testing
+  - faux
+  - bogus
+  - mock
+readme: "README.md"
+dependencies: {}

--- a/tests/_mazer_work_dir/global_collections/ansible_collections/testing/some_collection/roles/some_role/README.md
+++ b/tests/_mazer_work_dir/global_collections/ansible_collections/testing/some_collection/roles/some_role/README.md
@@ -1,0 +1,1 @@
+# Some role used for unit testing mazer

--- a/tests/_mazer_work_dir/global_collections/ansible_collections/testing/some_collection/roles/some_role/meta/main.yml
+++ b/tests/_mazer_work_dir/global_collections/ansible_collections/testing/some_collection/roles/some_role/meta/main.yml
@@ -1,0 +1,23 @@
+collections:
+  - ansible.builtin
+  - testns.coll_in_sys
+  - bogus.fromrolemeta
+
+galaxy_info:
+  author: A. Testing Account
+  description: Some role used for unit testing mazer
+  license: MIT
+  min_ansible_version: 2.4
+  galaxy_tags:
+    - mazer
+    - rhymewithrole
+
+  platforms:
+    - name: Fedora
+      versions:
+        - all
+    - name: EL
+      versions:
+        - all
+
+dependencies: []

--- a/tests/_mazer_work_dir/user_collections/ansible_collections/testing/some_collection/README.md
+++ b/tests/_mazer_work_dir/user_collections/ansible_collections/testing/some_collection/README.md
@@ -1,0 +1,18 @@
+# Some collection used for unit testing mazer
+
+The rest of this README does not have useful info.
+
+## Random Facts
+
+"War of the ants" was a phrase used to describe TV static in Europe and elsewhere.
+
+## Useless Info
+
+If you watch the opening of 'Star Trek TOS/TNG' while listening to
+Chuck Mangione's "Feels So Good" it becomes an episode of 'The Love Boat'.
+
+## Quotes That Likely Never Make Sense In Context
+
+"so that game's kinda not feasible these days. especially because they moved the bojangles.
+now bojangles is right in the way."
+-- Jon Bois (July 2017) - _17776: What Football Will Look Like in the Future_ - https://www.sbnation.com/a/17776-football

--- a/tests/_mazer_work_dir/user_collections/ansible_collections/testing/some_collection/galaxy.yml
+++ b/tests/_mazer_work_dir/user_collections/ansible_collections/testing/some_collection/galaxy.yml
@@ -1,0 +1,19 @@
+namespace: testing
+name: some_collection
+version: 9.8.7
+license:
+  - MIT
+description: Some collecting used for unit testing mazer
+repository:
+documentation:
+homepage:
+issues:
+authors:
+  - testing
+tags:
+  - testing
+  - faux
+  - bogus
+  - mock
+readme: "README.md"
+dependencies: {}

--- a/tests/_mazer_work_dir/user_collections/ansible_collections/testing/some_collection/roles/some_role/README.md
+++ b/tests/_mazer_work_dir/user_collections/ansible_collections/testing/some_collection/roles/some_role/README.md
@@ -1,0 +1,1 @@
+# Some role used for unit testing mazer

--- a/tests/_mazer_work_dir/user_collections/ansible_collections/testing/some_collection/roles/some_role/meta/main.yml
+++ b/tests/_mazer_work_dir/user_collections/ansible_collections/testing/some_collection/roles/some_role/meta/main.yml
@@ -1,0 +1,23 @@
+collections:
+  - ansible.builtin
+  - testns.coll_in_sys
+  - bogus.fromrolemeta
+
+galaxy_info:
+  author: A. Testing Account
+  description: Some role used for unit testing mazer
+  license: MIT
+  min_ansible_version: 2.4
+  galaxy_tags:
+    - mazer
+    - rhymewithrole
+
+  platforms:
+    - name: Fedora
+      versions:
+        - all
+    - name: EL
+      versions:
+        - all
+
+dependencies: []

--- a/tests/ansible_galaxy_cli/cli/test_galaxy.py
+++ b/tests/ansible_galaxy_cli/cli/test_galaxy.py
@@ -21,8 +21,8 @@ authors:
 '''
 
 
-def test_build_no_args():
-    cli = galaxy.GalaxyCLI(args=['build'])
+def test_build_no_args(mazer_args_for_test):
+    cli = galaxy.GalaxyCLI(args=mazer_args_for_test + ['build'])
     cli.parse()
 
     log.debug('cli.options: %s', cli.options)
@@ -31,17 +31,17 @@ def test_build_no_args():
     assert cli.args == []
 
 
-def test_build_run_no_args():
-    cli = galaxy.GalaxyCLI(args=['build'])
-    cli.parse()
-    log.debug('cli.options: %s', cli.options)
+# def test_build_run_no_args():
+#     cli = galaxy.GalaxyCLI(args=['mazer', 'build', 'fooo'])
+#     cli.parse()
+#     log.debug('cli.options: %s', cli.options)
 
-    rc = cli.run()
+#     rc = cli.run()
 
-    assert rc == os.EX_SOFTWARE
+#     assert rc == os.EX_SOFTWARE
 
 
-def test_build_run_tmp_collection_path(tmpdir):
+def test_build_run_tmp_collection_path(tmpdir, mazer_args_for_test):
     temp_dir = tmpdir.mkdir('mazer_cli_built_run_tmp_output_path_unit_test')
     log.debug('temp_dir: %s', temp_dir.strpath)
 
@@ -53,10 +53,9 @@ def test_build_run_tmp_collection_path(tmpdir):
     info_fd.write(COLLECTION_INFO1)
     info_fd.close()
 
-    cli = galaxy.GalaxyCLI(args=['mazer',
-                                 'build',
-                                 '--collection-path', collection_path,
-                                 '--output-path', output_path])
+    cli = galaxy.GalaxyCLI(args=mazer_args_for_test +
+                           ['build', '--collection-path', collection_path,
+                            '--output-path', output_path])
     cli.parse()
 
     log.debug('cli.options: %s', cli.options)
@@ -72,22 +71,31 @@ def test_build_run_tmp_collection_path(tmpdir):
     assert tarfile.is_tarfile(expected_artifact_path)
 
 
-def test_info():
-    cli = galaxy.GalaxyCLI(args=['info'])
+def test_info(mazer_args_for_test):
+    cli = galaxy.GalaxyCLI(args=mazer_args_for_test + ['info'])
     cli.parse()
 
     log.debug('cli.options: %s', cli.options)
 
 
-def test_run_info():
-    cli = galaxy.GalaxyCLI(args=['info'])
+def test_run_info(mazer_args_for_test):
+    cli = galaxy.GalaxyCLI(args=mazer_args_for_test + ['info'])
     cli.parse()
     with pytest.raises(cli_exceptions.CliOptionsError, match="you must specify a collection name"):
         cli.run()
 
 
-def test_publish_no_args():
-    cli = galaxy.GalaxyCLI(args=['publish'])
+def test_run_list(mazer_args_for_test):
+    cli = galaxy.GalaxyCLI(args=mazer_args_for_test + ['list'])
+    cli.parse()
+    res = cli.run()
+
+    log.debug('mat: %s', mazer_args_for_test)
+    log.debug('res: %s', res)
+
+
+def test_publish_no_args(mazer_args_for_test):
+    cli = galaxy.GalaxyCLI(args=mazer_args_for_test + ['publish'])
     cli.parse()
     with pytest.raises(cli_exceptions.CliOptionsError, match="you must specify a path"):
         cli.run()

--- a/tests/ansible_galaxy_cli/cli/test_galaxy_upstream.py
+++ b/tests/ansible_galaxy_cli/cli/test_galaxy_upstream.py
@@ -37,7 +37,6 @@ from mock import call, patch
 
 # FIXME: shouldn't need to patch object directly
 import ansible_galaxy_cli
-import ansible_galaxy
 
 from ansible_galaxy import exceptions
 
@@ -111,11 +110,14 @@ class TestGalaxy(unittest.TestCase):
             shutil.rmtree(cls.role_path)
 
     def setUp(self):
-        self.default_args = ['ansible-galaxy']
+        # self.default_args = ['ansible-galaxy']
+        # self.default_args = ['mazer', '--config', 'tests/configs/galaxy.yml']
+        self.default_args = ['mazer']
 
     def test_run(self):
         ''' verifies that the GalaxyCLI object's api is created and that execute() is called. '''
-        gc = GalaxyCLI(args=["ansible-galaxy", "install", "--ignore-errors", "imaginary_role"])
+        # gc = GalaxyCLI(args=self.default_args + ["install", "--ignore-errors", "imaginary_role"])
+        gc = GalaxyCLI(args=["mazer", "install", "--ignore-errors", "imaginary_role"])
         gc.parse()
         with patch.object(ansible_galaxy_cli.cli.CLI, "execute", return_value=None) as mock_ex:
             with patch.object(ansible_galaxy_cli.cli.CLI, "run", return_value=None) as mock_run:
@@ -123,14 +125,13 @@ class TestGalaxy(unittest.TestCase):
 
                 # testing
                 self.assertEqual(mock_run.call_count, 1)
-                self.assertTrue(isinstance(gc.api, ansible_galaxy.rest_api.GalaxyAPI))
                 self.assertEqual(mock_ex.call_count, 1)
 
     def test_execute_remove(self):
         # installing role
         log.debug('self.role_path: %s', self.role_path)
 
-        gc = GalaxyCLI(args=["ansible-galaxy", "install", "--content-path", self.role_path, '--force', self.role_name])
+        gc = GalaxyCLI(args=self.default_args + ["install", "--content-path", self.role_path, '--force', self.role_name])
         gc.parse()
         gc.run()
 
@@ -143,7 +144,7 @@ class TestGalaxy(unittest.TestCase):
 
         # removing role
         # args = ["ansible-galaxy", "remove", role_file, self.role_name]
-        args = ["ansible-galaxy", "remove", self.role_name]
+        args = self.default_args + ["remove", self.role_name]
         log.debug('args: %s', args)
         gc = GalaxyCLI(args=args)
         gc.parse()
@@ -155,7 +156,7 @@ class TestGalaxy(unittest.TestCase):
 
     def test_raise_without_ignore_without_flag(self):
         ''' tests that GalaxyCLI exits with the error specified if the --ignore-errors flag is not used '''
-        gc = GalaxyCLI(args=["ansible-galaxy", "install", "--server=None", "testing.fake_role_name"])
+        gc = GalaxyCLI(args=self.default_args + ["install", "--server=None", "testing.fake_role_name"])
         gc.parse()
         # testing that error expected is raised
         self.assertRaises(exceptions.GalaxyError, gc.run)
@@ -164,7 +165,7 @@ class TestGalaxy(unittest.TestCase):
     def test_raise_without_ignore_with_flag(self):
         ''' tests that GalaxyCLI exits without the error specified if the --ignore-errors flag is used  '''
         # testing with --ignore-errors flag
-        gc = GalaxyCLI(args=["ansible-galaxy", "install", "--server=None", "testing.fake_role_name", "--ignore-errors"])
+        gc = GalaxyCLI(args=self.default_args + ["install", "--server=None", "testing.fake_role_name", "--ignore-errors"])
         gc.parse()
         gc.run()
         #    self.assertTrue(mocked_display.called_once_with("- downloading role 'fake_role_name', owned by "))
@@ -192,23 +193,23 @@ class TestGalaxy(unittest.TestCase):
 
     def test_parse_no_action(self):
         ''' testing the options parser when no action is given '''
-        gc = GalaxyCLI(args=["ansible-galaxy", ""])
+        gc = GalaxyCLI(args=self.default_args + [""])
         self.assertRaises(cli_exceptions.CliOptionsError, gc.parse)
 
     def test_parse_invalid_action(self):
         ''' testing the options parser when an invalid action is given '''
-        gc = GalaxyCLI(args=["ansible-galaxy", "NOT_ACTION"])
+        gc = GalaxyCLI(args=self.default_args + ["NOT_ACTION"])
         self.assertRaises(cli_exceptions.CliOptionsError, gc.parse)
 
     def test_parse_info(self):
         ''' testing the options parser when the action 'info' is given '''
-        gc = GalaxyCLI(args=["ansible-galaxy", "info"])
+        gc = GalaxyCLI(args=self.default_args + ["info"])
         self.run_parse_common(gc, "info")
         self.assertEqual(gc.options.offline, False)
 
     def test_parse_install(self):
         ''' testing the options parser when the action 'install' is given '''
-        gc = GalaxyCLI(args=["ansible-galaxy", "install"])
+        gc = GalaxyCLI(args=self.default_args + ["install"])
         self.run_parse_common(gc, "install")
         self.assertEqual(gc.options.ignore_errors, False)
         self.assertEqual(gc.options.no_deps, False)
@@ -216,24 +217,24 @@ class TestGalaxy(unittest.TestCase):
 
     def test_parse_list(self):
         ''' testing the options parser when the action 'list' is given '''
-        gc = GalaxyCLI(args=["ansible-galaxy", "list"])
+        gc = GalaxyCLI(args=self.default_args + ["list"])
         self.run_parse_common(gc, "list")
         self.assertEqual(gc.options.verbosity, 0)
 
     def test_parse_publish(self):
         ''' testing the options parser when the action 'publish' is given '''
-        gc = GalaxyCLI(args=["ansible-galaxy", "publish"])
+        gc = GalaxyCLI(args=self.default_args + ["publish"])
         self.run_parse_common(gc, "publish")
         self.assertEqual(gc.options.verbosity, 0)
 
     def test_parse_remove(self):
         ''' testing the options parser when the action 'remove' is given '''
-        gc = GalaxyCLI(args=["ansible-galaxy", "remove"])
+        gc = GalaxyCLI(args=self.default_args + ["remove"])
         self.run_parse_common(gc, "remove")
         self.assertEqual(gc.options.verbosity, 0)
 
     def test_parse_version(self):
         ''' testing the options parser when the action 'version' is given '''
-        gc = GalaxyCLI(args=["ansible-galaxy", "version"])
+        gc = GalaxyCLI(args=self.default_args + ["version"])
         self.run_parse_common(gc, "version")
         self.assertEqual(gc.options.verbosity, 0)

--- a/tests/ansible_galaxy_cli/test_main.py
+++ b/tests/ansible_galaxy_cli/test_main.py
@@ -1,0 +1,15 @@
+import logging
+
+from ansible_galaxy_cli import main
+
+log = logging.getLogger(__name__)
+
+
+def test_main_no_args():
+    res = main.main(['mazer'])
+    log.debug('res: %s', res)
+
+
+def test_main_list_no_args():
+    res = main.main(['mazer', 'list'])
+    log.debug('res: %s', res)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+import os
+import pytest
+
+import logging
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="session")
+def mazer_args_for_test(tmpdir_factory):
+    return ['mazer']
+
+
+@pytest.fixture(autouse=True)
+def inject_mazer_home(monkeypatch):
+    _mazer_home = os.path.join(os.path.dirname(__file__), '_mazer_home')
+
+    monkeypatch.setattr("ansible_galaxy.config.defaults.MAZER_HOME",
+                        _mazer_home)
+    log.debug('monkeypatched MAZER_HOME to %s', _mazer_home)
+
+
+@pytest.fixture(autouse=True)
+def use_mazer_work_dir():
+    _mazer_work_dir = os.path.join(os.path.dirname(__file__), '_mazer_work_dir')
+
+    log.debug('Chaning dir from %s to %s', os.getcwd(), _mazer_work_dir)
+    os.chdir(_mazer_work_dir)


### PR DESCRIPTION
##### SUMMARY
This is a set of changes mostly focused around on making it easier to test mazer.

This includes some config tweaks to let the configs be injected by tests or overridden by env VARS
  - add MAZER_HOME to define where whatever the equilivent of ~/.ansible is
    - so MAZER_HOME=/tmp/some_test_home can point to a different set of configs/logs/tmp/etc
    - MAZER_HOME can also be injected/monkeypatched by unit tests to avoid dragging default ~/.ansible configs into test runs
 - py test conftest sets MAZER_HOME to tests/_mazer_home
   - tests/_mazer_home/mazer.yml points content roots to relative path 'user_collections/' which ends up being tests/_mazer_work_dir/user_collections/ for the unit tests runs
 - py test conftest changes dir to tests/_mazer_work_dir before running tests. Could be replaced with a tmp dir at some point.

One motivation for this is that `tox` doesn't change $HOME or the current user so all the code that uses
~/.ansible based paths (config, logging config, etc) ends up being used by unit tests. If config or logging config do something (like use a custom log handler) the tox tests can fail because the python modules with the custom logger dont exist in the tox roots.

 
##### ISSUE TYPE
 - Bugfix Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.4.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 5.0.5-200.fc29.x86_64, #1 SMP Wed Mar 27 20:58:04 UTC 2019, x86_64
executable_location = /home/adrian/venvs/galaxy-cli-py27/bin/mazer
python_version = 2.7.15 (default, Oct 15 2018, 15:26:09) [GCC 8.2.1 20180801 (Red Hat 8.2.1-2)]
python_executable = /home/adrian/venvs/galaxy-cli-py27/bin/python

```

