### PR TITLE
Galaxy rest API error support, better result paging, etc

### DIFF
--- a/ansible_galaxy/actions/publish.py
+++ b/ansible_galaxy/actions/publish.py
@@ -46,9 +46,9 @@ def _publish(galaxy_context,
         response_data = api.publish_file(form, publish_api_key)
         log.debug('response_data: %s', response_data)
         results['response_data'] = response_data
-    except exceptions.GalaxyRequestsError as requests_exc:
+    except exceptions.GalaxyError as exc:
         results['success'] = False
-        results['errors'].append(str(requests_exc))
+        results['errors'].append(str(exc))
 
     return results
 
@@ -62,6 +62,7 @@ def publish(galaxy_context, archive_path, publish_api_key, display_callback):
 
     log.debug('cli publish action results: %s', results)
 
+    # TODO: add a error_display_callback that understands the format of rest API responses
     if results['errors']:
         for error in results['errors']:
             display_callback(error)

--- a/ansible_galaxy/fetch/galaxy_url.py
+++ b/ansible_galaxy/fetch/galaxy_url.py
@@ -88,7 +88,7 @@ class GalaxyUrlFetch(base.BaseFetch):
             raise exceptions.GalaxyClientError("- sorry, %s was not found on %s." % (self.requirement_spec.label,
                                                                                      api.api_server))
 
-        versions_url = collection_detail_data.get('versions_url', None)
+        versions_list_url = collection_detail_data.get('versions_url', None)
 
         # TODO: if versions ends up with a 'related' we could follow it instead of specific
         #       get_collection_version_list()
@@ -102,9 +102,9 @@ class GalaxyUrlFetch(base.BaseFetch):
         #   "href": "/api/v2/collections/ansible/k8s/versions/1.2.3/",
         #  }]
         log.debug('Getting collectionversions for %s.%s from %s',
-                  namespace, collection_name, versions_url)
+                  namespace, collection_name, versions_list_url)
 
-        collection_version_list_data = api._get_paginated_list(versions_url)
+        collection_version_list_data = api.get_object(versions_list_url)
 
         log.debug('collectionvertlist data:\n%s', collection_version_list_data)
 

--- a/ansible_galaxy/multipart_form.py
+++ b/ansible_galaxy/multipart_form.py
@@ -1,4 +1,3 @@
-import mimetypes
 import io
 import uuid
 
@@ -23,11 +22,9 @@ class MultiPartForm(object):
         self.form_fields.append((name, value))
         return
 
-    def add_file(self, fieldname, filename, fileHandle, mimetype=None):
+    def add_file(self, fieldname, filename, fileHandle, mimetype):
         """Add a file to be uploaded."""
         body = fileHandle.read()
-        if mimetype is None:
-            mimetype = mimetypes.guess_type(filename)[0] or 'application/octet-stream'
         self.files.append((fieldname, filename, mimetype, body))
         return
 

--- a/ansible_galaxy/rest_api.py
+++ b/ansible_galaxy/rest_api.py
@@ -58,6 +58,18 @@ def user_agent():
     return USER_AGENT_FORMAT.format(**user_agent_data)
 
 
+def response_slug(response):
+    # The slug we use to identify a request by method, url and request id
+    # For ex, '"GET https://galaxy.ansible.com/api/v1/repositories" c48937f4e8e849828772c4a0ce0fd5ed'
+    slug = '"%s %s" %s' % (response.request.method, response.url, response.request.headers['X-Request-Id'])
+    return slug
+
+
+def request_slug(request):
+    slug = '"%s %s" %s' % (request.method, request.url, request.headers['X-Request-Id'])
+    return slug
+
+
 def g_connect(method):
     ''' wrapper to lazily initialize connection info to galaxy '''
 
@@ -75,6 +87,120 @@ def g_connect(method):
     return wrapped
 
 
+class RestClient(object):
+    def __init__(self, http_context=None):
+        self.http_context = http_context or {}
+
+        log.debug('http_context: %s', http_context)
+
+        self.user_agent = user_agent()
+
+        log.debug('User Agent: %s', self.user_agent)
+
+        self.session = requests.Session()
+        self.session.headers.update({'User-Agent': self.user_agent})
+
+        self.log = logging.getLogger(__name__ + '.' + self.__class__.__name__)
+
+    @property
+    def validate_certs(self):
+        return not self.http_context['server']['ignore_certs']
+
+    # TODO: raise an API/net specific exception?
+    def mkrequest(self, url, args=None, headers=None, http_method=None):
+        http_method = http_method or 'GET'
+
+        request_headers = headers or {}
+        request_id = uuid.uuid4().hex
+        request_headers['X-Request-ID'] = request_id
+
+        # The slug we use to identify a request by method, url and request id
+        # For ex, '"GET https://galaxy.ansible.com/api/v1/repositories" c48937f4e8e849828772c4a0ce0fd5ed'
+        pre_request_slug = '"%s %s" %s' % (http_method, url, request_id)
+
+        log.debug('self.session: %s', self.session)
+
+        try:
+            # log the http request_slug with request_id to the main log and
+            # to the http log, both at INFO level for now.
+            http_log.info('%s', pre_request_slug)
+            self.log.info('%s', pre_request_slug)
+
+            request_log.debug('%s args=%s', pre_request_slug, args)
+            request_log.debug('%s headers=%s', pre_request_slug, request_headers)
+
+            resp = self.session.request(http_method, url, data=args, headers=request_headers,
+                                        verify=self.validate_certs)
+
+            log.debug('resp: %s', resp)
+            log.debug('resp.request: %s', resp.request)
+            log.debug('resp.request.headers: %s', resp.request.headers)
+
+            slug = response_slug(resp)
+
+            response_log.info('%s http_status=%s', slug, resp.status_code)
+            response_log.debug('%s reason=%s', slug, resp.reason)
+            response_log.debug('%s headers=%s', slug, resp.headers)
+            response_log.debug('%s history=%s', slug, resp.history)
+
+            if resp.history:
+                for redirect in resp.history:
+                    log.debug('%s Redirected. %s is redirected to %s',
+                              slug, redirect.url, redirect.headers['Location'])
+
+            response_log.debug('%s resp repr:\n%r', slug, resp)
+
+            # FIXME: making the request and loading the response should be sep try/except blocks
+            response_body = resp.text
+
+            # debug log the raw response body
+            response_log.debug('%s response body:\n%s', slug, response_body)
+
+        except requests.exceptions.RequestException as http_exc:
+            self.log.debug('Exception on %s', pre_request_slug)
+            self.log.exception("%s: %s", pre_request_slug, http_exc)
+
+            http_log.error('%s data from server error response:\n%s', pre_request_slug, http_exc.response)
+
+            if http_exc.response:
+                # FIXME: probably need a try/except here if the response body isnt json which
+                #        can happen if a proxy mangles the response
+                try:
+                    error_msg = 'HTTP error on request %s: %s' % (pre_request_slug,
+                                                                  http_exc.response.json()['detail'])
+                    raise exceptions.GalaxyClientError(error_msg)
+                except (ValueError, KeyError, TypeError) as detail_parse_exc:
+                    self.log.exception("%s: %s", pre_request_slug, detail_parse_exc)
+                    self.log.warning('Unable to parse error detail from response for request: %s response:  %s', request_slug, detail_parse_exc)
+
+            # TODO: great place to be able to use 'raise from'
+            raise exceptions.GalaxyClientError(http_exc)
+        except (ssl.SSLError, socket.error) as e:
+            self.log.debug('Connection error to Galaxy API for request %s: %s', pre_request_slug, e)
+            self.log.exception("%s: %s", pre_request_slug, e)
+
+            raise exceptions.GalaxyClientAPIConnectionError('Connection error to Galaxy API for request %s: %s' % (pre_request_slug, e))
+
+        return resp
+
+# main objects we will deal with
+#
+# Api
+#     GET    /api/
+# Collection
+#     GET    /api/v2/collections/{namespace}/{name}
+#     GET    /api/v2/collections/{id}
+#    POST    /api/v2/collections/       (multiparm form post) "publish"
+#
+# CollectionVersion
+#     GET     /api/v2/collections/{namespace}/{name}/versions/{version}
+#
+# CollectionCollectionVersion
+#     GET    /api/v2/collections/{namespace}/{name}/versions/
+#            ('versions_url' ref on Collection)
+#
+
+
 class GalaxyAPI(object):
     ''' This class is meant to be used as a API client for an Ansible Galaxy server '''
 
