### PR TITLE
Dont send name/version to publish REST/upload API anymore

### DIFF
--- a/tests/ansible_galaxy/actions/test_publish_action.py
+++ b/tests/ansible_galaxy/actions/test_publish_action.py
@@ -1,0 +1,35 @@
+import logging
+
+from ansible_galaxy.actions import publish
+
+log = logging.getLogger(__name__)
+
+
+def display_callback(msg, **kwargs):
+    log.debug(msg)
+
+
+def test_publish(galaxy_context, mocker):
+    publish_api_key = "doesnt_matter_not_used"
+
+    mocker.patch('ansible_galaxy.actions.publish.GalaxyAPI.publish_file',
+                 return_value=b'{"task": "/api/v2/collection-imports/123456789"}')
+    res = publish.publish(galaxy_context, "/dev/null", publish_api_key, display_callback)
+
+    log.debug('res: %s', res)
+    assert res == 0
+
+
+def test__publish(galaxy_context, mocker):
+    publish_api_key = "doesnt_matter_not_used"
+
+    mocker.patch('ansible_galaxy.actions.publish.GalaxyAPI.publish_file',
+                 return_value=b'{"task": "/api/v2/collection-imports/8675309"}')
+    res = publish._publish(galaxy_context, "/dev/null", publish_api_key, display_callback)
+
+    log.debug('res: %s', res)
+    assert res['errors'] == []
+    assert res['success'] is True
+    assert res['response_data']['task'] == "/api/v2/collection-imports/8675309"
+
+# TODO: test error paths


### PR DESCRIPTION
The multipart-form upload API at POST /api/v2/collections
no longer needs form fields for 'name' and 'version', so
remove them and code needed to populate them.

Namespace,name, version are inferred server side from the filename
field in the form body. Currently nothing clever is done client
side to synthesize or generate that filename field if 'publish'
command is given a filename that is not of
the form 'namespace-name-1.2.3.tar.gz'.

Add a publish action unit test.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.4.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 5.0.5-200.fc29.x86_64, #1 SMP Wed Mar 27 20:58:04 UTC 2019, x86_64
executable_location = /home/adrian/venvs/mazer040test/bin/mazer
python_version = 3.6.8 (default, Jan 27 2019, 09:00:23) [GCC 8.2.1 20181215 (Red Hat 8.2.1-6)]
python_executable = /home/adrian/venvs/mazer040test/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

