### PR TITLE
Change 'content_root' to 'collections_path' and make 'ansible_collections' implicit #239

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,33 @@
 Changelog
 =========
 
+0.5.0
+-----
+
+* WARNING: The config file items and cli options for specifying install paths
+           have changed and may break existing configs and scripts.
+* The cli option '--content-root' is now '--collections-path'
+* The short cli option '-C' is now shorthand for '--collections-path' instead
+  of '--content-root'
+* The config item 'content_root' has been replaced with 'collections_path'
+* The config item 'global_content_root' has been replaced with 'global_collections_path'
+* The new 'collections_path' value no longer needs to end with 'ansible_collections'
+* The new 'global_collections_path' value no longer needs to end with 'ansible_collections'
+* The new 'collections_path' defaults to '~/.ansible/collections'.
+  Note that this replaces the previous 'content_root' config item that
+  defaulted to '~/.ansible/collections/ansible_collections'
+* The new 'global_collections_path' defaults to '/usr/share/ansible/collections'.
+  Note that this replaces the previous 'global_content_root' config item that
+  defaulted to '/usr/share/ansible/collections/ansible_collections'
+* 'mazer install' with default 'collections_path' ('~/.ansible/collections') will
+  still install to '~/.ansible/collections/ansible_collections', but install
+  will add the require trailing 'ansible_collections' automatically.
+* 'mazer install --global' with default 'globale_collections_path'
+  ('/usr/share/ansible/collections') will still install to
+  '/usr/share/ansible/collections/ansible_collections', but
+  'install --global' will add the require trailing
+  'ansible_collections' automatically.
+
 0.4.0 (2019-03-28)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -151,16 +151,16 @@ server:
 # When installing content like ansible collection globally (using the '-g/--global' flag),
 # mazer will install into sub directories of this path.
 #
-# default: /usr/share/ansible/collections/ansible_collections
+# default: /usr/share/ansible/collections
 #
-global_collections_path: /usr/share/ansible/collections/ansible_collections
+global_collections_path: /usr/share/ansible/collections
 
 # When installing content like ansible collections, mazer will install into
 # sub directories of this path.
 #
-# default: ~/.ansible/collections/ansible_collections
+# default: ~/.ansible/collections
 #
-collections_path: ~/.ansible/collections/ansible_collections
+collections_path: ~/.ansible/collections
 
 # The version of the config file format.
 # This should never need to be changed manually.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ to ~/.ansible/collections/ansible_collections/testing/ansible_testing_content/
 ### Install a collection to a different content path
 
 ```
-$ mazer install --content-path ~/my-ansible-content alikins.collection_inspect
+$ mazer install --collections-path ~/my-ansible-content alikins.collection_inspect
 ```
 
 This will install the alikins.collection_inspect collection to ~/my-ansible-content/alikins/collection_inspect
@@ -153,14 +153,14 @@ server:
 #
 # default: /usr/share/ansible/collections/ansible_collections
 #
-global_content_path: /usr/share/ansible/collections/ansible_collections
+global_collections_path: /usr/share/ansible/collections/ansible_collections
 
 # When installing content like ansible collections, mazer will install into
 # sub directories of this path.
 #
 # default: ~/.ansible/collections/ansible_collections
 #
-content_path: ~/.ansible/collections/ansible_collections
+collections_path: ~/.ansible/collections/ansible_collections
 
 # The version of the config file format.
 # This should never need to be changed manually.

--- a/ansible_galaxy/config/config.py
+++ b/ansible_galaxy/config/config.py
@@ -10,15 +10,15 @@ log = logging.getLogger(__name__)
 class Config(object):
     def __init__(self):
         self.server = {}
-        self.content_path = None
-        self.global_content_path = None
+        self.collections_path = None
+        self.global_collections_path = None
         self.options = {}
 
     def as_dict(self):
         return collections.OrderedDict([
             ('server', self.server),
-            ('content_path', self.content_path),
-            ('global_content_path', self.global_content_path),
+            ('collections_path', self.collections_path),
+            ('global_collections_path', self.global_collections_path),
             ('options', self.options),
         ])
 
@@ -26,8 +26,8 @@ class Config(object):
     def from_dict(cls, data):
         inst = cls()
         inst.server = data.get('server', inst.server)
-        inst.content_path = data.get('content_path', inst.content_path)
-        inst.global_content_path = data.get('global_content_path', inst.global_content_path)
+        inst.collections_path = data.get('collections_path', inst.collections_path)
+        inst.global_collections_path = data.get('global_collections_path', inst.global_collections_path)
         inst.options = data.get('options', inst.options)
         return inst
 

--- a/ansible_galaxy/config/defaults.py
+++ b/ansible_galaxy/config/defaults.py
@@ -2,6 +2,7 @@ import os
 
 MAZER_HOME = os.environ.get('MAZER_HOME', None) or '~/.ansible'
 DEFAULT_CONFIG_FILE = '~/.ansible/mazer.yml'
+COLLECTIONS_PYTHON_NAMESPACE = 'ansible_collections'
 
 
 def get_config_path():
@@ -24,8 +25,8 @@ DEFAULTS = [
      ),
 
     # In order of priority
