### PR TITLE
Fix test html coverage generation, stop chdir() in autouse test fixture

### DIFF
--- a/tests/_mazer_home/mazer.yml
+++ b/tests/_mazer_home/mazer.yml
@@ -2,7 +2,7 @@ server:
   ignore_certs: false
   url: http://localhost:8000
 
-content_path: user_collections/ansible_collections
-global_content_path: global_collections/ansible_collections
+content_path: tests/_mazer_work_dir/user_collections/ansible_collections
+global_content_path: tests/_mazer_work_dir/global_collections/ansible_collections
 
 version: 1

--- a/tests/_mazer_work_dir/user_collections/ansible_collections/testing/some_collection/meta/.galaxy_install_info
+++ b/tests/_mazer_work_dir/user_collections/ansible_collections/testing/some_collection/meta/.galaxy_install_info
@@ -1,0 +1,3 @@
+install_date: Tue Apr 16 18:10:58 2019
+install_date_iso: 2019-04-16 18:10:58.442745
+version: 9.8.7

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,12 +17,4 @@ def inject_mazer_home(monkeypatch):
 
     monkeypatch.setattr("ansible_galaxy.config.defaults.MAZER_HOME",
                         _mazer_home)
-    log.debug('monkeypatched MAZER_HOME to %s', _mazer_home)
-
-
-@pytest.fixture(autouse=True)
-def use_mazer_work_dir():
-    _mazer_work_dir = os.path.join(os.path.dirname(__file__), '_mazer_work_dir')
-
-    log.debug('Chaning dir from %s to %s', os.getcwd(), _mazer_work_dir)
-    os.chdir(_mazer_work_dir)
+    # log.debug('monkeypatched MAZER_HOME to %s', _mazer_home)


### PR DESCRIPTION
##### SUMMARY
Fix test htmlcov, stop chdir() in autouse test fixture

The use_mazer_work_dir() pytest autouser fixture was doing a chdir()
into tests/_mazer_work_dir so the default test mazer.yml could
use relative paths.

But the chdir() broke things like where the htmlcoverage report
gets written (it would end up in tests/_mazer_work_dir/htmlcov).

So remove that fixture, and just use relative paths from
the top of the source tree where pytest is run to point to
the test collections

Add a .galaxy_install_info for our test collection

Mostly just to remove some warnings if running pytest
with --log-level=DEBUG

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.4.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 5.0.5-200.fc29.x86_64, #1 SMP Wed Mar 27 20:58:04 UTC 2019, x86_64
executable_location = /home/adrian/venvs/mazer040test/bin/mazer
python_version = 3.6.8 (default, Jan 27 2019, 09:00:23) [GCC 8.2.1 20181215 (Red Hat 8.2.1-6)]
python_executable = /home/adrian/venvs/mazer040test/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