@@ -86,106 +212,16 @@ class GalaxyAPI(object):
 
         log.debug('Using galaxy server URL %s with ignore_certs=%s', galaxy_context.server['url'], galaxy_context.server['ignore_certs'])
 
-        self._validate_certs = not galaxy_context.server['ignore_certs']
-        self.initialized = False
-
         self.log = logging.getLogger(__name__ + '.' + self.__class__.__name__)
 
         # set the API server
         self._api_server = galaxy_context.server['url']
 
+        self.rest_client = RestClient(http_context={'server': galaxy_context.server})
         # self.log.debug('Validate TLS certificates for %s: %s', self._api_server, self._validate_certs)
 
-        self.user_agent = user_agent()
-        log.debug('User Agent: %s', self.user_agent)
-
-        self.session = requests.Session()
-        self.session.headers.update({'User-Agent': self.user_agent})
-
-    # TODO: raise an API/net specific exception?
-    @g_connect
-    def __call_galaxy(self, url, args=None, headers=None, http_method=None):
-        http_method = http_method or 'GET'
-
-        request_headers = headers or {}
-        request_id = uuid.uuid4().hex
-        request_headers['X-Request-ID'] = request_id
-
-        # The slug we use to identify a request by method, url and request id
-        # For ex, '"GET https://galaxy.ansible.com/api/v1/repositories" c48937f4e8e849828772c4a0ce0fd5ed'
-        request_slug = '"%s %s" %s' % (http_method, url, request_id)
-
-        log.debug('self.session: %s', self.session)
-
-        try:
-            # log the http request_slug with request_id to the main log and
-            # to the http log, both at INFO level for now.
-            http_log.info('%s', request_slug)
-            self.log.info('%s', request_slug)
-
-            request_log.debug('%s args=%s', request_slug, args)
-            request_log.debug('%s headers=%s', request_slug, request_headers)
-
-            resp = self.session.request(http_method, url, data=args, headers=request_headers,
-                                        verify=self._validate_certs)
-            log.debug('resp: %s', resp)
-            log.debug('resp.request: %s', resp.request)
-            log.debug('resp.request.headers: %s', resp.request.headers)
-
-            response_log.info('%s http_status=%s', request_slug, resp.status_code)
-            response_log.debug('%s reason=%s', request_slug, resp.reason)
-            response_log.debug('%s headers=%s', request_slug, resp.headers)
-            response_log.debug('%s history=%s', request_slug, resp.history)
-
-            if resp.history:
-                for redirect in resp.history:
-                    log.debug('%s Redirected. %s is redirected to %s',
-                              request_slug, redirect.url, redirect.headers['Location'])
-
-            response_log.debug('%s resp repr:\n%r', request_slug, resp)
-
-            # FIXME: making the request and loading the response should be sep try/except blocks
-            response_body = resp.text
-
-            # debug log the raw response body
-            response_log.debug('%s response body:\n%s', request_slug, response_body)
-
-            # TODO/FIXME: Move the loading/parsing of json up a layer, since we don't always need it
-            try:
-                data = resp.json()
-            except ValueError as e:
-                log.exception(e)
-                data = {}
-
-            # debug log a json version of the data that was created from the response
-            response_log.debug('%s data:\n%s', request_slug, json.dumps(data, indent=2))
-
-        except requests.exceptions.RequestException as http_exc:
-            self.log.debug('Exception on %s', request_slug)
-            self.log.exception("%s: %s", request_slug, http_exc)
-
-            http_log.error('%s data from server error response:\n%s', request_slug, http_exc.response)
-
-            if http_exc.response:
-                # FIXME: probably need a try/except here if the response body isnt json which
-                #        can happen if a proxy mangles the response
-                try:
-                    error_msg = 'HTTP error on request %s: %s' % (request_slug,
-                                                                  http_exc.response.json()['detail'])
-                    raise exceptions.GalaxyClientError(error_msg)
-                except (ValueError, KeyError, TypeError) as detail_parse_exc:
-                    self.log.exception("%s: %s", request_slug, detail_parse_exc)
-                    self.log.warning('Unable to parse error detail from response for request: %s response:  %s', request_slug, detail_parse_exc)
-
-            # TODO: great place to be able to use 'raise from'
-            raise exceptions.GalaxyClientError(http_exc)
-        except (ssl.SSLError, socket.error) as e:
-            self.log.debug('Connection error to Galaxy API for request %s: %s', request_slug, e)
-            self.log.exception("%s: %s", request_slug, e)
-
-            raise exceptions.GalaxyClientAPIConnectionError('Connection error to Galaxy API for request %s: %s' % (request_slug, e))
-
-        return data
+        # self._validate_certs = not galaxy_context.server['ignore_certs']
+        self.initialized = False
 
     @property
     def api_server(self):
