### PR TITLE
Add the trailing slash on collection detail urls

### DIFF
--- a/ansible_galaxy/fetch/galaxy_url.py
+++ b/ansible_galaxy/fetch/galaxy_url.py
@@ -76,9 +76,9 @@ class GalaxyUrlFetch(base.BaseFetch):
         # TODO: extract parsing of cli content sorta-url thing and add better tests
 
         # FIXME: Remove? We kind of need the actual Collection detail yet (ever?)
-        collection_detail_url = '{base_api_url}/v2/collections/{namespace}/{name}'.format(base_api_url=api.base_api_url,
-                                                                                          namespace=urlquote(namespace),
-                                                                                          name=urlquote(collection_name))
+        collection_detail_url = '{base_api_url}/v2/collections/{namespace}/{name}/'.format(base_api_url=api.base_api_url,
+                                                                                           namespace=urlquote(namespace),
+                                                                                           name=urlquote(collection_name))
 
         log.debug('collection_detail_url: %s', collection_detail_url)
 

--- a/tests/ansible_galaxy/fetch/test_galaxy_url.py
+++ b/tests/ansible_galaxy/fetch/test_galaxy_url.py
@@ -90,7 +90,7 @@ def test_galaxy_url_fetch_find(galaxy_url_fetch, requests_mock):
                             'version': '9.3.245'})
 
     # The Collection detail
-    requests_mock.get('http://example.invalid/api/v2/collections/some_namespace/some_name',
+    requests_mock.get('http://example.invalid/api/v2/collections/some_namespace/some_name/',
                       json={'versions_url': 'http://example.invalid/api/v2/collections/some_ns/some_name/versions/'})
 
     res = galaxy_url_fetch.find()
@@ -106,7 +106,7 @@ def test_galaxy_url_fetch_find(galaxy_url_fetch, requests_mock):
 def test_galaxy_url_fetch_find_no_repo_data(galaxy_url_fetch, galaxy_context, requests_mock):
     requests_mock.get('http://example.invalid/api/',
                       json={'current_version': 'v2'})
-    requests_mock.get('http://example.invalid/api/v2/collections/some_namespace/some_name',
+    requests_mock.get('http://example.invalid/api/v2/collections/some_namespace/some_name/',
                       json={})
 
     # galaxy_url_fetch = galaxy_url.GalaxyUrlFetch(requirement_spec=req_spec, galaxy_context=context)


### PR DESCRIPTION
ie, urls like
 https://galaxy.ansible.com/api/v2/collections/ns/name/

Avoid an unneeded 301 redirect.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

