### PR TITLE
Include url to find the API key in publish help.

### DIFF
--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -84,10 +84,10 @@ class GalaxyCLI(cli.CLI):
                                    help='The path in which the collection artifact will be created. The default is ./releases/.')
         if self.action == "publish":
             self.parser.set_usage("usage: %prog publish [options] archive_path")
-            # TODO: Include the url for the pref page where the API key can be found, however, that
-            #       needs to know the server url which isn't known until after cli args are parsed.
+            # TODO: Instead of hardcode galaxy.ansible.com, show url for configured server url
+            #       however that isn't known until after cli args are parsed.
             self.parser.add_option('--api-key', dest='publish_api_key', action='store', default=None,
-                                   help='The Galaxy API key.')
+                                   help='The Galaxy API key which can be found at https://galaxy.ansible.com/me/preferences')
         if self.action == "info":
             self.parser.set_usage("usage: %prog info [options] repo_name[,version]")
         elif self.action == "install":


### PR DESCRIPTION
##### SUMMARY

Include the url to find the API key (https://galaxy.ansible.com/me/preferences) in publish help.

Hardcode for galaxy.ansible.com for now.

Fixes: #230


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.4.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 5.0.5-200.fc29.x86_64, #1 SMP Wed Mar 27 20:58:04 UTC 2019, x86_64
executable_location = /home/adrian/venvs/mazer_0.4.0_py36/bin/mazer
python_version = 3.6.8 (default, Jan 27 2019, 09:00:23) [GCC 8.2.1 20181215 (Red Hat 8.2.1-6)]
python_executable = /home/adrian/venvs/mazer_0.4.0_py36/bin/python
```



```