@@ -195,10 +231,6 @@ class GalaxyAPI(object):
     def base_api_url(self):
         return '%s/api' % self._api_server
 
-    @property
-    def validate_certs(self):
-        return self._validate_certs
-
     def _get_server_api_version(self):
         """
         Fetches the Galaxy API current version to ensure
@@ -206,22 +238,8 @@ class GalaxyAPI(object):
         """
         url = '%s/api/' % self._api_server
 
-        try:
-            resp = self.session.get(url, verify=self._validate_certs)
-        except requests.exceptions.RequestException as e:
-            raise exceptions.GalaxyClientError("Failed to get data from the API server (%s): %s " % (url, to_native(e)))
-
-        try:
-            # data = json.loads(to_text(return_data.read(), errors='surrogate_or_strict'))
-            data = resp.json()
-        except Exception as e:
-            raise exceptions.GalaxyClientError("Could not process data from the API server (%s): %s " % (url, to_native(e)))
-
-        # Don't raise connection indicating errors unless we dont have valid error json
-        try:
-            resp.raise_for_status()
-        except Exception as e:
-            raise exceptions.GalaxyClientError("Failed to get data from the API server (%s): %s " % (url, to_native(e)))
+        # Call without the @g_connect wrapper to avoid recursion
+        data = self._get_object(href=url)
 
         if 'current_version' not in data:
             raise exceptions.GalaxyClientError("missing required 'current_version' from server response (%s)" % url)
@@ -273,17 +291,62 @@ class GalaxyAPI(object):
         url = "%s%s" % (self.base_api_url,
                         '/v2/collections/{namespace}/{name}'.format(namespace=namespace, name=name))
 
-        data = self.__call_galaxy(url, http_method='GET')
+        # data = self.rest_client.mkrequest(url, http_method='GET')
+        data = self.get_object(href=url)
+        return data
+
+    def _get_object(self, href=None):
+        '''Get a full url and return deserialized results'''
+        url = href
+        # url = "%s%s" % (self.api_server, href)
+
+        resp = self.rest_client.mkrequest(url, http_method='GET')
+
+        slug = response_slug(resp)
+
+        # TODO/FIXME: Move the loading/parsing of json up a layer, since we don't always need it
+        try:
+            data = resp.json()
+            # debug log a json version of the data that was created from the response
+            self.log.debug('%s data:\n%s', slug, json.dumps(data, indent=2))
+            return data
+        except ValueError as e:
+            log.exception(e)
+            raise exceptions.GalaxyClientError("Could not process data from the API server (%s): %s " % (resp.url, to_native(e)))
+
+        # The rest of this is handling cases where we got an http error, but the body did not contain json
+
+        # Don't raise connection indicating errors unless we dont have valid error json
+        try:
+            resp.raise_for_status()
+        except requests.exceptions.HTTPError as http_exc:
+            self.log.debug('Exception on %s', slug)
+            self.log.exception("%s: %s", slug, http_exc)
+
+            http_log.error('%s data from server error response:\n%s', slug, http_exc.response)
+
+            if http_exc.response:
+                # TODO: plugin in exception mapper layer if we need it, to handle the error response from galaxy api
+
+                try:
+                    error_msg = 'HTTP error on request %s: %s' % (slug,
+                                                                  # TODO: update for new error message format
+                                                                  http_exc.response.json()['detail'])
+                    raise exceptions.GalaxyClientError(error_msg)
+                except (ValueError, KeyError, TypeError) as detail_parse_exc:
+                    self.log.exception("%s: %s", slug, detail_parse_exc)
+                    self.log.warning('Unable to parse error detail from response for request: %s response:  %s', slug, detail_parse_exc)
+
+            # TODO: great place to be able to use 'raise from'
+            # TODO: if we want client specific errors for say, a 409 on publish, could raise them here
+            raise exceptions.GalaxyClientError(http_exc)
+
         return data
 
     @g_connect
     def get_object(self, href=None):
         '''Get a full url and return deserialized results'''
-        url = href
-        # url = "%s%s" % (self.api_server, href)
-
-        data = self.__call_galaxy(url, http_method='GET')
-        return data
+        return self._get_object(href=href)
 
     # FIXME: update publish_file to be easier to test/mock
     # This is so unit test can mock args to form.add_file()
@@ -328,8 +391,9 @@ class GalaxyAPI(object):
         try:
 
             # TODO: pass in a file-like object and use stream=True
-            resp = self.session.post(url, data=form_buffer,
-                                     headers=request_headers, verify=self._validate_certs)
+            resp = self.rest_client.mkrequest(url, args=form_buffer,
+                                              headers=request_headers,
+                                              http_method='POST')
 
         except socket.error as exc:
             log.exception(exc)

--- a/ansible_galaxy/rest_api.py
+++ b/ansible_galaxy/rest_api.py
@@ -57,11 +57,6 @@ def response_slug(response):
     return slug
 
 
-def request_slug(request):
-    slug = '"%s %s" %s' % (request.method, request.url, request.headers['X-Request-Id'])
-    return slug
-
-
 def g_connect(method):
     ''' wrapper to lazily initialize connection info to galaxy '''
 

--- a/tests/ansible_galaxy/actions/test_publish_action.py
+++ b/tests/ansible_galaxy/actions/test_publish_action.py
@@ -13,7 +13,7 @@ def test_publish(galaxy_context, mocker):
     publish_api_key = "doesnt_matter_not_used"
 
     mocker.patch('ansible_galaxy.actions.publish.GalaxyAPI.publish_file',
-                 return_value=b'{"task": "/api/v2/collection-imports/123456789"}')
+                 return_value={"task": "/api/v2/collection-imports/123456789"})
     res = publish.publish(galaxy_context, "/dev/null", publish_api_key, display_callback)
 
     log.debug('res: %s', res)