-    ('collections_path', os.path.join(MAZER_HOME, 'collections/ansible_collections')),
-    ('global_collections_path', '/usr/share/ansible/collections/ansible_collections'),
+    ('collections_path', os.path.join(MAZER_HOME, 'collections')),
+    ('global_collections_path', '/usr/share/ansible/collections'),
 
     # runtime options
     ('options',

--- a/ansible_galaxy/config/defaults.py
+++ b/ansible_galaxy/config/defaults.py
@@ -24,8 +24,8 @@ DEFAULTS = [
      ),
 
     # In order of priority
-    ('content_path', os.path.join(MAZER_HOME, 'collections/ansible_collections')),
-    ('global_content_path', '/usr/share/ansible/collections/ansible_collections'),
+    ('collections_path', os.path.join(MAZER_HOME, 'collections/ansible_collections')),
+    ('global_collections_path', '/usr/share/ansible/collections/ansible_collections'),
 
     # runtime options
     ('options',

--- a/ansible_galaxy/fetch/editable.py
+++ b/ansible_galaxy/fetch/editable.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 from ansible_galaxy import exceptions
+from ansible_galaxy.config.defaults import COLLECTIONS_PYTHON_NAMESPACE
 
 log = logging.getLogger(__name__)
 
@@ -38,7 +39,8 @@ class EditableFetch(object):
             raise exceptions.GalaxyClientError('Error fetching an editable install of %s because no "real_path" was found in find_results',
                                                self.requirement_spec.src, real_path)
 
-        dst_ns_root = os.path.join(self.galaxy_context.collections_path, self.requirement_spec.namespace)
+        dst_ns_root = os.path.join(self.galaxy_context.collections_path, COLLECTIONS_PYTHON_NAMESPACE, self.requirement_spec.namespace)
+
         dst_repo_root = os.path.join(dst_ns_root,
                                      self.requirement_spec.name)
 

--- a/ansible_galaxy/fetch/editable.py
+++ b/ansible_galaxy/fetch/editable.py
@@ -38,7 +38,7 @@ class EditableFetch(object):
             raise exceptions.GalaxyClientError('Error fetching an editable install of %s because no "real_path" was found in find_results',
                                                self.requirement_spec.src, real_path)
 
-        dst_ns_root = os.path.join(self.galaxy_context.content_path, self.requirement_spec.namespace)
+        dst_ns_root = os.path.join(self.galaxy_context.collections_path, self.requirement_spec.namespace)
         dst_repo_root = os.path.join(dst_ns_root,
                                      self.requirement_spec.name)
 

--- a/ansible_galaxy/install.py
+++ b/ansible_galaxy/install.py
@@ -139,21 +139,13 @@ def install(galaxy_context,
     namespaced_repository_path = '%s/%s' % (repository_spec.namespace,
                                             repository_spec.name)
 
-    install_info_path = os.path.join(galaxy_context.collections_path,
-                                     namespaced_repository_path,
-                                     'meta/.galaxy_install_info')
-
-    # extract_archive_to_dir depends on the repo_archive type, so ask it
-    extract_archive_to_dir = os.path.join(galaxy_context.collections_path,
-                                          namespaced_repository_path)
-
     editable = repository_spec.fetch_method == FetchMethods.EDITABLE
 
-    destination_info = InstallDestinationInfo(destination_root_dir=galaxy_context.collections_path,
+    # FIXME: compensate for 'ansible_collections' in InstallDestinationInfo?
+    #        ie, build extract_archive_to_dir instead of setting explicitly
+    destination_info = InstallDestinationInfo(collections_path=galaxy_context.collections_path,
                                               repository_spec=repository_spec,
-                                              extract_archive_to_dir=extract_archive_to_dir,
                                               namespaced_repository_path=namespaced_repository_path,
-                                              install_info_path=install_info_path,
                                               force_overwrite=force_overwrite,
                                               editable=editable)
 

--- a/ansible_galaxy/install.py
+++ b/ansible_galaxy/install.py
@@ -141,8 +141,6 @@ def install(galaxy_context,
 
     editable = repository_spec.fetch_method == FetchMethods.EDITABLE
 
-    # FIXME: compensate for 'ansible_collections' in InstallDestinationInfo?
-    #        ie, build extract_archive_to_dir instead of setting explicitly
     destination_info = InstallDestinationInfo(collections_path=galaxy_context.collections_path,
                                               repository_spec=repository_spec,
                                               namespaced_repository_path=namespaced_repository_path,

--- a/ansible_galaxy/install.py
+++ b/ansible_galaxy/install.py
@@ -130,26 +130,26 @@ def install(galaxy_context,
     # hand, does not have a parent directory at all.
 
     # preparation for archive extraction
-    if not os.path.isdir(galaxy_context.content_path):
-        log.debug('No content path (%s) found so creating it', galaxy_context.content_path)
+    if not os.path.isdir(galaxy_context.collections_path):
+        log.debug('No content path (%s) found so creating it', galaxy_context.collections_path)
 
-        os.makedirs(galaxy_context.content_path)
+        os.makedirs(galaxy_context.collections_path)
 
     # Build up all the info about where the repository will be installed to
     namespaced_repository_path = '%s/%s' % (repository_spec.namespace,
                                             repository_spec.name)
 
-    install_info_path = os.path.join(galaxy_context.content_path,
+    install_info_path = os.path.join(galaxy_context.collections_path,
                                      namespaced_repository_path,
                                      'meta/.galaxy_install_info')
 
     # extract_archive_to_dir depends on the repo_archive type, so ask it
-    extract_archive_to_dir = os.path.join(galaxy_context.content_path,
+    extract_archive_to_dir = os.path.join(galaxy_context.collections_path,
                                           namespaced_repository_path)
 
     editable = repository_spec.fetch_method == FetchMethods.EDITABLE
 
-    destination_info = InstallDestinationInfo(destination_root_dir=galaxy_context.content_path,
+    destination_info = InstallDestinationInfo(destination_root_dir=galaxy_context.collections_path,
                                               repository_spec=repository_spec,
                                               extract_archive_to_dir=extract_archive_to_dir,
                                               namespaced_repository_path=namespaced_repository_path,
@@ -167,7 +167,7 @@ def install(galaxy_context,
 
     if display_callback:
         display_callback("- The repository %s was successfully installed to %s" % (repository_spec.label,
-                                                                                   galaxy_context.content_path))
+                                                                                   galaxy_context.collections_path))
 
     # rm any temp files created when getting the content archive
     # TODO: use some sort of callback?

--- a/ansible_galaxy/installed_namespaces_db.py
+++ b/ansible_galaxy/installed_namespaces_db.py
@@ -2,6 +2,7 @@
 import logging
 import os
 
+from ansible_galaxy.config.defaults import COLLECTIONS_PYTHON_NAMESPACE
 from ansible_galaxy import matchers
 from ansible_galaxy.models.galaxy_namespace import GalaxyNamespace
 
@@ -13,15 +14,20 @@ def get_namespace_paths(collections_path):
     #       possibly to prepare for nested dirs, multiple paths, various
     #       filters/whitelist/blacklist/excludes, caching, or respecting
     #       fs ordering, etc
+
+    ansible_collections_path = os.path.join(collections_path, COLLECTIONS_PYTHON_NAMESPACE)
+
     try:
         # TODO: filter on any rules for what a namespace path looks like
         #       may one being 'somenamespace.somename' (a dot sep ns and name)
         #
-        namespace_paths = os.listdir(collections_path)
+        namespace_paths = os.listdir(ansible_collections_path)
     except OSError as e:
         log.exception(e)
-        log.warning('The content path %s did not exist so no content or repositories were found.',
-                    collections_path)
+        # FIXME: need to make it clearer that 'collections_path' does not include an explicit 'ansible_collections'
+        #        but that it is added implictly
+        log.warning('The collections path %s did not exist so no content or repositories were found.',
+                    ansible_collections_path)
         namespace_paths = []
 
     return namespace_paths
@@ -38,7 +44,7 @@ def installed_namespace_iterator(galaxy_context,
 
     log.debug('Looking for namespaces in %s', collections_path)
     for namespace_path in namespace_paths:
-        namespace_full_path = os.path.join(collections_path, namespace_path)
+        namespace_full_path = os.path.join(collections_path, COLLECTIONS_PYTHON_NAMESPACE, namespace_path)
 
         collection_namespace = GalaxyNamespace(namespace=namespace_path,
                                                path=namespace_full_path)

--- a/ansible_galaxy/installed_namespaces_db.py
+++ b/ansible_galaxy/installed_namespaces_db.py
@@ -8,7 +8,7 @@ from ansible_galaxy.models.galaxy_namespace import GalaxyNamespace
 log = logging.getLogger(__name__)
 
 
-def get_namespace_paths(content_path):
+def get_namespace_paths(collections_path):
     # TODO: abstract this a bit?  one to make it easier to mock, but also
     #       possibly to prepare for nested dirs, multiple paths, various
     #       filters/whitelist/blacklist/excludes, caching, or respecting
@@ -17,11 +17,11 @@ def get_namespace_paths(content_path):
         # TODO: filter on any rules for what a namespace path looks like
         #       may one being 'somenamespace.somename' (a dot sep ns and name)
         #
-        namespace_paths = os.listdir(content_path)
+        namespace_paths = os.listdir(collections_path)
     except OSError as e:
         log.exception(e)
         log.warning('The content path %s did not exist so no content or repositories were found.',
-                    content_path)
+                    collections_path)
         namespace_paths = []
 
     return namespace_paths
@@ -32,13 +32,13 @@ def installed_namespace_iterator(galaxy_context,
 
     namespace_match_filter = match_filter or matchers.MatchAll()
 
-    content_path = galaxy_context.content_path
+    collections_path = galaxy_context.collections_path
 
-    namespace_paths = get_namespace_paths(content_path)
+    namespace_paths = get_namespace_paths(collections_path)
 
-    log.debug('Looking for namespaces in %s', content_path)
+    log.debug('Looking for namespaces in %s', collections_path)
     for namespace_path in namespace_paths:
-        namespace_full_path = os.path.join(content_path, namespace_path)
+        namespace_full_path = os.path.join(collections_path, namespace_path)
 
         collection_namespace = GalaxyNamespace(namespace=namespace_path,
                                                path=namespace_full_path)

--- a/ansible_galaxy/installed_repository_db.py
+++ b/ansible_galaxy/installed_repository_db.py
@@ -51,8 +51,10 @@ def installed_repository_iterator(galaxy_context,
 
         for repository_path in repository_paths:
 
+            # TODO: just build up one dir and pass it in
             # TODO: if we need to distinquish repo from collection or role, we could do it here
             repository_ = repository.load_from_dir(galaxy_context.collections_path,
+                                                   namespace_path=namespace.path,
                                                    namespace=namespace.namespace,
                                                    name=repository_path,
                                                    installed=True)

--- a/ansible_galaxy/installed_repository_db.py
+++ b/ansible_galaxy/installed_repository_db.py
@@ -33,7 +33,7 @@ def installed_repository_iterator(galaxy_context,
                                   namespace_match_filter=None,
                                   repository_spec_match_filter=None,
                                   requirement_spec_match_filter=None):
-    '''For each repository in galaxy_context.content_path, yield matching repositories'''
+    '''For each repository in galaxy_context.collections_path, yield matching repositories'''
 
     namespace_match_filter = namespace_match_filter or matchers.MatchAll()
     repository_spec_match_filter = repository_spec_match_filter or matchers.MatchAll()
@@ -52,7 +52,7 @@ def installed_repository_iterator(galaxy_context,
         for repository_path in repository_paths:
 
             # TODO: if we need to distinquish repo from collection or role, we could do it here
-            repository_ = repository.load_from_dir(galaxy_context.content_path,
+            repository_ = repository.load_from_dir(galaxy_context.collections_path,
                                                    namespace=namespace.namespace,
                                                    name=repository_path,
                                                    installed=True)

--- a/ansible_galaxy/models/context.py
+++ b/ansible_galaxy/models/context.py
@@ -31,11 +31,11 @@ log = logging.getLogger(__name__)
 class GalaxyContext(object):
     ''' Keeps global galaxy info '''
 
-    def __init__(self, content_path=None, server=None):
+    def __init__(self, collections_path=None, server=None):
         self.server = server or {'url': None,
                                  'ignore_certs': False}
-        self.content_path = content_path
+        self.collections_path = collections_path
 
     def __repr__(self):
-        return 'GalaxyContext(content_path=%s, server=%s)' % \
-            (self.content_path, self.server)
+        return 'GalaxyContext(collections_path=%s, server=%s)' % \
+            (self.collections_path, self.server)

--- a/ansible_galaxy/models/install_destination.py
+++ b/ansible_galaxy/models/install_destination.py
@@ -3,6 +3,7 @@ import os
 
 import attr
 
+from ansible_galaxy.config.defaults import COLLECTIONS_PYTHON_NAMESPACE
 from ansible_galaxy.models.repository_spec import RepositorySpec
 
 log = logging.getLogger(__name__)
@@ -14,28 +15,16 @@ INSTALL_RECORD = '.galaxy_install_info'
 class InstallDestinationInfo(object):
     collections_path = attr.ib()
 
-    # destination_root_dir = attr.ib()
     repository_spec = attr.ib(type=RepositorySpec)
 
-    # NOTE: destination_root_dir is the root of where the install begins
-    #       but extract_archive_to is where the archive is extract to.
-    #       The normal case (collection or multi-content archives) these values
-    #       are the same (for ex, ~/.ansible/content/alikins/some_collection), but
-    #       for trad roles they are different (for ex,
-    #       destination_root_dir=~/.ansible/content/geerlingguy/ntp when
-    #       extract_archive_to_dir=~/.ansible/content/geerlingguy/ntp/roles/ntp)
-    # extract_archive_to_dir = attr.ib()
-
-    # 'alikins/collections_reqs_test/'
+    # For example 'alikins/collections_reqs_test/'
     namespaced_repository_path = attr.ib()
-
-    # install_info_path = attr.ib()
 
     force_overwrite = attr.ib(default=False)
 
     editable = attr.ib(default=False)
 
-    python_namespace = attr.ib(default='ansible_collections')
+    python_namespace = attr.ib(default=COLLECTIONS_PYTHON_NAMESPACE)
 
     @property
     def path(self):

--- a/ansible_galaxy/models/install_destination.py
+++ b/ansible_galaxy/models/install_destination.py
@@ -7,10 +7,14 @@ from ansible_galaxy.models.repository_spec import RepositorySpec
 
 log = logging.getLogger(__name__)
 
+INSTALL_RECORD = '.galaxy_install_info'
+
 
 @attr.s(frozen=True)
 class InstallDestinationInfo(object):
-    destination_root_dir = attr.ib()
+    collections_path = attr.ib()
+
+    # destination_root_dir = attr.ib()
     repository_spec = attr.ib(type=RepositorySpec)
 
     # NOTE: destination_root_dir is the root of where the install begins
@@ -20,22 +24,33 @@ class InstallDestinationInfo(object):
     #       for trad roles they are different (for ex,
     #       destination_root_dir=~/.ansible/content/geerlingguy/ntp when
     #       extract_archive_to_dir=~/.ansible/content/geerlingguy/ntp/roles/ntp)
-    extract_archive_to_dir = attr.ib()
+    # extract_archive_to_dir = attr.ib()
 
     # 'alikins/collections_reqs_test/'
     namespaced_repository_path = attr.ib()
 
-    install_info_path = attr.ib()
+    # install_info_path = attr.ib()
 
     force_overwrite = attr.ib(default=False)
 
     editable = attr.ib(default=False)
 
+    python_namespace = attr.ib(default='ansible_collections')
+
     @property
     def path(self):
         '''The full path to the eventually installed repository
 
-        For, /home/user/.ansible/content/geerlingguy/ntp
+        For, /home/user/.ansible/collections/ansible_collections/geerlingguy/ntp
         '''
-        return os.path.join(self.destination_root_dir,
+        return os.path.join(self.collections_path,
+                            self.python_namespace,
                             self.namespaced_repository_path)
+
+    @property
+    def install_info_path(self):
+        '''The full path to the eventually installed collections install record
+
+        For, /home/user/.ansible/collections/ansible_collections/geerlingguy/ntp/meta/.galaxy_install_info
+        '''
+        return os.path.join(self.path, 'meta', INSTALL_RECORD)

--- a/ansible_galaxy/repository.py
+++ b/ansible_galaxy/repository.py
@@ -78,9 +78,12 @@ def load_from_archive(repository_archive, namespace=None, installed=True):
     return repository
 
 
+# TODO: rename load_from_dir_in_namespace()?
 # TODO: simplify this, rename as part of Repository->Collection re-re-naming
-def load_from_dir(content_dir, namespace, name, installed=True):
-    path_name = os.path.join(content_dir, namespace, name)
+def load_from_dir(content_dir, namespace_path, namespace, name, installed=True):
+    path_name = os.path.join(namespace_path, name)
+
+    log.debug('Loading repository %s.%s from path: %s', namespace, name, path_name)
 
     if not os.path.isdir(path_name):
         log.debug('The directory %s does not exist, unable to load a Repository from it', path_name)
@@ -179,7 +182,7 @@ def load_from_dir(content_dir, namespace, name, installed=True):
                             installed=installed,
                             requirements=requirements_list,)
 
-    log.debug('Repository %s loaded from %s', repository.repository_spec.label, path_name)
+    log.debug('Loaded repository %s from %s', repository.repository_spec.label, path_name)
 
     return repository
 

--- a/ansible_galaxy/repository_archive.py
+++ b/ansible_galaxy/repository_archive.py
@@ -145,8 +145,8 @@ def install(repository_archive, repository_spec, destination_info, display_callb
         all_installed_files = []
     else:
         all_installed_files = extract(repository_spec,
-                                      collections_path=destination_info.destination_root_dir,
-                                      extract_archive_to_dir=destination_info.extract_archive_to_dir,
+                                      collections_path=destination_info.collections_path,
+                                      extract_archive_to_dir=destination_info.path,
                                       tar_file=repository_archive.tar_file,
                                       display_callback=display_callback)
 

--- a/ansible_galaxy/repository_archive.py
+++ b/ansible_galaxy/repository_archive.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 
 # TODO: extract_archive_to_dir may not be needed now (was for roles)
 def extract(repository_spec,
-            content_path,
+            collections_path,
             extract_archive_to_dir,
             tar_file,
             force_overwrite=False,
@@ -31,7 +31,7 @@ def extract(repository_spec,
         # TODO: better error
         raise exceptions.GalaxyError('While installing a collection , no namespace was found. Try providing one with --namespace')
 
-    log.debug('About to extract "%s" to %s', repository_spec.label, content_path)
+    log.debug('About to extract "%s" to collections_path %s', repository_spec.label, collections_path)
 
     tar_members = tar_file.members
 
@@ -145,7 +145,7 @@ def install(repository_archive, repository_spec, destination_info, display_callb
         all_installed_files = []
     else:
         all_installed_files = extract(repository_spec,
-                                      content_path=destination_info.destination_root_dir,
+                                      collections_path=destination_info.destination_root_dir,
                                       extract_archive_to_dir=destination_info.extract_archive_to_dir,
                                       tar_file=repository_archive.tar_file,
                                       display_callback=display_callback)

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -186,7 +186,7 @@ class GalaxyCLI(cli.CLI):
             # use ignore certs from options if available, but fallback to configured ignore_certs
             server['ignore_certs'] = options.ignore_certs
 
-        galaxy_context = GalaxyContext(server=server, content_path=content_path)
+        galaxy_context = GalaxyContext(server=server, collections_path=content_path)
 
         return galaxy_context
 

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -160,7 +160,7 @@ class GalaxyCLI(cli.CLI):
 
         super(GalaxyCLI, self).parse()
 
-        if self.action == 'install' and getattr(self.options, 'content_path') and getattr(self.options, 'global_install'):
+        if self.action == 'install' and getattr(self.options, 'collections_path') and getattr(self.options, 'global_install'):
             raise cli_exceptions.CliOptionsError('--content-path and --global are mutually exclusive')
 
     def _get_galaxy_context(self, options, config):
@@ -174,8 +174,7 @@ class GalaxyCLI(cli.CLI):
         if hasattr(options, 'global_install') and options.global_install:
             raw_collections_path = config.global_collections_path
 
-        # content_path = os.path.expanduser(raw_content_path)
-        content_path = os.path.abspath(os.path.expanduser(raw_content_path))
+        collections_path = os.path.abspath(os.path.expanduser(raw_collections_path))
 
         server = config.server.copy()
 
@@ -186,7 +185,7 @@ class GalaxyCLI(cli.CLI):
             # use ignore certs from options if available, but fallback to configured ignore_certs
             server['ignore_certs'] = options.ignore_certs
 
-        galaxy_context = GalaxyContext(server=server, collections_path=content_path)
+        galaxy_context = GalaxyContext(server=server, collections_path=collections_path)
 
         return galaxy_context
 

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -94,7 +94,7 @@ class GalaxyCLI(cli.CLI):
             self.parser.set_usage("usage: %prog install [options] [-r FILE | repo_name(s)[,version] | scm+repo_url[,version] | tar_file(s)]")
             self.parser.add_option('-g', '--global', dest='global_install', action='store_true',
                                    help='Install content to the path containing your global or system-wide content. The default is the '
-                                   'global_content_path configured in your mazer.yml file (/usr/share/ansible/content, if not configured)')
+                                   'global_collections_path configured in your mazer.yml file (/usr/share/ansible/content, if not configured)')
             self.parser.add_option('-e', '--editable', dest='editable_install', action='store_true',
                                    help='Link a local directory into the content path for development and testing')
             self.parser.add_option('-i', '--ignore-errors', dest='ignore_errors', action='store_true', default=False,
@@ -118,8 +118,8 @@ class GalaxyCLI(cli.CLI):
         if self.action not in ("publish", "version",):
             # NOTE: while the option type=str, the default is a list, and the
             # callback will set the value to a list.
-            self.parser.add_option('-C', '--content-path', dest='content_path',
-                                   help='The path to the directory containing your Galaxy content. The default is the content_path configured in your'
+            self.parser.add_option('-C', '--collections-path', dest='collections_path',
+                                   help='The path to the directory containing your Galaxy content. The default is the collections_path configured in your'
                                         'mazer.yml file (~/.ansible/content, if not configured)', type='str')
 
         if self.action == "migrate_role":
@@ -164,15 +164,15 @@ class GalaxyCLI(cli.CLI):
             raise cli_exceptions.CliOptionsError('--content-path and --global are mutually exclusive')
 
     def _get_galaxy_context(self, options, config):
-        # use content_path from options if availble but fallback to configured content_path
-        options_content_path = None
-        if hasattr(options, 'content_path'):
-            options_content_path = options.content_path
+        # use collections_path from options if availble but fallback to configured collections_path
+        options_collections_path = None
+        if hasattr(options, 'collections_path'):
+            options_collections_path = options.collections_path
 
-        raw_content_path = options_content_path or config.content_path
+        raw_collections_path = options_collections_path or config.collections_path
 
         if hasattr(options, 'global_install') and options.global_install:
-            raw_content_path = config.global_content_path
+            raw_collections_path = config.global_collections_path
 
         # content_path = os.path.expanduser(raw_content_path)
         content_path = os.path.abspath(os.path.expanduser(raw_content_path))

--- a/config/galaxy-localhost.yml
+++ b/config/galaxy-localhost.yml
@@ -2,5 +2,5 @@ defaults: {}
 server:
   ignore_certs: false
   url: http://localhost:8000
-collections_path: ~/.ansible/collections/ansible_collections
+collections_path: ~/.ansible/collections
 version: 1

--- a/config/galaxy-localhost.yml
+++ b/config/galaxy-localhost.yml
@@ -2,5 +2,5 @@ defaults: {}
 server:
   ignore_certs: false
   url: http://localhost:8000
-content_path: ~/.ansible/collections/ansible_collections
+collections_path: ~/.ansible/collections/ansible_collections
 version: 1

--- a/config/galaxy.yml
+++ b/config/galaxy.yml
@@ -2,5 +2,5 @@ defaults: {}
 server:
   ignore_certs: false
   url: https://galaxy-qa.ansible.com
-content_path: ~/.ansible/collections/ansible_collections
+collections_path: ~/.ansible/collections/ansible_collections
 version: 1

--- a/config/galaxy.yml
+++ b/config/galaxy.yml
@@ -2,5 +2,5 @@ defaults: {}
 server:
   ignore_certs: false
   url: https://galaxy-qa.ansible.com
-collections_path: ~/.ansible/collections/ansible_collections
+collections_path: ~/.ansible/collections
 version: 1

--- a/tests/_mazer_home/mazer.yml
+++ b/tests/_mazer_home/mazer.yml
@@ -2,7 +2,7 @@ server:
   ignore_certs: false
   url: http://localhost:8000
 
-content_path: tests/_mazer_work_dir/user_collections/ansible_collections
-global_content_path: tests/_mazer_work_dir/global_collections/ansible_collections
+collections_path: tests/_mazer_work_dir/user_collections/ansible_collections
+global_collections_path: tests/_mazer_work_dir/global_collections/ansible_collections
 
 version: 1

--- a/tests/_mazer_home/mazer.yml
+++ b/tests/_mazer_home/mazer.yml
@@ -2,7 +2,7 @@ server:
   ignore_certs: false
   url: http://localhost:8000
 
-collections_path: tests/_mazer_work_dir/user_collections/ansible_collections
-global_collections_path: tests/_mazer_work_dir/global_collections/ansible_collections
+collections_path: tests/_mazer_work_dir/user_collections
+global_collections_path: tests/_mazer_work_dir/global_collections
 
 version: 1

--- a/tests/ansible_galaxy/actions/test_list.py
+++ b/tests/ansible_galaxy/actions/test_list.py
@@ -14,7 +14,6 @@ def display_callback(msg, **kwargs):
 # TODO: make a fixture that sets up a faux installed_*_db
 
 def test__list(galaxy_context, mocker):
-    # galaxy_context.content_path = os.path.join(galaxy_context.content_path, 'doesntexist')
     mocker.patch('ansible_galaxy.installed_namespaces_db.get_namespace_paths',
                  return_value=iter(['ns_blip', 'ns_foo']))
     mocker.patch('ansible_galaxy.installed_repository_db.get_repository_paths',
@@ -48,10 +47,10 @@ def test_list_empty_roles_paths(galaxy_context):
 
 
 def test_list_no_content_dir(galaxy_context):
-    galaxy_context.content_path = os.path.join(galaxy_context.content_path, 'doesntexist')
+    galaxy_context.collections_path = os.path.join(galaxy_context.collections_path, 'doesntexist')
     res = list_action.list_action(galaxy_context,
                                   display_callback=display_callback)
 
-    # TODO: list should probably return non-zero if galaxy_context.content_path doesnt exist,
+    # TODO: list should probably return non-zero if galaxy_context.collections_path doesnt exist,
     #       but should probaly initially check that when creating galaxy_context
     assert res == 0

--- a/tests/ansible_galaxy/actions/test_publish_action.py
+++ b/tests/ansible_galaxy/actions/test_publish_action.py
@@ -38,7 +38,7 @@ def test__publish(galaxy_context, mocker):
 def test__publish_api_error(galaxy_context, mocker, requests_mock):
     publish_api_key = "doesnt_matter_not_used"
 
-    context = GalaxyContext(content_path=galaxy_context.content_path,
+    context = GalaxyContext(collections_path=galaxy_context.collections_path,
                             server={'url': 'http://notreal.invalid:8000',
                                     'ignore_certs': False})
     log.debug('galaxy_context: %s', context)

--- a/tests/ansible_galaxy/config/test_config.py
+++ b/tests/ansible_galaxy/config/test_config.py
@@ -6,7 +6,7 @@ from ansible_galaxy.config import config
 
 log = logging.getLogger(__name__)
 
-CONFIG_SECTIONS = ['server', 'content_path', 'global_content_path', 'options']
+CONFIG_SECTIONS = ['server', 'collections_path', 'global_collections_path', 'options']
 
 
 def assert_object(config_obj):
@@ -65,8 +65,8 @@ def test_config_as_dict():
     orig_config_data = OrderedDict([
         ('server', {'url': 'some_url_value',
                     'ignore_certs': True}),
-        ('content_path', None),
-        ('global_content_path', None),
+        ('collections_path', None),
+        ('global_collections_path', None),
         ('options', {'some_option': 'some_option_value'}),
     ])
 
@@ -97,7 +97,7 @@ def test_config_as_dict_from_partial_dict():
     assert isinstance(config_data['options'], dict)
     assert config_data['options'] == {}
 
-    assert config_data['content_path'] is None
+    assert config_data['collections_path'] is None
 
 
 def test_load_empty():
@@ -123,7 +123,7 @@ def test_save_empty():
 
     assert written_yaml != ''
     assert 'server' in written_yaml
-    assert 'content_path' in written_yaml
+    assert 'collections_path' in written_yaml
 
 
 def test_save():

--- a/tests/ansible_galaxy/config/test_config.py
+++ b/tests/ansible_galaxy/config/test_config.py
@@ -21,6 +21,10 @@ def test_config_init():
 
     assert_object(config_)
 
+    assert config_.server == {}
+    assert config_.collections_path is None
+    assert config_.global_collections_path is None
+
 
 def test_config_unknown_attr():
     config_ = config.Config()
@@ -103,10 +107,15 @@ def test_config_as_dict_from_partial_dict():
 def test_load_empty():
     yaml_fo = tempfile.NamedTemporaryFile()
 
-    config_ = config.load(yaml_fo.name)
+    config_obj = config.load(yaml_fo.name)
 
-    assert_object(config_)
-    log.debug('data: %s', config_.as_dict())
+    assert_object(config_obj)
+    log.debug('data: %s', config_obj.as_dict())
+
+    assert config_obj.server['url'] == 'https://galaxy.ansible.com'
+    assert config_obj.server['ignore_certs'] is False
+    assert config_obj.collections_path == '~/.ansible/collections'
+    assert config_obj.global_collections_path == '/usr/share/ansible/collections'
 
 
 def test_save_empty():

--- a/tests/ansible_galaxy/config/test_config_file.py
+++ b/tests/ansible_galaxy/config/test_config_file.py
@@ -61,8 +61,8 @@ VALID_YAML = b'''
 server:
   ignore_certs: true
   url: https://someserver.example.com
-content_path: ~/.ansible/some_collections_path/ansible_collections
-global_content_path: /usr/local/share/collections/ansible_collections
+collections_path: ~/.ansible/some_collections_path/ansible_collections
+global_collections_path: /usr/local/share/collections/ansible_collections
 options:
   verbosity: 0
 version: 1
@@ -79,14 +79,14 @@ def test_load_valid_yaml():
     log.debug('config_data: %s', config_data)
 
     assert config_data is not None
-    expected_keys = ['server', 'content_path', 'options']
+    expected_keys = ['server', 'collections_path', 'options']
     for expected_key in expected_keys:
         assert expected_key in config_data
 
     assert config_data['server']['url'] == 'https://someserver.example.com'
     assert config_data['server']['ignore_certs'] is True
-    assert config_data['content_path'] == '~/.ansible/some_collections_path/ansible_collections'
-    assert config_data['global_content_path'] == '/usr/local/share/collections/ansible_collections'
+    assert config_data['collections_path'] == '~/.ansible/some_collections_path/ansible_collections'
+    assert config_data['global_collections_path'] == '/usr/local/share/collections/ansible_collections'
 
 
 def test_save_empty_config():
@@ -106,7 +106,7 @@ def test_save_config():
 
     config.server = {'url': 'https://someserver.example.com',
                      'ignore_certs': True}
-    config.content_path = '~/.ansible/not-content-path'
+    config.collections_path = '~/.ansible/not-collections-path'
 
     res = config_file.save(_config.as_dict(), yaml_fo.name)
 
@@ -118,7 +118,7 @@ def test_save_bogus_path():
 
     config.server = {'url': 'https://someserver.example.com',
                      'ignore_certs': True}
-    config.content_path = '~/.ansible/not-content-path'
+    config.collections_path = '~/.ansible/not-collections-path'
 
     bogus_path = '/dev/null/doesnt/exist.yml'
     res = None

--- a/tests/ansible_galaxy/config/test_config_file.py
+++ b/tests/ansible_galaxy/config/test_config_file.py
@@ -61,8 +61,8 @@ VALID_YAML = b'''
 server:
   ignore_certs: true
   url: https://someserver.example.com
-collections_path: ~/.ansible/some_collections_path/ansible_collections
-global_collections_path: /usr/local/share/collections/ansible_collections
+collections_path: ~/.ansible/some_collections_path
+global_collections_path: /usr/local/share/collections
 options:
   verbosity: 0
 version: 1
@@ -85,8 +85,8 @@ def test_load_valid_yaml():
 
     assert config_data['server']['url'] == 'https://someserver.example.com'
     assert config_data['server']['ignore_certs'] is True
-    assert config_data['collections_path'] == '~/.ansible/some_collections_path/ansible_collections'
-    assert config_data['global_collections_path'] == '/usr/local/share/collections/ansible_collections'
+    assert config_data['collections_path'] == '~/.ansible/some_collections_path'
+    assert config_data['global_collections_path'] == '/usr/local/share/collections'
 
 
 def test_save_empty_config():

--- a/tests/ansible_galaxy/conftest.py
+++ b/tests/ansible_galaxy/conftest.py
@@ -3,7 +3,6 @@ import pytest
 
 @pytest.fixture
 def galaxy_context(tmpdir):
-    # tmp_content_path = tempfile.mkdtemp()
     # FIXME: mock
     server = {'url': 'http://localhost:8000',
               'ignore_certs': False}

--- a/tests/ansible_galaxy/conftest.py
+++ b/tests/ansible_galaxy/conftest.py
@@ -10,4 +10,4 @@ def galaxy_context(tmpdir):
     content_dir = tmpdir.mkdir('collections')
     collections_dir = content_dir.mkdir('ansible_collections')
     from ansible_galaxy.models.context import GalaxyContext
-    return GalaxyContext(server=server, content_path=collections_dir.strpath)
+    return GalaxyContext(server=server, collections_path=collections_dir.strpath)

--- a/tests/ansible_galaxy/conftest.py
+++ b/tests/ansible_galaxy/conftest.py
@@ -6,7 +6,8 @@ def galaxy_context(tmpdir):
     # FIXME: mock
     server = {'url': 'http://localhost:8000',
               'ignore_certs': False}
-    content_dir = tmpdir.mkdir('collections')
-    collections_dir = content_dir.mkdir('ansible_collections')
+    collections_path = tmpdir.mkdir('collections')
+
     from ansible_galaxy.models.context import GalaxyContext
-    return GalaxyContext(server=server, collections_path=collections_dir.strpath)
+
+    return GalaxyContext(server=server, collections_path=collections_path.strpath)

--- a/tests/ansible_galaxy/fetch/test_editable.py
+++ b/tests/ansible_galaxy/fetch/test_editable.py
@@ -62,7 +62,7 @@ def test_editable_fetch_fetch(galaxy_context, mocker, tmpdir):
     res = fetcher.fetch(find_results=find_results)
     log.debug('res: %s', res)
 
-    expected_link_name = os.path.join(galaxy_context.content_path,
+    expected_link_name = os.path.join(galaxy_context.collections_path,
                                       namespace_override,
                                       name)
     log.debug('expected_link_name: %s', expected_link_name)

--- a/tests/ansible_galaxy/fetch/test_editable.py
+++ b/tests/ansible_galaxy/fetch/test_editable.py
@@ -2,6 +2,7 @@
 import logging
 import os
 
+from ansible_galaxy.config.defaults import COLLECTIONS_PYTHON_NAMESPACE
 from ansible_galaxy.fetch import editable
 from ansible_galaxy import requirements
 from ansible_galaxy.models.requirement_spec import RequirementSpec
@@ -63,6 +64,7 @@ def test_editable_fetch_fetch(galaxy_context, mocker, tmpdir):
     log.debug('res: %s', res)
 
     expected_link_name = os.path.join(galaxy_context.collections_path,
+                                      COLLECTIONS_PYTHON_NAMESPACE,
                                       namespace_override,
                                       name)
     log.debug('expected_link_name: %s', expected_link_name)

--- a/tests/ansible_galaxy/fetch/test_galaxy_url.py
+++ b/tests/ansible_galaxy/fetch/test_galaxy_url.py
@@ -47,7 +47,7 @@ EXAMPLE_REPO_VERSIONS_LIST = \
 
 @pytest.fixture
 def galaxy_context_example_invalid(galaxy_context):
-    context = GalaxyContext(content_path=galaxy_context.content_path,
+    context = GalaxyContext(collections_path=galaxy_context.collections_path,
                             server={'url': 'http://example.invalid',
                                     'ignore_certs': False})
     return context

--- a/tests/ansible_galaxy/models/test_context.py
+++ b/tests/ansible_galaxy/models/test_context.py
@@ -12,68 +12,68 @@ def test_context_empty_init():
     galaxy_context = context.GalaxyContext()
 
     assert galaxy_context.server is not None
-    assert galaxy_context.content_path is None
+    assert galaxy_context.collections_path is None
     assert isinstance(galaxy_context.server, dict)
 
 
-def test_context_with_content_path_and_server():
-    content_path = '/dev/null/some_content_path'
+def test_context_with_collections_path_and_server():
+    collections_path = '/dev/null/some_content_path'
     server_url = 'http://example.com:9999/'
     ignore_certs = False
 
     server = {'url': server_url,
               'ignore_certs': ignore_certs}
 
-    galaxy_context = context.GalaxyContext(server=server, content_path=content_path)
+    galaxy_context = context.GalaxyContext(server=server, collections_path=collections_path)
 
     log.debug('galaxy_context: %s', galaxy_context)
     assert isinstance(galaxy_context, context.GalaxyContext)
 
-    assert isinstance(galaxy_context.content_path, six.string_types)
+    assert isinstance(galaxy_context.collections_path, six.string_types)
     assert isinstance(galaxy_context.server, dict)
 
     assert galaxy_context.server['url'] == server_url
     assert galaxy_context.server['ignore_certs'] == ignore_certs
 
-    assert galaxy_context.content_path == content_path
+    assert galaxy_context.collections_path == collections_path
 
 
 def test_context_from_empty_server():
     server = {}
     galaxy_context = context.GalaxyContext(server=server)
 
-    assert galaxy_context.content_path is None
+    assert galaxy_context.collections_path is None
     assert isinstance(galaxy_context.server, dict)
     log.debug('server: %s', galaxy_context.server)
     assert galaxy_context.server['url'] is None
     assert galaxy_context.server['ignore_certs'] is False
 
 
-def test_context_server_none_content_path_none():
+def test_context_server_none_collections_path_none():
 
     galaxy_context = context.GalaxyContext(server=None,
-                                           content_path=None)
+                                           collections_path=None)
 
-    assert galaxy_context.content_path is None
+    assert galaxy_context.collections_path is None
     assert isinstance(galaxy_context.server, dict)
     assert galaxy_context.server['url'] is None
     assert galaxy_context.server['ignore_certs'] is False
 
 
 def test_context_repr():
-    content_path = '/dev/null/some_content_path'
+    collections_path = '/dev/null/some_content_path'
     server_url = 'http://example.com:9999/'
     ignore_certs = False
 
     server = {'url': server_url,
               'ignore_certs': ignore_certs}
 
-    galaxy_context = context.GalaxyContext(server=server, content_path=content_path)
+    galaxy_context = context.GalaxyContext(server=server, collections_path=collections_path)
     rep_res = repr(galaxy_context)
 
     log.debug('rep_res: %s', rep_res)
 
     assert isinstance(rep_res, six.string_types)
-    assert 'content_path' in rep_res
+    assert 'collections_path' in rep_res
     assert 'server' in rep_res
     assert 'some_content_path' in rep_res

--- a/tests/ansible_galaxy/models/test_context.py
+++ b/tests/ansible_galaxy/models/test_context.py
@@ -17,7 +17,7 @@ def test_context_empty_init():
 
 
 def test_context_with_collections_path_and_server():
-    collections_path = '/dev/null/some_content_path'
+    collections_path = '/dev/null/some_collections_path'
     server_url = 'http://example.com:9999/'
     ignore_certs = False
 
@@ -61,7 +61,7 @@ def test_context_server_none_collections_path_none():
 
 
 def test_context_repr():
-    collections_path = '/dev/null/some_content_path'
+    collections_path = '/dev/null/some_collections_path'
     server_url = 'http://example.com:9999/'
     ignore_certs = False
 
@@ -76,4 +76,4 @@ def test_context_repr():
     assert isinstance(rep_res, six.string_types)
     assert 'collections_path' in rep_res
     assert 'server' in rep_res
-    assert 'some_content_path' in rep_res
+    assert 'some_collections_path' in rep_res

--- a/tests/ansible_galaxy/test_install.py
+++ b/tests/ansible_galaxy/test_install.py
@@ -60,7 +60,7 @@ def test_install(galaxy_context, mocker):
     assert len(res) > 0
     assert isinstance(res[0], Repository)
     assert res[0].repository_spec == repo_spec
-    assert galaxy_context.content_path in res[0].path
+    assert galaxy_context.collections_path in res[0].path
 
 
 def test_find(mocker):

--- a/tests/ansible_galaxy/test_installed_content_item_db.py
+++ b/tests/ansible_galaxy/test_installed_content_item_db.py
@@ -69,9 +69,9 @@ def test_installed_content_item_iterator_tmp_content(galaxy_context):
     ici = installed_content_item_db.installed_content_item_iterator(galaxy_context,
                                                                     content_item_type='roles')
 
-    content_path = galaxy_context.content_path
+    collections_path = galaxy_context.collections_path
 
-    # make some 'namespace_paths' in temp content_path
+    # make some 'namespace_paths' in temp collections_path
     tmp_namespace_paths = ['ns1.repo1', 'ns1.repo2', 'ns2.repo1']
     content_item_type_dirs = ['roles']
     content_item_names = ['somerole1', 'somerole2', 'role3']
@@ -82,7 +82,7 @@ def test_installed_content_item_iterator_tmp_content(galaxy_context):
         for content_item_type_dir in content_item_type_dirs:
             for content_item_name in content_item_names:
                 for role_subdir in role_subdirs:
-                    full_content_item_path = os.path.join(content_path, tmp_namespace_path, content_item_type_dir, content_item_name, role_subdir)
+                    full_content_item_path = os.path.join(collections_path, tmp_namespace_path, content_item_type_dir, content_item_name, role_subdir)
                     log.debug('full_content_path: %s', full_content_item_path)
                     os.makedirs(full_content_item_path)
 

--- a/tests/ansible_galaxy/test_installed_repository_db.py
+++ b/tests/ansible_galaxy/test_installed_repository_db.py
@@ -7,7 +7,7 @@ from ansible_galaxy import matchers
 log = logging.getLogger(__name__)
 
 
-# galaxy_context.content_path is empty
+# galaxy_context.collections_path is empty
 def test_installed_repository_db(galaxy_context):
     icdb = installed_repository_db.InstalledRepositoryDatabase(galaxy_context)
 
@@ -15,7 +15,7 @@ def test_installed_repository_db(galaxy_context):
         log.debug('x: %s', x)
 
 
-# galaxy_context.content_path is empty
+# galaxy_context.collections_path is empty
 def test_installed_repository_db_match_names(galaxy_context):
     icdb = installed_repository_db.InstalledRepositoryDatabase(galaxy_context)
 

--- a/tests/ansible_galaxy/test_repository.py
+++ b/tests/ansible_galaxy/test_repository.py
@@ -46,7 +46,7 @@ def test_load_from_archive_artifact(galaxy_context, tmpdir):
 
 # def load_from_dir(content_dir, namespace, name, installed=True):
 def test_load_from_dir_no_dir():
-    res = repository.load_from_dir('/dev/null/doesntexist', 'some_namespace', 'some_name')
+    res = repository.load_from_dir('/dev/null/doesntexist', 'ns/path', 'some_namespace', 'some_name')
 
     log.debug('res: %s', res)
 

--- a/tests/ansible_galaxy/test_repository_archive.py
+++ b/tests/ansible_galaxy/test_repository_archive.py
@@ -49,15 +49,15 @@ def test_install(galaxy_context, tmpdir):
     namespaced_repository_path = '%s/%s' % (repo_spec.namespace,
                                             repo_spec.name)
 
-    extract_archive_to_dir = os.path.join(galaxy_context.content_path,
+    extract_archive_to_dir = os.path.join(galaxy_context.collections_path,
                                           namespaced_repository_path,
                                           '')
 
-    install_info_path = os.path.join(galaxy_context.content_path,
+    install_info_path = os.path.join(galaxy_context.collections_path,
                                      namespaced_repository_path,
                                      'meta/.galaxy_install_info')
 
-    destination_info = InstallDestinationInfo(destination_root_dir=galaxy_context.content_path,
+    destination_info = InstallDestinationInfo(destination_root_dir=galaxy_context.collections_path,
                                               repository_spec=repo_spec,
                                               extract_archive_to_dir=extract_archive_to_dir,
                                               namespaced_repository_path=namespaced_repository_path,

--- a/tests/ansible_galaxy/test_repository_archive.py
+++ b/tests/ansible_galaxy/test_repository_archive.py
@@ -49,19 +49,9 @@ def test_install(galaxy_context, tmpdir):
     namespaced_repository_path = '%s/%s' % (repo_spec.namespace,
                                             repo_spec.name)
 
-    extract_archive_to_dir = os.path.join(galaxy_context.collections_path,
-                                          namespaced_repository_path,
-                                          '')
-
-    install_info_path = os.path.join(galaxy_context.collections_path,
-                                     namespaced_repository_path,
-                                     'meta/.galaxy_install_info')
-
-    destination_info = InstallDestinationInfo(destination_root_dir=galaxy_context.collections_path,
+    destination_info = InstallDestinationInfo(collections_path=galaxy_context.collections_path,
                                               repository_spec=repo_spec,
-                                              extract_archive_to_dir=extract_archive_to_dir,
                                               namespaced_repository_path=namespaced_repository_path,
-                                              install_info_path=install_info_path,
                                               force_overwrite=True,
                                               editable=False)
 

--- a/tests/ansible_galaxy/test_rest_api.py
+++ b/tests/ansible_galaxy/test_rest_api.py
@@ -31,7 +31,7 @@ default_server_dict = {'url': 'http://bogus.invalid:9443',
 
 @pytest.fixture
 def galaxy_context_example_invalid(galaxy_context):
-    context = GalaxyContext(content_path=galaxy_context.content_path,
+    context = GalaxyContext(collections_path=galaxy_context.collections_path,
                             server={'url': default_server_dict['url'],
                                     'ignore_certs': False})
     return context

--- a/tests/ansible_galaxy_cli/cli/test_galaxy_upstream.py
+++ b/tests/ansible_galaxy_cli/cli/test_galaxy_upstream.py
@@ -131,7 +131,7 @@ class TestGalaxy(unittest.TestCase):
         # installing role
         log.debug('self.role_path: %s', self.role_path)
 
-        gc = GalaxyCLI(args=self.default_args + ["install", "--content-path", self.role_path, '--force', self.role_name])
+        gc = GalaxyCLI(args=self.default_args + ["install", "--collections-path", self.role_path, '--force', self.role_name])
         gc.parse()
         gc.run()
 


### PR DESCRIPTION
##### SUMMARY

Change 'content_root' to 'collections_path' and make 'ansible_collections' implicit
Fixes: #239 

From CHANGELOG.rst
- WARNING: The config file items and cli options for specifying install paths
           have changed and may break existing configs and scripts.
- The config item `content_root` has been replaced with `collections_path`
- The config item `global_content_root` has been replaced with `global_collections_path`
- The new `collections_path` value no longer needs to end with `ansible_collections`
- The new `global_collections_path` value no longer needs to end with `ansible_collections`
- The new `collections_path` defaults to `~/.ansible/collections`.
  Note that this replaces the previous `content_root` config item that
  defaulted to `~/.ansible/collections/ansible_collections`
- The new `global_collections_path` defaults to `/usr/share/ansible/collections`.
  Note that this replaces the previous `global_content_root` config item that
  defaulted to `/usr/share/ansible/collections/ansible_collections`
- `mazer install` with default `collections_path` (`~/.ansible/collections`) will
  still install to `~/.ansible/collections/ansible_collections`, but install
  will add the require trailing 'ansible_collections' automatically.
- `mazer install --global` with default `global_collections_path`
  (`/usr/share/ansible/collections`) will still install to
  `usr/share/ansible/collections/ansible_collections`, but
  `mazer install --global` will add the require trailing
  `ansible_collections` automatically.



##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.4.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 5.0.5-200.fc29.x86_64, #1 SMP Wed Mar 27 20:58:04 UTC 2019, x86_64
executable_location = /home/adrian/venvs/mazer_0.4.0_py36/bin/mazer
python_version = 3.6.8 (default, Jan 27 2019, 09:00:23) [GCC 8.2.1 20181215 (Red Hat 8.2.1-6)]
python_executable = /home/adrian/venvs/mazer_0.4.0_py36/bin/python

```


