### PR TITLE
Improve error message on build validation errors.

### DIFF
--- a/ansible_galaxy/actions/build.py
+++ b/ansible_galaxy/actions/build.py
@@ -29,6 +29,7 @@ def _build(galaxy_context,
     results['collection_path'] = collection_path
     results['info_file_path'] = collection_info_file_path
     results['errors'] = []
+    results['success'] = False
 
     info = None
 
@@ -37,13 +38,14 @@ def _build(galaxy_context,
             info = collection_info.load(info_fd)
 
             log.debug('info: %s', info)
-    except IOError as e:
+    except (IOError, ValueError) as e:
         log.error('Error loading the %s at %s: %s', collection_info.COLLECTION_INFO_FILENAME, collection_info_file_path, e)
-        results['errors'].append('Error loading the %s at %s: %s' % (collection_info.COLLECTION_INFO_FILENAME,
-                                                                     collection_info_file_path, e))
+        results['errors'].append('Error loading the %s at %s' % (collection_info.COLLECTION_INFO_FILENAME,
+                                                                 collection_info_file_path))
+        results['errors'].append(str(e))
+        return results
 
     if not info:
-        results['success'] = False
         results['errors'].append('There was no collection info in %s' % collection_info_file_path)
         return results
 
@@ -65,7 +67,6 @@ def _build(galaxy_context,
         results['success'] = True
         return results
 
-    results['success'] = False
     return results
 
 


### PR DESCRIPTION

##### SUMMARY
Improve error message on build validation errors.
Catch any exceptions and display formatted error messages.

Catch 'ValueError' if any of the CollectionInfo
validators fail. Append to errors list instead of
postfixing to the error msg.

<!--- Describe the change, including rationale and design decisions -->


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### MAZER VERSION

```
name = mazer
version = 0.4.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 5.0.5-200.fc29.x86_64, #1 SMP Wed Mar 27 20:58:04 UTC 2019, x86_64
executable_location = /home/adrian/venvs/mazer_0.4.0_py36/bin/mazer
python_version = 3.6.8 (default, Jan 27 2019, 09:00:23) [GCC 8.2.1 20181215 (Red Hat 8.2.1-6)]
python_executable = /home/adrian/venvs/mazer_0.4.0_py36/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

