### PR TITLE
[WIP] Fix cli use of a version=$VERSION_SPEC (Fixes: #246)

### DIFF
--- a/ansible_galaxy/models/requirement_spec.py
+++ b/ansible_galaxy/models/requirement_spec.py
@@ -51,7 +51,7 @@ class RequirementSpec(object):
                 if version_needs_aka(str(ver)):
                     data['version'] = normalize_version_string(ver)
                     data['version_aka'] = ver
-                version_spec_str = '==%s' % data['version']
+                version_spec_str = data['version']
             else:
                 # No version_spec, and version is None, that means match anything
                 version_spec_str = '*'

--- a/tests/ansible_galaxy/models/test_requirement_spec_model.py
+++ b/tests/ansible_galaxy/models/test_requirement_spec_model.py
@@ -1,0 +1,72 @@
+
+import logging
+
+import pytest
+import semantic_version
+
+from ansible_galaxy.models import requirement_spec
+
+log = logging.getLogger(__name__)
+
+
+def test_req_spec():
+    rs = requirement_spec.RequirementSpec(namespace='some_ns',
+                                          name='some_name',
+                                          version_spec='^1.2.3')
+
+    log.debug('rs: %s', rs)
+    assert isinstance(rs, requirement_spec.RequirementSpec)
+    assert isinstance(rs.version_spec, semantic_version.Spec)
+
+    too_old = semantic_version.Version('1.0.1')
+    too_new = semantic_version.Version('3.1.4')
+    just_right = semantic_version.Version('1.2.7')
+
+    assert rs.version_spec.match(just_right)
+    assert not rs.version_spec.match(too_old)
+    assert not rs.version_spec.match(too_new)
+
+
+def test_from_dict():
+    spec_data = {'namespace': 'some_ns',
+                 'name': 'some_name',
+                 'version_spec': '>1.1.0,!=1.2.2'}
+
+    rs = requirement_spec.RequirementSpec.from_dict(spec_data)
+
+    log.debug('rs: %s', rs)
+    assert isinstance(rs, requirement_spec.RequirementSpec)
+    assert isinstance(rs.version_spec, semantic_version.Spec)
+
+
+vspecs_and_expected = \
+    [
+        {'ver': '1.2.3', 'spec': '==1.2.3', 'expected': True},
+        {'ver': '1.2.3', 'spec': '1.2.3', 'expected': True},
+        {'ver': '1.2.2', 'spec': '==1.2.3', 'expected': False},
+        {'ver': '1.2.3', 'spec': '>=1.2.3', 'expected': True},
+        {'ver': '1.2.3', 'spec': '<1.2.3', 'expected': False},
+    ]
+
+
+@pytest.fixture(scope='module',
+                params=vspecs_and_expected,
+                ids=["spec '%s' matches version '%s' is %s" % (x['spec'], x['ver'], x['expected']) for x in vspecs_and_expected])
+def vspecs(request):
+    yield request.param
+
+
+def test_match(vspecs):
+    spec_data = {'namespace': 'some_ns',
+                 'name': 'some_name',
+                 'version_spec': vspecs['spec']}
+
+    rs = requirement_spec.RequirementSpec.from_dict(spec_data)
+
+    log.debug('rs: %s', rs)
+    assert isinstance(rs, requirement_spec.RequirementSpec)
+    assert isinstance(rs.version_spec, semantic_version.Spec)
+
+    ver = semantic_version.Version(vspecs['ver'])
+
+    assert rs.version_spec.match(ver) == vspecs['expected']


### PR DESCRIPTION
##### SUMMARY

Fix cli use of a version=$VERSION_SPEC (Fixes: #246)

semantic_version.Spec() will convert a plain
version ('1.2.3') into a '==' version spec itself,
no longer need to do it in requirement_spec.py

Fixes: #246

Work in progress because it's needs unit tests.

##### ISSUE TYPE


 - Bugfix Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.4.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 5.0.5-200.fc29.x86_64, #1 SMP Wed Mar 27 20:58:04 UTC 2019, x86_64
executable_location = /home/adrian/venvs/mazer_0.4.0_py36/bin/mazer
python_version = 3.6.8 (default, Jan 27 2019, 09:00:23) [GCC 8.2.1 20181215 (Red Hat 8.2.1-6)]
python_executable = /home/adrian/venvs/mazer_0.4.0_py36/bin/python
```