@@ -24,7 +24,7 @@ def test__publish(galaxy_context, mocker):
     publish_api_key = "doesnt_matter_not_used"
 
     mocker.patch('ansible_galaxy.actions.publish.GalaxyAPI.publish_file',
-                 return_value=b'{"task": "/api/v2/collection-imports/8675309"}')
+                 return_value={"task": "/api/v2/collection-imports/8675309"})
     res = publish._publish(galaxy_context, "/dev/null", publish_api_key, display_callback)
 
     log.debug('res: %s', res)

--- a/tests/ansible_galaxy/actions/test_publish_action.py
+++ b/tests/ansible_galaxy/actions/test_publish_action.py
@@ -1,6 +1,8 @@
 import logging
+import os
 
 from ansible_galaxy.actions import publish
+from ansible_galaxy.models.context import GalaxyContext
 
 log = logging.getLogger(__name__)
 
@@ -31,5 +33,50 @@ def test__publish(galaxy_context, mocker):
     assert res['errors'] == []
     assert res['success'] is True
     assert res['response_data']['task'] == "/api/v2/collection-imports/8675309"
+
+
+def test__publish_api_error(galaxy_context, mocker, requests_mock):
+    publish_api_key = "doesnt_matter_not_used"
+
+    context = GalaxyContext(content_path=galaxy_context.content_path,
+                            server={'url': 'http://notreal.invalid:8000',
+                                    'ignore_certs': False})
+    log.debug('galaxy_context: %s', context)
+
+    err_409_conflict_json = {'code': 'conflict.collection_exists', 'message': 'Collection "testing-ansible_testing_content-4.0.4" already exists.'}
+    requests_mock.get('http://notreal.invalid:8000/api/',
+                      status_code=200,
+                      json={'current_version': 'v1'})
+
+    requests_mock.post('http://notreal.invalid:8000/api/v2/collections/',
+                       status_code=409,
+                       reason='Conflict',
+                       json=err_409_conflict_json)
+
+    res = publish._publish(context, "/dev/null", publish_api_key, display_callback)
+
+    log.debug('res: %s', res)
+    assert res['errors'] == ['Error publishing null to http://notreal.invalid:8000/api/v2/collections/ '
+                             + '- Collection "testing-ansible_testing_content-4.0.4" already exists.']
+    assert res['success'] is False
+
+
+def test_publish_api_errors(mocker):
+    error_msg = 'Error publishing ns-n-1.0.0 to http://notreal.invalid:8000/api/v2/collections/ - Collection "ns-n-1.0.0" already exists.'
+    mocker.patch('ansible_galaxy.actions.publish._publish',
+                 return_value={'errors':
+                               [error_msg], 'success': False})
+
+    mock_display_callback = mocker.Mock()
+
+    context = None
+    publish_api_key = None
+    res = publish.publish(context, "/dev/null", publish_api_key, mock_display_callback)
+
+    log.debug('res: %s', res)
+
+    assert res == os.EX_SOFTWARE  # 70
+    assert mock_display_callback.called is True
+
 
 # TODO: test error paths

--- a/tests/ansible_galaxy/test_rest_api.py
+++ b/tests/ansible_galaxy/test_rest_api.py
@@ -1,11 +1,10 @@
 import io
-import json
 import logging
-import ssl
 import sys
 
 import pytest
 
+import requests
 from six import text_type
 
 import ansible_galaxy
@@ -465,7 +464,6 @@ def test_get_object_500_with_html(galaxy_api_mocked, requests_mock):
     # exc str(): Could not process data from the API server (http://bogus.invalid:9443/api/v24/rhymes/orange/): Expecting value: line 1 column 1 (char 0)
     with pytest.raises(exceptions.GalaxyRestServerError,
                        match='.*500 Server Error: Internal Server Ooopsie for url.*bogus.invalid:9443.*') as exc_info:
-        # match="Could not process data from the API server") as exc_info:
         galaxy_api_mocked.get_object(href=url)
 
     log.debug('exc_info: %s', exc_info)
@@ -514,9 +512,10 @@ def test_get_object_500_with_html(galaxy_api_mocked, requests_mock):
 def test_galaxy_api_get_collection_detail_SSLError(mocker, galaxy_api, requests_mock):
     ssl_msg = 'ssl stuff broke... good luck and godspeed.'
     requests_mock.get('http://bogus.invalid:9443/api/v2/collections/some-test-namespace/some-test-name',
-                      exc=ssl.SSLError(ssl_msg)
+                      exc=requests.exceptions.SSLError(ssl_msg)
                       )
 
+    # ansible_galaxy.exceptions.GalaxyClientAPIConnectionError: ssl stuff broke... good luck and godspeed.
     with pytest.raises(exceptions.GalaxyClientAPIConnectionError, match='.*%s.*' % ssl_msg) as exc_info:
         galaxy_api.get_collection_detail('some-test-namespace', 'some-test-name')
 

--- a/tests/ansible_galaxy/test_rest_api.py
+++ b/tests/ansible_galaxy/test_rest_api.py
@@ -5,8 +5,6 @@ import ssl
 import sys
 
 import pytest
-import requests
-import mock
 
 from six import text_type
 
@@ -27,79 +25,47 @@ def test_galaxy_api_init():
     assert api.galaxy_context == gc
 
 
