### PR TITLE
Add support for /api/v2/collections API

### DIFF
--- a/ansible_galaxy/actions/info.py
+++ b/ansible_galaxy/actions/info.py
@@ -107,7 +107,7 @@ def info_repository_specs(galaxy_context,
         log.debug('showing info for repository spec: %s', repository_spec_string)
 
         if online:
-            remote_data = api.lookup_repo_by_name(repo_spec.namespace, repo_spec.name)
+            remote_data = api.get_collection_detail(repo_spec.namespace, repo_spec.name)
             if remote_data:
                 display_callback(_repr_remote_repo(remote_data))
 

--- a/ansible_galaxy/actions/install.py
+++ b/ansible_galaxy/actions/install.py
@@ -355,6 +355,7 @@ def install_repository(galaxy_context,
     try:
         find_results = install.find(fetcher)
     except exceptions.GalaxyError as e:
+        log.debug('requirement_to_install %s failed to be met: %s', requirement_to_install, e)
         log.warning('Unable to find metadata for %s: %s', requirement_spec_to_install.label, e)
         # FIXME: raise dep error exception?
         raise_without_ignore(ignore_errors, e)

--- a/ansible_galaxy/exceptions/__init__.py
+++ b/ansible_galaxy/exceptions/__init__.py
@@ -46,6 +46,14 @@ class GalaxyRepositorySpecError(GalaxyClientError):
         self.repository_spec = repository_spec
 
 
+class GalaxyCouldNotFindAnswerForRequirement(GalaxyClientError):
+    '''Raised if a fetch.find() can not find a collection that meets the requirement spec'''
+    def __init__(self, *args, **kwargs):
+        requirement_spec = kwargs.pop('requirement_spec', None)
+        super(GalaxyCouldNotFindAnswerForRequirement, self).__init__(*args, **kwargs)
+        self.requirement_spec = requirement_spec
+
+
 class GalaxyClientAPIConnectionError(GalaxyClientError):
     '''Raised if there were errors connecting to the Galaxy REST API'''
     pass

--- a/ansible_galaxy/models/requirement_spec.py
+++ b/ansible_galaxy/models/requirement_spec.py
@@ -31,7 +31,7 @@ class RequirementSpec(object):
 
     @property
     def label(self):
-        return '%s.%s' % (self.namespace, self.name)
+        return '%s.%s (version_spec: %s)' % (self.namespace, self.name, str(self.version_spec))
 
     @classmethod
     def from_dict(cls, data):

--- a/tests/ansible_galaxy/test_repository_version.py
+++ b/tests/ansible_galaxy/test_repository_version.py
@@ -19,7 +19,7 @@ def test_get_content_version_none():
                      'name': 'some_name',
                      'version': None}
     req_spec = RequirementSpec.from_dict(req_spec_data)
-    with pytest.raises(exceptions.GalaxyError, match="The list of available versions for some_namespace.some_name is empty"):
+    with pytest.raises(exceptions.GalaxyError, match="The list of available versions for some_namespace.some_name.*version_spec.*is empty"):
         repository_version.get_repository_version({}, req_spec, [])
 
 


### PR DESCRIPTION
##### SUMMARY
This is a sketch of supporting the /api/v2/collections API and removing
the use of /api/v2/repositories API. 

This includes:
 - add entry points for the API endpoints to ansible_galaxy.rest_api.GalaxyAPI
 - updating ansible_galaxy.fetch.galaxy_url to be collections centric and use the collections API
 - removing various fiddly version compare code paths that previously had to deal with a mix of semver style versions and 'v1.2.3' style versions. 
 - removing some download url guessing code that was previously based on Repository 'external_url' and sometimes just guessing at github style archive urls
 - GalaxyAPI.* methods renamed to kind of sort of reflect the names of the Galaxy server views they use (ie, get_collection_detail() and get_collection_version_list())
 - some tweaks to internals of GalaxyAPI
 - unit tests updates for the new API (and some stuff that was kind of wrong since the change to use 'requests')

Note: As of 2019-04-15, the galaxy side of (most) of /api/v2/collections API doesn't exist,
so this branch doesn't work at the moment.

Fixes: #216

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request
 

##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.4.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 5.0.5-200.fc29.x86_64, #1 SMP Wed Mar 27 20:58:04 UTC 2019, x86_64
executable_location = /home/adrian/venvs/mazer040test/bin/mazer
python_version = 3.6.8 (default, Jan 27 2019, 09:00:23) [GCC 8.2.1 20181215 (Red Hat 8.2.1-6)]
python_executable = /home/adrian/venvs/mazer040test/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

