### PR TITLE
For envs w/no LANG/locale/text encoding, assume utf8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,14 @@
 # -*- coding: utf-8 -*-
 
 """The setup script."""
+import codecs
 
 from setuptools import setup, find_packages
 
-with open('README.rst') as readme_file:
+with codecs.open('README.rst', encoding='utf-8') as readme_file:
     readme = readme_file.read()
 
-with open('CHANGELOG.rst') as changelog_file:
+with codecs.open('CHANGELOG.rst', encoding='utf-8') as changelog_file:
     changelog = changelog_file.read()
 
 requirements = ['six',


### PR DESCRIPTION


##### SUMMARY
For envs w/no LANG/locale/text encoding, assume utf8 when setup.py opens
README.rst and CHANGELOG.rst

Fixes: #228

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.4.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 5.0.5-200.fc29.x86_64, #1 SMP Wed Mar 27 20:58:04 UTC 2019, x86_64
executable_location = /home/adrian/venvs/mazer_0.4.0_py36/bin/mazer
python_version = 3.6.8 (default, Jan 27 2019, 09:00:23) [GCC 8.2.1 20181215 (Red Hat 8.2.1-6)]
python_executable = /home/adrian/venvs/mazer_0.4.0_py36/bin/python3.6

```


##### ADDITIONAL INFORMATION

I wasn't able to reproduce this failure, but the changes here seem reasonable.