-class FauxUrlOpenResponse(object):
-    def __init__(self, url=None, body=None, status=None, data=None, info=None, redirect_url=None):
-        self.status_code = status or 200
-        self.data = data
-        if self.data is not None:
-            self.body = json.dumps(self.data)
-        else:
-            self.body = body or ''
-        self.url = url
-        self._info = info
-        self.redirect_url = redirect_url or url
-        self.request = requests.Request(method='GET', url=self.redirect_url)
-        self.reason = 'Some Reason'
-        self.headers = {}
-        self.history = []
-        self.text = ''
-
-    # mock requests.Response.json
-    def json(self):
-        if self.body is None:
-            raise ValueError('Response body was not valid JSON')
-
-        return json.loads(self.body)
-
-    def raise_for_status(self):
-        if self.status_code >= 400:
-            raise requests.exceptions.HTTPError("A Faux %s error occurred" % self.status_code, response=self)
-
-    def __repr__(self):
-        return '%s(url="%s", status_code=%s, info="%s", body="%s", data="%s")' % \
-            (self.__class__.__name__, self.url, self.status_code, self._info, self.body, self.data)
-
-
-class FauxUrlResponder(object):
-    def __init__(self, list_of_responses=None):
-        self.responses = list_of_responses or []
-        self.calls = []
-        # log.debug('self.responses: %s', pprint.pformat(self.responses))
-
-    def __call__(self, *args, **kwargs):
-        next_response = self.responses.pop(0)
-
-        # set the response url to the same as the request url
-        url = args[1]
-
-        next_response.url = url
-
-        self.calls.append({'args': args,
-                           'kwargs': kwargs,
-                           'response': next_response})
-        # log.debug('next_response: %s', next_response)
-        return next_response
-
-    def __repr__(self):
-        return '%s(responses=%s, calls=%s)' % (self.__class__.__name__,
-                                               self.responses,
-                                               self.calls)
-
-
-default_server_dict = {'url': 'http://bogus.invalid:9553',
+default_server_dict = {'url': 'http://bogus.invalid:9443',
                        'ignore_certs': False}
 
 
-def test_galaxy_api_get_server_api_version(mocker):
-    mocker.patch('ansible_galaxy.rest_api.requests.Session.request',
-                 new=FauxUrlResponder(
-                     [
-                         FauxUrlOpenResponse(data={'current_version': 'v1'}),
-                     ]
-                 ))
+@pytest.fixture
+def galaxy_context_example_invalid(galaxy_context):
+    context = GalaxyContext(content_path=galaxy_context.content_path,
+                            server={'url': default_server_dict['url'],
+                                    'ignore_certs': False})
+    return context
 
-    gc = GalaxyContext(server=default_server_dict)
-    api = rest_api.GalaxyAPI(gc)
+
+@pytest.fixture
+def galaxy_api(galaxy_context_example_invalid, requests_mock):
+
+    # mock the result of _get_server_api_versions here, so that we dont get the extra
+    # call when calling the tests
+
+    requests_mock.get('http://bogus.invalid:9443/api/',
+                      json={'current_version': 'v1'})
+    requests_mock.get('http://bogus.invalid:9443/api/whatever/',
+                      json={'results': [{'foo1': 11,
+                                         'foo2': 12}
+                                        ]
+                            })
+
+    api = rest_api.GalaxyAPI(galaxy_context_example_invalid)
+
+    # do a call so that we run g_connect and _get_server_api_versions by side effect now
+    # api.get_object(href='http://bogus.invalid:9443/api/whatever/')
+
+    log.debug('api: %s', api)
+
+    yield api
+
+
+def test_galaxy_api_get_server_api_version(galaxy_context_example_invalid, requests_mock):
+    requests_mock.get('http://bogus.invalid:9443/api/',
+                      json={'current_version': 'v1'})
+
+    api = rest_api.GalaxyAPI(galaxy_context_example_invalid)
     res = api._get_server_api_version()
 
     log.debug('res: %s %r', res, res)
@@ -108,44 +74,28 @@ def test_galaxy_api_get_server_api_version(mocker):
     assert res == 'v1'
 
 
-def test_galaxy_api_get_server_api_version_not_supported_version(mocker):
-    mocker.patch('ansible_galaxy.rest_api.requests.Session.request',
-                 new=FauxUrlResponder(
-                     [
-                         FauxUrlOpenResponse(data={'current_version': 'v11.22.13beta4.preRC-16.0.0.0.42.42.37.1final'}),
-                         # doesn't matter response, just need a second call
-                         FauxUrlOpenResponse(data={'results': 'stuff'},
-                                             url='blippyblopfakeurl'),
-                     ]
-                 ))
+def test_galaxy_api_get_server_api_version_not_supported_version(galaxy_context_example_invalid, requests_mock):
+    requests_mock.get('http://bogus.invalid:9443/api/',
+                      json={'current_version': 'v11.22.13beta4.preRC-16.0.0.0.42.42.37.1final'})
 
-    gc = GalaxyContext(server=default_server_dict)
-    api = rest_api.GalaxyAPI(gc)
+    api = rest_api.GalaxyAPI(galaxy_context_example_invalid)
 
     # expected to raise a client error about the server version not being supported in client
     # TODO: should be the server deciding if the client version is sufficient
-    try:
+    with pytest.raises(exceptions.GalaxyClientError, match='.*Unsupported Galaxy server API.*') as exc_info:
         api.get_collection_detail('test-namespace', 'test-repo')
-    except exceptions.GalaxyClientError as e:
-        log.exception(e)
-        assert 'Unsupported Galaxy server API' in '%s' % e
-        return
 
-    assert False, 'Expected a GalaxyClientError about supported server apis, but didnt happen'
+    log.debug('exc_info: %s', exc_info)
 
 
-def test_galaxy_api_get_server_api_version_HTTPError_500(mocker):
+def test_galaxy_api_get_server_api_version_HTTPError_500(galaxy_context_example_invalid, requests_mock):
     data = {"detail": "Stuff broke, 500 error but server response has valid json include the detail key"}
+    requests_mock.get('http://bogus.invalid:9443/api/',
+                      json=data,
+                      status_code=500)
 
-    mocker.patch('ansible_galaxy.rest_api.requests.Session.request',
-                 new=FauxUrlResponder(
-                     [
-                         FauxUrlOpenResponse(status=500, data=data),
-                     ],
-                 ))
+    api = rest_api.GalaxyAPI(galaxy_context_example_invalid)
 
-    gc = GalaxyContext(server=default_server_dict)
-    api = rest_api.GalaxyAPI(gc)
     try:
         api._get_server_api_version()
     except exceptions.GalaxyClientError as e:
@@ -157,16 +107,13 @@ def test_galaxy_api_get_server_api_version_HTTPError_500(mocker):
     assert False, 'Expected a GalaxyClientError here but that did not happen'
 
 
-def test_galaxy_api_get_server_api_version_HTTPError_not_json(mocker):
-    mocker.patch('ansible_galaxy.rest_api.requests.Session.request',
-                 new=FauxUrlResponder(
-                     [
-                         FauxUrlOpenResponse(status=500, body='{stuff-that-is-not-valid-json'),
-                     ]
-                 ))
+def test_galaxy_api_get_server_api_version_HTTPError_not_json(galaxy_context_example_invalid, requests_mock):
+    requests_mock.get('http://bogus.invalid:9443/api/',
+                      text='{stuff-that-is-not-valid-json',
+                      status_code=500)
 
-    gc = GalaxyContext(server=default_server_dict)
-    api = rest_api.GalaxyAPI(gc)
+    api = rest_api.GalaxyAPI(galaxy_context_example_invalid)
+
     try:
         api._get_server_api_version()
     except exceptions.GalaxyClientError as e:
@@ -179,17 +126,13 @@ def test_galaxy_api_get_server_api_version_HTTPError_not_json(mocker):
     assert False, 'Expected a GalaxyClientError here but that did not happen'
 
 
-def test_galaxy_api_get_server_api_version_no_current_version(mocker):
-    mocker.patch('ansible_galaxy.rest_api.requests.Session.request',
-                 new=FauxUrlResponder(
-                     [
-                         FauxUrlOpenResponse(status=200, data={'some_key': 'some_value',
-                                                               'but_not_current_value': 2}),
-                     ]
-                 ))
+def test_galaxy_api_get_server_api_version_no_current_version(galaxy_context_example_invalid, requests_mock):
+    requests_mock.get('http://bogus.invalid:9443/api/',
+                      json={'some_key': 'some_value',
+                            'but_not_current_value': 2},
+                      status_code=200)
 
-    gc = GalaxyContext(server=default_server_dict)
-    api = rest_api.GalaxyAPI(gc)
+    api = rest_api.GalaxyAPI(galaxy_context_example_invalid)
     try:
         api._get_server_api_version()
     except exceptions.GalaxyClientError as e:
@@ -202,54 +145,12 @@ def test_galaxy_api_get_server_api_version_no_current_version(mocker):
     assert False, 'Expected a GalaxyClientError here but that did not happen'
 
 
-galaxy_context_params = [{'server': default_server_dict,
-                          'content_dir': None}]
-
-
-@pytest.fixture(scope='module',
-                params=galaxy_context_params)
-def galaxy_api(request):
-    gc = GalaxyContext(server=request.param['server'])
-    # log.debug('gc: %s', gc)
-
-    # mock the result of _get_server_api_versions here, so that we dont get the extra
-    # call when calling the tests
-
-    patcher = mock.patch('ansible_galaxy.rest_api.requests.Session.request',
-                         new=FauxUrlResponder(
-                             [
-                                 FauxUrlOpenResponse(data={'current_version': 'v1'}),
-                                 FauxUrlOpenResponse(data={'results': [{'foo1': 11, 'foo2': 12}]},
-                                                     url='blippyblopfakeurl'),
-                             ]
-                         ))
-
-    patcher.start()
-    api = rest_api.GalaxyAPI(gc)
-
-    # do a call so that we run g_connect and _get_server_api_versions by side effect now
-    api.get_collection_detail('test-namespace', 'test-repo')
-
-    # now unpatch
-    patcher.stop()
-
-    yield api
-
-
 def test_galaxy_api_properties(galaxy_api):
     log.debug('api_server: %s', galaxy_api.api_server)
     log.debug('validate_certs: %s', galaxy_api.validate_certs)
 
     assert galaxy_api.api_server == default_server_dict['url']
     assert galaxy_api.validate_certs is True
-
-
-@pytest.fixture
-def galaxy_context_example_invalid(galaxy_context):
-    context = GalaxyContext(content_path=galaxy_context.content_path,
-                            server={'url': 'http://example.invalid',
-                                    'ignore_certs': False})
-    return context
 
 
 @pytest.fixture
@@ -260,7 +161,7 @@ def galaxy_api_mocked(mocker, galaxy_context_example_invalid, requests_mock):
     mocker.patch('ansible_galaxy.rest_api.GalaxyAPI._form_add_file_args',
                  return_value=('file', 'dummy args', None, 'application/octet-stream'))
 
-    requests_mock.get('http://example.invalid/api/',
+    requests_mock.get('http://bogus.invalid:9443/api/',
                       json={'current_version': 'v2'})
 
     api = rest_api.GalaxyAPI(galaxy_context_example_invalid)
@@ -271,8 +172,8 @@ def galaxy_api_mocked(mocker, galaxy_context_example_invalid, requests_mock):
 def test_galaxy_api_publish_file_202(galaxy_api_mocked, requests_mock, tmpdir):
     status_202_json = {"task": "https://galaxy-dev.ansible.com/api/v2/collection-imports/224/"}
 
-    # POST http://example.invalid/api/v2/collections/
-    requests_mock.post('http://example.invalid/api/v2/collections/',
+    # POST http://bogus.invalid:9443/api/v2/collections/
+    requests_mock.post('http://bogus.invalid:9443/api/v2/collections/',
                        status_code=202,
                        json=status_202_json)
 
@@ -287,8 +188,8 @@ def test_galaxy_api_publish_file_202(galaxy_api_mocked, requests_mock, tmpdir):
 def test_galaxy_api_publish_file_conflict_409(galaxy_api_mocked, requests_mock, tmpdir):
     err_409_conflict_json = {'code': 'conflict.collection_exists', 'message': 'Collection "testing-ansible_testing_content-4.0.4" already exists.'}
 
-    # POST http://example.invalid/api/v2/collections/
-    requests_mock.post('http://example.invalid/api/v2/collections/',
+    # POST http://bogus.invalid:9443/api/v2/collections/
+    requests_mock.post('http://bogus.invalid:9443/api/v2/collections/',
                        status_code=409,
                        json=err_409_conflict_json)
 
@@ -298,31 +199,28 @@ def test_galaxy_api_publish_file_conflict_409(galaxy_api_mocked, requests_mock, 
     log.debug('exc_info:%s', exc_info)
 
 
-def test_galaxy_api_get_collection_detail(mocker, galaxy_api):
+def test_galaxy_api_get_collection_detail(mocker, galaxy_api, requests_mock):
     data_dict = {
         "id": 24,
-        "href": "/api/v2/collections/ansible/k8s/",
+        "href": "http://bogus.invalid:9443/api/v2/collections/ansible/k8s/",
         "name": "k8s",
         "namespace": {
             "id": 12,
-            "href": "/api/v2/namespaces/ansible/",
+            "href": "http://bogus.invalid:9443/api/v2/namespaces/ansible/",
             "name": "ansible",
         },
+        "versions_url": "http://bogus.invalid:9443/api/v2/collections/ansible/k8s/versions/",
         "highest_version": {
             "version": "4.2.0",
-            "href": "/api/v2/collections/ansible/k8s/versions/4.2.0",
+            "href": "http://bogus.invalid:9443/api/v2/collections/ansible/k8s/versions/4.2.0",
         },
         "deprecated": "false",
         "created": "2019-03-15T10:05:11.589728-04:00",
         "modified": "2019-03-22T10:05:11.589728-04:00",
     }
-    mocker.patch('ansible_galaxy.rest_api.requests.Session.request',
-                 new=FauxUrlResponder(
-                     [
-                         FauxUrlOpenResponse(data=data_dict,
-                                             url='blippyblopfakeurl'),
-                     ]
-                 ))
+
+    requests_mock.get('http://bogus.invalid:9443/api/v2/collections/ansible/k8s',
+                      json=data_dict)
 
     namespace = 'ansible'
     name = 'k8s'
@@ -334,17 +232,12 @@ def test_galaxy_api_get_collection_detail(mocker, galaxy_api):
     assert isinstance(res, dict)
     assert res['id'] == 24
     assert 'highest_version' in res
-    assert res['href'] == "/api/v2/collections/ansible/k8s/"
+    assert res['href'] == "http://bogus.invalid:9443/api/v2/collections/ansible/k8s/"
 
 
-def test_galaxy_api_get_collection_detail_empty_results(mocker, galaxy_api):
-    mocker.patch('ansible_galaxy.rest_api.requests.Session.request',
-                 new=FauxUrlResponder(
-                     [
-                         FauxUrlOpenResponse(data={},
-                                             url='blippyblopfakeurl'),
-                     ]
-                 ))
+def test_galaxy_api_get_collection_detail_empty_results(mocker, galaxy_api, requests_mock):
+    requests_mock.get('http://bogus.invalid:9443/api/v2/collections/alikins/role-awx',
+                      json={})
 
     namespace = 'alikins'
     name = 'role-awx'
@@ -358,34 +251,21 @@ def test_galaxy_api_get_collection_detail_empty_results(mocker, galaxy_api):
     assert res == {}
 
 
-def test_galaxy_api_get_collection_detail_redirect_url(mocker, galaxy_api):
-    data_dict = {
-        "href": "/api/v2/collections/ansible/k8s/",
-    }
+def test_galaxy_api_get_collection_detail_404(mocker, galaxy_api, requests_mock):
 
-    orig_url = 'http://notreal.invalid:11111'
-    redirect_url = 'https://redirectedtothisurl/foo/blorp'
-
-    blip = mocker.patch('ansible_galaxy.rest_api.requests.Session.request',
-                        new=FauxUrlResponder(
-                            [
-                                FauxUrlOpenResponse(data=data_dict,
-                                                    url=orig_url,
-                                                    redirect_url=redirect_url),
-                            ]
-                        ))
+    requests_mock.get('http://bogus.invalid:9443/api/v2/collections/alikins/some_collection_that_doesnt_exist',
+                      status_code=404,
+                      json={'code': 'not_found',
+                            'message': 'Not found.'})
 
     namespace = 'alikins'
     name = 'some_collection_that_doesnt_exist'
     res = galaxy_api.get_collection_detail(namespace, name)
 
     log.debug('res: %s', res)
-    # If there are no results, we expect to get back an empty dict.
-    # FIXME: should probably return the full list and let the app care what that means
+
     assert isinstance(res, dict)
-    assert blip.calls[0]['args'] == ('GET',
-                                     'http://bogus.invalid:9553/api/v2/collections/alikins/some_collection_that_doesnt_exist')
-    # assert res == {}
+    assert res['code'] == 'not_found'
 
 # # FIXME:use mocked requests.Response, set status. requests wont raise an exception so side_effect is wrong
 # def test_galaxy_api_get_collection_detail_500_json_not_dict(mocker, galaxy_api):
@@ -427,19 +307,16 @@ def test_galaxy_api_get_collection_detail_redirect_url(mocker, galaxy_api):
 #     assert False, 'Excepted to get a GalaxyClientError here but did not.'
 
 
-def test_galaxy_api_get_collection_detail_SSLError(mocker, galaxy_api):
-    mocker.patch('ansible_galaxy.rest_api.requests.Session.request',
-                 side_effect=ssl.SSLError('ssl stuff broke... good luck and godspeed.'))
+def test_galaxy_api_get_collection_detail_SSLError(mocker, galaxy_api, requests_mock):
+    ssl_msg = 'ssl stuff broke... good luck and godspeed.'
+    requests_mock.get('http://bogus.invalid:9443/api/v2/collections/some-test-namespace/some-test-name',
+                      exc=ssl.SSLError(ssl_msg)
+                      )
 
-    try:
+    with pytest.raises(exceptions.GalaxyClientAPIConnectionError, match='.*%s.*' % ssl_msg) as exc_info:
         galaxy_api.get_collection_detail('some-test-namespace', 'some-test-name')
-    except exceptions.GalaxyClientAPIConnectionError as e:
-        log.exception(e)
-        log.debug(e)
 
-        return
-
-    assert False, 'Excepted to get a GalaxyClientAPIConnectionError here but did not.'
+    log.debug('exc_info: %s', exc_info)
 
 
 def test_user_agent():

--- a/tests/ansible_galaxy/test_rest_api.py
+++ b/tests/ansible_galaxy/test_rest_api.py
@@ -207,8 +207,8 @@ def test_galaxy_api_publish_file_202(galaxy_api_mocked, requests_mock, tmpdir):
 
     log.debug('res: %s', res)
 
-    assert isinstance(res, text_type)
-    assert json.loads(res) == status_202_json
+    assert isinstance(res, dict)
+    assert res == status_202_json
 
 
 def test_galaxy_api_publish_file_conflict_409(galaxy_api_mocked, requests_mock, tmpdir):

--- a/tests/ansible_galaxy/test_rest_api.py
+++ b/tests/ansible_galaxy/test_rest_api.py
@@ -362,6 +362,48 @@ def test_get_object(galaxy_api_mocked, requests_mock):
     assert data['stuff'] == [3, 4, 5]
 
 
+def test_get_object_list(galaxy_api_mocked, requests_mock):
+    url = 'http://bogus.invalid:9443/api/v3/unicorns/sparkleland/magestic/'
+
+    requests_mock.get(url,
+                      status_code=200,
+                      reason='OK',
+                      json=[{'stuff': [3, 4, 5]},
+                            {'stuff': [1, 2, 3]}])
+
+    data = galaxy_api_mocked.get_object(href=url)
+
+    log.debug('data:\n%s', data)
+
+    assert isinstance(data, list)
+    assert data[0]['stuff'] == [3, 4, 5]
+    assert data[1]['stuff'] == [1, 2, 3]
+
+
+def test_get_object_dict_with_results_but_not_paginated(galaxy_api_mocked, requests_mock):
+    url = 'http://bogus.invalid:9443/api/v3/unicorns/sparkleland/magestic/enemies/'
+
+    response_data = {
+        "results": [
+            {'stuff': [3, 4, 5]},
+            {'stuff': [1, 2, 3]}
+        ]
+    }
+
+    requests_mock.get(url,
+                      status_code=200,
+                      reason='OK',
+                      json=response_data,)
+
+    data = galaxy_api_mocked.get_object(href=url)
+
+    log.debug('data:\n%s', data)
+
+    assert isinstance(data, dict)
+    assert data['results'][0]['stuff'] == [3, 4, 5]
+    assert data['results'][1]['stuff'] == [1, 2, 3]
+
+
 def test_get_object_paginated(galaxy_api_mocked, requests_mock):
     url_page1 = 'http://bogus.invalid:9443/api/v3/unicorns/sparkleland/magestic/versions/'
 

--- a/tests/ansible_galaxy/test_rest_api.py
+++ b/tests/ansible_galaxy/test_rest_api.py
@@ -255,15 +255,17 @@ def test_galaxy_api_publish_file_unauthorized_401(galaxy_api_mocked, requests_mo
 
 
 def test_galaxy_api_publish_file_request_error(galaxy_api_mocked, requests_mock, tmpdir, file_upload_form):
-    ssl_msg = 'SSL stuff broke? Good luck figuring that out'
 
     # POST http://bogus.invalid:9443/api/v2/collections/
+    # requests_mock.get('http://bogus.invalid:9443/api/',
+    #                  exc=requests.
+    exc = exceptions.GalaxyClientAPIConnectionError(requests.exceptions.SSLError('SSL stuff broke'))
     requests_mock.post('http://bogus.invalid:9443/api/v2/collections/',
-                       exc=requests.exceptions.SSLError(ssl_msg))
+                       exc=exc)
 
     publish_api_key = '1f107befb89e0863829264d5241111a'
 
-    with pytest.raises(ansible_galaxy.exceptions.GalaxyPublishError) as exc_info:
+    with pytest.raises(ansible_galaxy.exceptions.GalaxyClientAPIConnectionError) as exc_info:
         galaxy_api_mocked.publish_file(form=file_upload_form, publish_api_key=publish_api_key)
 
     log.debug('exc_info:%s', exc_info)

--- a/tests/ansible_galaxy/test_rest_api.py
+++ b/tests/ansible_galaxy/test_rest_api.py
@@ -380,6 +380,46 @@ def test_get_object_list(galaxy_api_mocked, requests_mock):
     assert data[1]['stuff'] == [1, 2, 3]
 
 
+def test_get_object_redirect_302(galaxy_api_mocked, requests_mock):
+    url = 'http://bogus.invalid:9443/api/v3/unicorns/sparkleland/magestic/versions/1.0.0/artifact/'
+    new_url = 'https://bogus.invalid:9443/box_of_unicorns/f7325978-5339-4669-b7a4-a9406f32994f'
+    requests_mock.get(url,
+                      status_code=302,
+                      reason='Found',
+                      headers={'location': new_url})
+
+    requests_mock.get(new_url,
+                      status_code=200,
+                      reason='OK',
+                      json={'unicorn_stuff': [5, 10, 15]})
+
+    data = galaxy_api_mocked.get_object(href=url)
+
+    log.debug('data:\n%s', data)
+
+    assert data['unicorn_stuff'] == [5, 10, 15]
+
+
+def test_get_object_redirect_301(galaxy_api_mocked, requests_mock):
+    url = 'http://bogus.invalid:9443/api/v3/unicorns/sparkleland/magestic/versions/1.0.0/artifact/'
+    ssl_url = 'https://bogus.invalid:9443/api/v3/unicorns/sparkleland/magestic/versions/1.0.0/artifact/'
+    requests_mock.get(url,
+                      status_code=301,
+                      reason='Permanently Moved',
+                      headers={'location': ssl_url})
+
+    requests_mock.get(ssl_url,
+                      status_code=200,
+                      reason='OK',
+                      json={'unicorn_stuff': [5, 10, 15]})
+
+    data = galaxy_api_mocked.get_object(href=url)
+
+    log.debug('data:\n%s', data)
+
+    assert data['unicorn_stuff'] == [5, 10, 15]
+
+
 def test_get_object_dict_with_results_but_not_paginated(galaxy_api_mocked, requests_mock):
     url = 'http://bogus.invalid:9443/api/v3/unicorns/sparkleland/magestic/enemies/'
 

--- a/tests/ansible_galaxy/test_rest_api.py
+++ b/tests/ansible_galaxy/test_rest_api.py
@@ -12,6 +12,7 @@ import ansible_galaxy
 from ansible_galaxy import exceptions
 from ansible_galaxy.models.context import GalaxyContext
 from ansible_galaxy import rest_api
+from ansible_galaxy.utils.text import to_text
 
 log = logging.getLogger(__name__)
 
@@ -101,7 +102,7 @@ def test_galaxy_api_get_server_api_version_HTTPError_500(galaxy_context_example_
     except exceptions.GalaxyClientError as e:
         log.exception(e)
         # fragile, but currently return same exception so look for the right msg in args
-        assert 'Failed to get data from the API server' in '%s' % e
+        assert 'Failed to get data from the API server' in to_text(e)
         return
 
     assert False, 'Expected a GalaxyClientError here but that did not happen'
@@ -147,10 +148,10 @@ def test_galaxy_api_get_server_api_version_no_current_version(galaxy_context_exa
 
 def test_galaxy_api_properties(galaxy_api):
     log.debug('api_server: %s', galaxy_api.api_server)
-    log.debug('validate_certs: %s', galaxy_api.validate_certs)
+    log.debug('validate_certs: %s', galaxy_api.rest_client.validate_certs)
 
     assert galaxy_api.api_server == default_server_dict['url']
-    assert galaxy_api.validate_certs is True
+    assert galaxy_api.rest_client.validate_certs is True
 
 
 @pytest.fixture


### PR DESCRIPTION
##### SUMMARY
[WIP] Galaxy rest API error support, better result paging, etc

More unit testing of rest_api, better use of requests, 
exceptions for differentiating between client/request errors,
connection/ssl errors, and server http and app errors.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request
 