### PR TITLE
Scm url reqspec 236

### DIFF
--- a/ansible_galaxy/models/requirement_spec.py
+++ b/ansible_galaxy/models/requirement_spec.py
@@ -27,7 +27,10 @@ class RequirementSpec(object):
     version_aka = attr.ib(default=None)
     fetch_method = attr.ib(default=None, cmp=False)
     src = attr.ib(default=None, cmp=False)
-    req_spec_string = attr.ib(default=None, cmp=False)
+    scm = attr.ib(default=None, cmp=False)
+
+    # If created from a parsed string, spec_string is copy of the full string
+    spec_string = attr.ib(default=None, cmp=False)
 
     @property
     def label(self):
@@ -58,7 +61,8 @@ class RequirementSpec(object):
                        version_spec=version_spec_str,
                        version_aka=data.get('version_aka', None),
                        fetch_method=data.get('fetch_method', None),
-                       req_spec_string=data.get('req_spec_string', None),
+                       scm=data.get('scm', None),
+                       spec_string=data.get('spec_string', None),
                        src=data.get('src', None),
                        )
         return instance

--- a/ansible_galaxy/requirements.py
+++ b/ansible_galaxy/requirements.py
@@ -15,7 +15,6 @@ def from_dependencies_dict(dependencies_dict, namespace_override=None, editable=
                                               namespace_override=namespace_override,
                                               editable=editable)
         req_spec_data['version_spec'] = req_version_spec
-        req_spec_data['req_spec_string'] = req_spec_data.pop('spec_string', None)
 
         log.debug('req_spec_data: %s', req_spec_data)
 

--- a/ansible_galaxy/utils/scm_archive.py
+++ b/ansible_galaxy/utils/scm_archive.py
@@ -54,12 +54,13 @@ def scm_archive_content(src, name, scm='git', version='HEAD'):
     log.debug('Archiving scm src %s to tar file: %s', src, temp_file.name)
 
     if scm == 'hg':
-        archive_cmd = ['hg', 'archive', '--prefix', "%s/" % name]
+        # archive --prefix . builds archive with no top level dir or prefix
+        archive_cmd = ['hg', 'archive', '--prefix', '.']
         if version:
             archive_cmd.extend(['-r', version])
         archive_cmd.append(temp_file.name)
     if scm == 'git':
-        archive_cmd = ['git', 'archive', '--prefix=%s/' % name, '--output=%s' % temp_file.name]
+        archive_cmd = ['git', 'archive', '--output=%s' % temp_file.name]
         if version:
             archive_cmd.append(version)
         else:


### PR DESCRIPTION
##### SUMMARY
Fix some issues with using scm url with collections from the cli.

- Change the scm archive building code to not include a top dir
- Fix the way RequirementSpec would get it's spec_string populated
- Add 'scm' back to RequirementSpec, since we need to know the scm type to
 later build the right url for archive since the `git+https://github.com/alikins/whatever`
style isnt understood by git, git-archive, or the scm_archive module

Fixes part of the issue reported in #236 for now.

Long term, may just remove scm_url support entirely, or at least not support it except for
semver version tags.

Related: #236

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.4.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 5.0.5-200.fc29.x86_64, #1 SMP Wed Mar 27 20:58:04 UTC 2019, x86_64
executable_location = /home/adrian/venvs/mazer_0.4.0_py36/bin/mazer
python_version = 3.6.8 (default, Jan 27 2019, 09:00:23) [GCC 8.2.1 20181215 (Red Hat 8.2.1-6)]
python_executable = /home/adrian/venvs/mazer_0.4.0_py36/bin/python
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

