### PR TITLE
Prep for 0 5 0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,9 +2,14 @@
 Changelog
 =========
 
-0.5.0
------
+0.5.0 (2019-04-15)
+------------------
 
+* WARNING: Mazer now requires a Ansible Galaxy server that provides the 'v2' style REST API.
+  At time of release, that includes galaxy-dev.ansible.com and galaxy-qa.ansible.com
+* WARNING: Support for directly installing 'traditional' style roles from Ansible Galaxy
+  is no longer supported. ie, 'mazer install geerlingguy.ntp' will no longer work.
+  However, roles can still be installed if they are included in a collection
 * WARNING: The config file items and cli options for specifying install paths
            have changed and may break existing configs and scripts.
 * The cli option '--content-root' is now '--collections-path'
@@ -28,6 +33,15 @@ Changelog
   '/usr/share/ansible/collections/ansible_collections', but
   'install --global' will add the require trailing
   'ansible_collections' automatically.
+* The REST API client now uses 'requests' python module instead of the 'url' module bundle from ansible.
+* Add cli '--config' option to specify a path to an alternative config file.
+* Add support for 'MAZER_HOME' environment variable. MAZER_HOME defaults to ~/.ansible and
+  specifies where mazer looks for it's config (mazer.yml and mazer-logging.yml)
+* `216 Use Galaxy REST API v2 <https://github.com/ansible/mazer/issues/216>`_.
+* `239 Rename content-root to collections-path to be consistent with ansible <https://github.com/ansible/mazer/issues/239>`_.
+* `228 For envs w/no LANG/locale/text encoding, assume utf8 <https://github.com/ansible/mazer/issues/228>`_.
+* `236 Partial fix for scm_url installs <https://github.com/ansible/mazer/issues/236>`_.
+
 
 0.4.0 (2019-03-28)
 ------------------

--- a/README.md
+++ b/README.md
@@ -41,12 +41,9 @@ to ~/.ansible/collections/ansible_collections/testing/ansible_testing_content/
 
 ```
 /home/adrian/.ansible/collections/ansible_collections
-└── alikins
+└── testing
     ├── ansible_testing_content
     │   ├── FILES.json
-    │   ├── galaxy.yml
-    │   ├── galaxy.yml.new
-    │   ├── __init__.py
     │   ├── LICENSE
     │   ├── MANIFEST.json
     │   ├── meta

--- a/ansible_galaxy/data/spdx_licenses.json
+++ b/ansible_galaxy/data/spdx_licenses.json
@@ -173,6 +173,9 @@
     "BitTorrent-1.1":{
         "deprecated":false
     },
+    "BlueOak-1.0.0":{
+        "deprecated":false
+    },
     "Borceux":{
         "deprecated":false
     },

--- a/data/spdx_licenses.json
+++ b/data/spdx_licenses.json
@@ -1,11 +1,11 @@
 {
-  "licenseListVersion": "3.4-59-ga68ef3c",
+  "licenseListVersion": "3.5-9-g99ae859",
   "licenses": [
     {
       "reference": "./0BSD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/0BSD.json",
-      "referenceNumber": "315",
+      "referenceNumber": "316",
       "name": "BSD Zero Clause License",
       "licenseId": "0BSD",
       "seeAlso": [
@@ -42,7 +42,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-1.1.json",
-      "referenceNumber": "115",
+      "referenceNumber": "116",
       "name": "Academic Free License v1.1",
       "licenseId": "AFL-1.1",
       "seeAlso": [
@@ -56,7 +56,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-1.2.json",
-      "referenceNumber": "133",
+      "referenceNumber": "134",
       "name": "Academic Free License v1.2",
       "licenseId": "AFL-1.2",
       "seeAlso": [
@@ -70,7 +70,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-2.0.json",
-      "referenceNumber": "112",
+      "referenceNumber": "113",
       "name": "Academic Free License v2.0",
       "licenseId": "AFL-2.0",
       "seeAlso": [
@@ -83,7 +83,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-2.1.json",
-      "referenceNumber": "248",
+      "referenceNumber": "249",
       "name": "Academic Free License v2.1",
       "licenseId": "AFL-2.1",
       "seeAlso": [
@@ -96,7 +96,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-3.0.json",
-      "referenceNumber": "213",
+      "referenceNumber": "214",
       "name": "Academic Free License v3.0",
       "licenseId": "AFL-3.0",
       "seeAlso": [
@@ -110,7 +110,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AGPL-1.0.json",
-      "referenceNumber": "330",
+      "referenceNumber": "331",
       "name": "Affero General Public License v1.0",
       "licenseId": "AGPL-1.0",
       "seeAlso": [
@@ -122,7 +122,7 @@
       "reference": "./AGPL-1.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AGPL-1.0-only.json",
-      "referenceNumber": "376",
+      "referenceNumber": "377",
       "name": "Affero General Public License v1.0 only",
       "licenseId": "AGPL-1.0-only",
       "seeAlso": [
@@ -134,7 +134,7 @@
       "reference": "./AGPL-1.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AGPL-1.0-or-later.json",
-      "referenceNumber": "327",
+      "referenceNumber": "328",
       "name": "Affero General Public License v1.0 or later",
       "licenseId": "AGPL-1.0-or-later",
       "seeAlso": [
@@ -147,7 +147,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AGPL-3.0.json",
-      "referenceNumber": "226",
+      "referenceNumber": "227",
       "name": "GNU Affero General Public License v3.0",
       "licenseId": "AGPL-3.0",
       "seeAlso": [
@@ -161,7 +161,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AGPL-3.0-only.json",
-      "referenceNumber": "92",
+      "referenceNumber": "93",
       "name": "GNU Affero General Public License v3.0 only",
       "licenseId": "AGPL-3.0-only",
       "seeAlso": [
@@ -175,7 +175,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AGPL-3.0-or-later.json",
-      "referenceNumber": "152",
+      "referenceNumber": "153",
       "name": "GNU Affero General Public License v3.0 or later",
       "licenseId": "AGPL-3.0-or-later",
       "seeAlso": [
@@ -188,7 +188,7 @@
       "reference": "./AMDPLPA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AMDPLPA.json",
-      "referenceNumber": "32",
+      "referenceNumber": "33",
       "name": "AMD\u0027s plpa_map.c License",
       "licenseId": "AMDPLPA",
       "seeAlso": [
@@ -200,7 +200,7 @@
       "reference": "./AML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AML.json",
-      "referenceNumber": "145",
+      "referenceNumber": "146",
       "name": "Apple MIT License",
       "licenseId": "AML",
       "seeAlso": [
@@ -212,7 +212,7 @@
       "reference": "./AMPAS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AMPAS.json",
-      "referenceNumber": "188",
+      "referenceNumber": "189",
       "name": "Academy of Motion Picture Arts and Sciences BSD",
       "licenseId": "AMPAS",
       "seeAlso": [
@@ -224,7 +224,7 @@
       "reference": "./ANTLR-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ANTLR-PD.json",
-      "referenceNumber": "387",
+      "referenceNumber": "388",
       "name": "ANTLR Software Rights Notice",
       "licenseId": "ANTLR-PD",
       "seeAlso": [
@@ -236,7 +236,7 @@
       "reference": "./APAFML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APAFML.json",
-      "referenceNumber": "192",
+      "referenceNumber": "193",
       "name": "Adobe Postscript AFM License",
       "licenseId": "APAFML",
       "seeAlso": [
@@ -248,7 +248,7 @@
       "reference": "./APL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APL-1.0.json",
-      "referenceNumber": "249",
+      "referenceNumber": "250",
       "name": "Adaptive Public License 1.0",
       "licenseId": "APL-1.0",
       "seeAlso": [
@@ -260,7 +260,7 @@
       "reference": "./APSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APSL-1.0.json",
-      "referenceNumber": "348",
+      "referenceNumber": "349",
       "name": "Apple Public Source License 1.0",
       "licenseId": "APSL-1.0",
       "seeAlso": [
@@ -272,7 +272,7 @@
       "reference": "./APSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APSL-1.1.json",
-      "referenceNumber": "320",
+      "referenceNumber": "321",
       "name": "Apple Public Source License 1.1",
       "licenseId": "APSL-1.1",
       "seeAlso": [
@@ -284,7 +284,7 @@
       "reference": "./APSL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APSL-1.2.json",
-      "referenceNumber": "33",
+      "referenceNumber": "34",
       "name": "Apple Public Source License 1.2",
       "licenseId": "APSL-1.2",
       "seeAlso": [
@@ -297,7 +297,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/APSL-2.0.json",
-      "referenceNumber": "106",
+      "referenceNumber": "107",
       "name": "Apple Public Source License 2.0",
       "licenseId": "APSL-2.0",
       "seeAlso": [
@@ -309,7 +309,7 @@
       "reference": "./Abstyles.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Abstyles.json",
-      "referenceNumber": "78",
+      "referenceNumber": "79",
       "name": "Abstyles License",
       "licenseId": "Abstyles",
       "seeAlso": [
@@ -321,7 +321,7 @@
       "reference": "./Adobe-2006.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Adobe-2006.json",
-      "referenceNumber": "282",
+      "referenceNumber": "283",
       "name": "Adobe Systems Incorporated Source Code License Agreement",
       "licenseId": "Adobe-2006",
       "seeAlso": [
@@ -333,7 +333,7 @@
       "reference": "./Adobe-Glyph.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Adobe-Glyph.json",
-      "referenceNumber": "104",
+      "referenceNumber": "105",
       "name": "Adobe Glyph List License",
       "licenseId": "Adobe-Glyph",
       "seeAlso": [
@@ -345,7 +345,7 @@
       "reference": "./Afmparse.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Afmparse.json",
-      "referenceNumber": "41",
+      "referenceNumber": "42",
       "name": "Afmparse License",
       "licenseId": "Afmparse",
       "seeAlso": [
@@ -357,7 +357,7 @@
       "reference": "./Aladdin.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Aladdin.json",
-      "referenceNumber": "255",
+      "referenceNumber": "256",
       "name": "Aladdin Free Public License",
       "licenseId": "Aladdin",
       "seeAlso": [
@@ -370,7 +370,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Apache-1.0.json",
-      "referenceNumber": "234",
+      "referenceNumber": "235",
       "name": "Apache License 1.0",
       "licenseId": "Apache-1.0",
       "seeAlso": [
@@ -383,7 +383,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Apache-1.1.json",
-      "referenceNumber": "82",
+      "referenceNumber": "83",
       "name": "Apache License 1.1",
       "licenseId": "Apache-1.1",
       "seeAlso": [
@@ -397,7 +397,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Apache-2.0.json",
-      "referenceNumber": "25",
+      "referenceNumber": "26",
       "name": "Apache License 2.0",
       "licenseId": "Apache-2.0",
       "seeAlso": [
@@ -410,7 +410,7 @@
       "reference": "./Artistic-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Artistic-1.0.json",
-      "referenceNumber": "162",
+      "referenceNumber": "163",
       "name": "Artistic License 1.0",
       "licenseId": "Artistic-1.0",
       "seeAlso": [
@@ -422,7 +422,7 @@
       "reference": "./Artistic-1.0-Perl.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Artistic-1.0-Perl.json",
-      "referenceNumber": "369",
+      "referenceNumber": "370",
       "name": "Artistic License 1.0 (Perl)",
       "licenseId": "Artistic-1.0-Perl",
       "seeAlso": [
@@ -447,7 +447,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Artistic-2.0.json",
-      "referenceNumber": "186",
+      "referenceNumber": "187",
       "name": "Artistic License 2.0",
       "licenseId": "Artistic-2.0",
       "seeAlso": [
@@ -460,7 +460,7 @@
       "reference": "./BSD-1-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-1-Clause.json",
-      "referenceNumber": "351",
+      "referenceNumber": "352",
       "name": "BSD 1-Clause License",
       "licenseId": "BSD-1-Clause",
       "seeAlso": [
@@ -472,7 +472,7 @@
       "reference": "./BSD-2-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause.json",
-      "referenceNumber": "321",
+      "referenceNumber": "322",
       "name": "BSD 2-Clause \"Simplified\" License",
       "licenseId": "BSD-2-Clause",
       "seeAlso": [
@@ -485,7 +485,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-FreeBSD.json",
-      "referenceNumber": "118",
+      "referenceNumber": "119",
       "name": "BSD 2-Clause FreeBSD License",
       "licenseId": "BSD-2-Clause-FreeBSD",
       "seeAlso": [
@@ -497,7 +497,7 @@
       "reference": "./BSD-2-Clause-NetBSD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-NetBSD.json",
-      "referenceNumber": "373",
+      "referenceNumber": "374",
       "name": "BSD 2-Clause NetBSD License",
       "licenseId": "BSD-2-Clause-NetBSD",
       "seeAlso": [
@@ -509,7 +509,7 @@
       "reference": "./BSD-2-Clause-Patent.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-Patent.json",
-      "referenceNumber": "166",
+      "referenceNumber": "167",
       "name": "BSD-2-Clause Plus Patent License",
       "licenseId": "BSD-2-Clause-Patent",
       "seeAlso": [
@@ -522,7 +522,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause.json",
-      "referenceNumber": "267",
+      "referenceNumber": "268",
       "name": "BSD 3-Clause \"New\" or \"Revised\" License",
       "licenseId": "BSD-3-Clause",
       "seeAlso": [
@@ -534,7 +534,7 @@
       "reference": "./BSD-3-Clause-Attribution.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-Attribution.json",
-      "referenceNumber": "38",
+      "referenceNumber": "39",
       "name": "BSD with attribution",
       "licenseId": "BSD-3-Clause-Attribution",
       "seeAlso": [
@@ -547,7 +547,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-Clear.json",
-      "referenceNumber": "209",
+      "referenceNumber": "210",
       "name": "BSD 3-Clause Clear License",
       "licenseId": "BSD-3-Clause-Clear",
       "seeAlso": [
@@ -559,7 +559,7 @@
       "reference": "./BSD-3-Clause-LBNL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-LBNL.json",
-      "referenceNumber": "332",
+      "referenceNumber": "333",
       "name": "Lawrence Berkeley National Labs BSD variant license",
       "licenseId": "BSD-3-Clause-LBNL",
       "seeAlso": [
@@ -583,7 +583,7 @@
       "reference": "./BSD-3-Clause-No-Nuclear-License-2014.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.json",
-      "referenceNumber": "134",
+      "referenceNumber": "135",
       "name": "BSD 3-Clause No Nuclear License 2014",
       "licenseId": "BSD-3-Clause-No-Nuclear-License-2014",
       "seeAlso": [
@@ -595,7 +595,7 @@
       "reference": "./BSD-3-Clause-No-Nuclear-Warranty.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.json",
-      "referenceNumber": "43",
+      "referenceNumber": "44",
       "name": "BSD 3-Clause No Nuclear Warranty",
       "licenseId": "BSD-3-Clause-No-Nuclear-Warranty",
       "seeAlso": [
@@ -608,7 +608,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-4-Clause.json",
-      "referenceNumber": "159",
+      "referenceNumber": "160",
       "name": "BSD 4-Clause \"Original\" or \"Old\" License",
       "licenseId": "BSD-4-Clause",
       "seeAlso": [
@@ -620,7 +620,7 @@
       "reference": "./BSD-4-Clause-UC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-4-Clause-UC.json",
-      "referenceNumber": "200",
+      "referenceNumber": "201",
       "name": "BSD-4-Clause (University of California-Specific)",
       "licenseId": "BSD-4-Clause-UC",
       "seeAlso": [
@@ -632,7 +632,7 @@
       "reference": "./BSD-Protection.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-Protection.json",
-      "referenceNumber": "116",
+      "referenceNumber": "117",
       "name": "BSD Protection License",
       "licenseId": "BSD-Protection",
       "seeAlso": [
@@ -644,7 +644,7 @@
       "reference": "./BSD-Source-Code.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-Source-Code.json",
-      "referenceNumber": "305",
+      "referenceNumber": "306",
       "name": "BSD Source Code Attribution",
       "licenseId": "BSD-Source-Code",
       "seeAlso": [
@@ -657,7 +657,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSL-1.0.json",
-      "referenceNumber": "221",
+      "referenceNumber": "222",
       "name": "Boost Software License 1.0",
       "licenseId": "BSL-1.0",
       "seeAlso": [
@@ -670,7 +670,7 @@
       "reference": "./Bahyph.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Bahyph.json",
-      "referenceNumber": "359",
+      "referenceNumber": "360",
       "name": "Bahyph License",
       "licenseId": "Bahyph",
       "seeAlso": [
@@ -682,7 +682,7 @@
       "reference": "./Barr.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Barr.json",
-      "referenceNumber": "328",
+      "referenceNumber": "329",
       "name": "Barr License",
       "licenseId": "Barr",
       "seeAlso": [
@@ -707,7 +707,7 @@
       "reference": "./BitTorrent-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BitTorrent-1.0.json",
-      "referenceNumber": "215",
+      "referenceNumber": "216",
       "name": "BitTorrent Open Source License v1.0",
       "licenseId": "BitTorrent-1.0",
       "seeAlso": [
@@ -720,7 +720,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BitTorrent-1.1.json",
-      "referenceNumber": "176",
+      "referenceNumber": "177",
       "name": "BitTorrent Open Source License v1.1",
       "licenseId": "BitTorrent-1.1",
       "seeAlso": [
@@ -729,10 +729,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./BlueOak-1.0.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/BlueOak-1.0.0.json",
+      "referenceNumber": "23",
+      "name": "Blue Oak Model License 1.0.0",
+      "licenseId": "BlueOak-1.0.0",
+      "seeAlso": [
+        "https://blueoakcouncil.org/license/1.0.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./Borceux.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Borceux.json",
-      "referenceNumber": "308",
+      "referenceNumber": "309",
       "name": "Borceux license",
       "licenseId": "Borceux",
       "seeAlso": [
@@ -744,7 +756,7 @@
       "reference": "./CATOSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CATOSL-1.1.json",
-      "referenceNumber": "259",
+      "referenceNumber": "260",
       "name": "Computer Associates Trusted Open Source License 1.1",
       "licenseId": "CATOSL-1.1",
       "seeAlso": [
@@ -756,7 +768,7 @@
       "reference": "./CC-BY-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-1.0.json",
-      "referenceNumber": "125",
+      "referenceNumber": "126",
       "name": "Creative Commons Attribution 1.0 Generic",
       "licenseId": "CC-BY-1.0",
       "seeAlso": [
@@ -768,7 +780,7 @@
       "reference": "./CC-BY-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-2.0.json",
-      "referenceNumber": "229",
+      "referenceNumber": "230",
       "name": "Creative Commons Attribution 2.0 Generic",
       "licenseId": "CC-BY-2.0",
       "seeAlso": [
@@ -780,7 +792,7 @@
       "reference": "./CC-BY-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-2.5.json",
-      "referenceNumber": "126",
+      "referenceNumber": "127",
       "name": "Creative Commons Attribution 2.5 Generic",
       "licenseId": "CC-BY-2.5",
       "seeAlso": [
@@ -792,7 +804,7 @@
       "reference": "./CC-BY-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-3.0.json",
-      "referenceNumber": "253",
+      "referenceNumber": "254",
       "name": "Creative Commons Attribution 3.0 Unported",
       "licenseId": "CC-BY-3.0",
       "seeAlso": [
@@ -805,7 +817,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-4.0.json",
-      "referenceNumber": "326",
+      "referenceNumber": "327",
       "name": "Creative Commons Attribution 4.0 International",
       "licenseId": "CC-BY-4.0",
       "seeAlso": [
@@ -817,7 +829,7 @@
       "reference": "./CC-BY-NC-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-1.0.json",
-      "referenceNumber": "127",
+      "referenceNumber": "128",
       "name": "Creative Commons Attribution Non Commercial 1.0 Generic",
       "licenseId": "CC-BY-NC-1.0",
       "seeAlso": [
@@ -829,7 +841,7 @@
       "reference": "./CC-BY-NC-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-2.0.json",
-      "referenceNumber": "241",
+      "referenceNumber": "242",
       "name": "Creative Commons Attribution Non Commercial 2.0 Generic",
       "licenseId": "CC-BY-NC-2.0",
       "seeAlso": [
@@ -853,7 +865,7 @@
       "reference": "./CC-BY-NC-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-3.0.json",
-      "referenceNumber": "252",
+      "referenceNumber": "253",
       "name": "Creative Commons Attribution Non Commercial 3.0 Unported",
       "licenseId": "CC-BY-NC-3.0",
       "seeAlso": [
@@ -865,7 +877,7 @@
       "reference": "./CC-BY-NC-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-4.0.json",
-      "referenceNumber": "183",
+      "referenceNumber": "184",
       "name": "Creative Commons Attribution Non Commercial 4.0 International",
       "licenseId": "CC-BY-NC-4.0",
       "seeAlso": [
@@ -877,7 +889,7 @@
       "reference": "./CC-BY-NC-ND-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-1.0.json",
-      "referenceNumber": "58",
+      "referenceNumber": "59",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
       "licenseId": "CC-BY-NC-ND-1.0",
       "seeAlso": [
@@ -889,7 +901,7 @@
       "reference": "./CC-BY-NC-ND-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-2.0.json",
-      "referenceNumber": "35",
+      "referenceNumber": "36",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
       "licenseId": "CC-BY-NC-ND-2.0",
       "seeAlso": [
@@ -901,7 +913,7 @@
       "reference": "./CC-BY-NC-ND-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-2.5.json",
-      "referenceNumber": "155",
+      "referenceNumber": "156",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
       "licenseId": "CC-BY-NC-ND-2.5",
       "seeAlso": [
@@ -913,7 +925,7 @@
       "reference": "./CC-BY-NC-ND-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-3.0.json",
-      "referenceNumber": "47",
+      "referenceNumber": "48",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
       "licenseId": "CC-BY-NC-ND-3.0",
       "seeAlso": [
@@ -925,7 +937,7 @@
       "reference": "./CC-BY-NC-ND-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-4.0.json",
-      "referenceNumber": "278",
+      "referenceNumber": "279",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
       "licenseId": "CC-BY-NC-ND-4.0",
       "seeAlso": [
@@ -937,7 +949,7 @@
       "reference": "./CC-BY-NC-SA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-1.0.json",
-      "referenceNumber": "175",
+      "referenceNumber": "176",
       "name": "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
       "licenseId": "CC-BY-NC-SA-1.0",
       "seeAlso": [
@@ -949,7 +961,7 @@
       "reference": "./CC-BY-NC-SA-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-2.0.json",
-      "referenceNumber": "79",
+      "referenceNumber": "80",
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
       "licenseId": "CC-BY-NC-SA-2.0",
       "seeAlso": [
@@ -961,7 +973,7 @@
       "reference": "./CC-BY-NC-SA-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-2.5.json",
-      "referenceNumber": "61",
+      "referenceNumber": "62",
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
       "licenseId": "CC-BY-NC-SA-2.5",
       "seeAlso": [
@@ -985,7 +997,7 @@
       "reference": "./CC-BY-NC-SA-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-4.0.json",
-      "referenceNumber": "46",
+      "referenceNumber": "47",
       "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
       "licenseId": "CC-BY-NC-SA-4.0",
       "seeAlso": [
@@ -997,7 +1009,7 @@
       "reference": "./CC-BY-ND-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-1.0.json",
-      "referenceNumber": "49",
+      "referenceNumber": "50",
       "name": "Creative Commons Attribution No Derivatives 1.0 Generic",
       "licenseId": "CC-BY-ND-1.0",
       "seeAlso": [
@@ -1009,7 +1021,7 @@
       "reference": "./CC-BY-ND-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-2.0.json",
-      "referenceNumber": "284",
+      "referenceNumber": "285",
       "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
       "licenseId": "CC-BY-ND-2.0",
       "seeAlso": [
@@ -1021,7 +1033,7 @@
       "reference": "./CC-BY-ND-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-2.5.json",
-      "referenceNumber": "67",
+      "referenceNumber": "68",
       "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
       "licenseId": "CC-BY-ND-2.5",
       "seeAlso": [
@@ -1033,7 +1045,7 @@
       "reference": "./CC-BY-ND-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-3.0.json",
-      "referenceNumber": "385",
+      "referenceNumber": "386",
       "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
       "licenseId": "CC-BY-ND-3.0",
       "seeAlso": [
@@ -1045,7 +1057,7 @@
       "reference": "./CC-BY-ND-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-4.0.json",
-      "referenceNumber": "129",
+      "referenceNumber": "130",
       "name": "Creative Commons Attribution No Derivatives 4.0 International",
       "licenseId": "CC-BY-ND-4.0",
       "seeAlso": [
@@ -1057,7 +1069,7 @@
       "reference": "./CC-BY-SA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-1.0.json",
-      "referenceNumber": "318",
+      "referenceNumber": "319",
       "name": "Creative Commons Attribution Share Alike 1.0 Generic",
       "licenseId": "CC-BY-SA-1.0",
       "seeAlso": [
@@ -1069,7 +1081,7 @@
       "reference": "./CC-BY-SA-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-2.0.json",
-      "referenceNumber": "139",
+      "referenceNumber": "140",
       "name": "Creative Commons Attribution Share Alike 2.0 Generic",
       "licenseId": "CC-BY-SA-2.0",
       "seeAlso": [
@@ -1081,7 +1093,7 @@
       "reference": "./CC-BY-SA-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-2.5.json",
-      "referenceNumber": "303",
+      "referenceNumber": "304",
       "name": "Creative Commons Attribution Share Alike 2.5 Generic",
       "licenseId": "CC-BY-SA-2.5",
       "seeAlso": [
@@ -1093,7 +1105,7 @@
       "reference": "./CC-BY-SA-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-3.0.json",
-      "referenceNumber": "386",
+      "referenceNumber": "387",
       "name": "Creative Commons Attribution Share Alike 3.0 Unported",
       "licenseId": "CC-BY-SA-3.0",
       "seeAlso": [
@@ -1106,7 +1118,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-4.0.json",
-      "referenceNumber": "31",
+      "referenceNumber": "32",
       "name": "Creative Commons Attribution Share Alike 4.0 International",
       "licenseId": "CC-BY-SA-4.0",
       "seeAlso": [
@@ -1119,7 +1131,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CC0-1.0.json",
-      "referenceNumber": "210",
+      "referenceNumber": "211",
       "name": "Creative Commons Zero v1.0 Universal",
       "licenseId": "CC0-1.0",
       "seeAlso": [
@@ -1132,7 +1144,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CDDL-1.0.json",
-      "referenceNumber": "135",
+      "referenceNumber": "136",
       "name": "Common Development and Distribution License 1.0",
       "licenseId": "CDDL-1.0",
       "seeAlso": [
@@ -1144,7 +1156,7 @@
       "reference": "./CDDL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CDDL-1.1.json",
-      "referenceNumber": "368",
+      "referenceNumber": "369",
       "name": "Common Development and Distribution License 1.1",
       "licenseId": "CDDL-1.1",
       "seeAlso": [
@@ -1157,7 +1169,7 @@
       "reference": "./CDLA-Permissive-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CDLA-Permissive-1.0.json",
-      "referenceNumber": "247",
+      "referenceNumber": "248",
       "name": "Community Data License Agreement Permissive 1.0",
       "licenseId": "CDLA-Permissive-1.0",
       "seeAlso": [
@@ -1169,7 +1181,7 @@
       "reference": "./CDLA-Sharing-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CDLA-Sharing-1.0.json",
-      "referenceNumber": "307",
+      "referenceNumber": "308",
       "name": "Community Data License Agreement Sharing 1.0",
       "licenseId": "CDLA-Sharing-1.0",
       "seeAlso": [
@@ -1181,7 +1193,7 @@
       "reference": "./CECILL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CECILL-1.0.json",
-      "referenceNumber": "220",
+      "referenceNumber": "221",
       "name": "CeCILL Free Software License Agreement v1.0",
       "licenseId": "CECILL-1.0",
       "seeAlso": [
@@ -1193,7 +1205,7 @@
       "reference": "./CECILL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CECILL-1.1.json",
-      "referenceNumber": "297",
+      "referenceNumber": "298",
       "name": "CeCILL Free Software License Agreement v1.1",
       "licenseId": "CECILL-1.1",
       "seeAlso": [
@@ -1206,7 +1218,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CECILL-2.0.json",
-      "referenceNumber": "346",
+      "referenceNumber": "347",
       "name": "CeCILL Free Software License Agreement v2.0",
       "licenseId": "CECILL-2.0",
       "seeAlso": [
@@ -1218,7 +1230,7 @@
       "reference": "./CECILL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CECILL-2.1.json",
-      "referenceNumber": "117",
+      "referenceNumber": "118",
       "name": "CeCILL Free Software License Agreement v2.1",
       "licenseId": "CECILL-2.1",
       "seeAlso": [
@@ -1231,7 +1243,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CECILL-B.json",
-      "referenceNumber": "335",
+      "referenceNumber": "336",
       "name": "CeCILL-B Free Software License Agreement",
       "licenseId": "CECILL-B",
       "seeAlso": [
@@ -1244,7 +1256,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CECILL-C.json",
-      "referenceNumber": "75",
+      "referenceNumber": "76",
       "name": "CeCILL-C Free Software License Agreement",
       "licenseId": "CECILL-C",
       "seeAlso": [
@@ -1256,7 +1268,7 @@
       "reference": "./CERN-OHL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CERN-OHL-1.1.json",
-      "referenceNumber": "336",
+      "referenceNumber": "337",
       "name": "CERN Open Hardware License v1.1",
       "licenseId": "CERN-OHL-1.1",
       "seeAlso": [
@@ -1280,7 +1292,7 @@
       "reference": "./CNRI-Jython.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CNRI-Jython.json",
-      "referenceNumber": "91",
+      "referenceNumber": "92",
       "name": "CNRI Jython License",
       "licenseId": "CNRI-Jython",
       "seeAlso": [
@@ -1292,7 +1304,7 @@
       "reference": "./CNRI-Python.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CNRI-Python.json",
-      "referenceNumber": "44",
+      "referenceNumber": "45",
       "name": "CNRI Python License",
       "licenseId": "CNRI-Python",
       "seeAlso": [
@@ -1304,7 +1316,7 @@
       "reference": "./CNRI-Python-GPL-Compatible.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CNRI-Python-GPL-Compatible.json",
-      "referenceNumber": "199",
+      "referenceNumber": "200",
       "name": "CNRI Python Open Source GPL Compatible License Agreement",
       "licenseId": "CNRI-Python-GPL-Compatible",
       "seeAlso": [
@@ -1317,7 +1329,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CPAL-1.0.json",
-      "referenceNumber": "167",
+      "referenceNumber": "168",
       "name": "Common Public Attribution License 1.0",
       "licenseId": "CPAL-1.0",
       "seeAlso": [
@@ -1330,7 +1342,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CPL-1.0.json",
-      "referenceNumber": "169",
+      "referenceNumber": "170",
       "name": "Common Public License 1.0",
       "licenseId": "CPL-1.0",
       "seeAlso": [
@@ -1342,7 +1354,7 @@
       "reference": "./CPOL-1.02.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CPOL-1.02.json",
-      "referenceNumber": "27",
+      "referenceNumber": "28",
       "name": "Code Project Open License 1.02",
       "licenseId": "CPOL-1.02",
       "seeAlso": [
@@ -1354,7 +1366,7 @@
       "reference": "./CUA-OPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CUA-OPL-1.0.json",
-      "referenceNumber": "358",
+      "referenceNumber": "359",
       "name": "CUA Office Public License v1.0",
       "licenseId": "CUA-OPL-1.0",
       "seeAlso": [
@@ -1366,7 +1378,7 @@
       "reference": "./Caldera.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Caldera.json",
-      "referenceNumber": "105",
+      "referenceNumber": "106",
       "name": "Caldera License",
       "licenseId": "Caldera",
       "seeAlso": [
@@ -1379,7 +1391,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ClArtistic.json",
-      "referenceNumber": "268",
+      "referenceNumber": "269",
       "name": "Clarified Artistic License",
       "licenseId": "ClArtistic",
       "seeAlso": [
@@ -1393,7 +1405,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Condor-1.1.json",
-      "referenceNumber": "304",
+      "referenceNumber": "305",
       "name": "Condor Public License v1.1",
       "licenseId": "Condor-1.1",
       "seeAlso": [
@@ -1406,7 +1418,7 @@
       "reference": "./Crossword.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Crossword.json",
-      "referenceNumber": "356",
+      "referenceNumber": "357",
       "name": "Crossword License",
       "licenseId": "Crossword",
       "seeAlso": [
@@ -1418,7 +1430,7 @@
       "reference": "./CrystalStacker.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CrystalStacker.json",
-      "referenceNumber": "165",
+      "referenceNumber": "166",
       "name": "CrystalStacker License",
       "licenseId": "CrystalStacker",
       "seeAlso": [
@@ -1430,7 +1442,7 @@
       "reference": "./Cube.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Cube.json",
-      "referenceNumber": "363",
+      "referenceNumber": "364",
       "name": "Cube License",
       "licenseId": "Cube",
       "seeAlso": [
@@ -1442,7 +1454,7 @@
       "reference": "./D-FSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/D-FSL-1.0.json",
-      "referenceNumber": "179",
+      "referenceNumber": "180",
       "name": "Deutsche Freie Software Lizenz",
       "licenseId": "D-FSL-1.0",
       "seeAlso": [
@@ -1461,7 +1473,7 @@
       "reference": "./DOC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/DOC.json",
-      "referenceNumber": "157",
+      "referenceNumber": "158",
       "name": "DOC License",
       "licenseId": "DOC",
       "seeAlso": [
@@ -1473,7 +1485,7 @@
       "reference": "./DSDP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/DSDP.json",
-      "referenceNumber": "138",
+      "referenceNumber": "139",
       "name": "DSDP License",
       "licenseId": "DSDP",
       "seeAlso": [
@@ -1485,7 +1497,7 @@
       "reference": "./Dotseqn.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Dotseqn.json",
-      "referenceNumber": "382",
+      "referenceNumber": "383",
       "name": "Dotseqn License",
       "licenseId": "Dotseqn",
       "seeAlso": [
@@ -1497,7 +1509,7 @@
       "reference": "./ECL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ECL-1.0.json",
-      "referenceNumber": "388",
+      "referenceNumber": "389",
       "name": "Educational Community License v1.0",
       "licenseId": "ECL-1.0",
       "seeAlso": [
@@ -1510,7 +1522,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ECL-2.0.json",
-      "referenceNumber": "295",
+      "referenceNumber": "296",
       "name": "Educational Community License v2.0",
       "licenseId": "ECL-2.0",
       "seeAlso": [
@@ -1522,7 +1534,7 @@
       "reference": "./EFL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/EFL-1.0.json",
-      "referenceNumber": "147",
+      "referenceNumber": "148",
       "name": "Eiffel Forum License v1.0",
       "licenseId": "EFL-1.0",
       "seeAlso": [
@@ -1536,7 +1548,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EFL-2.0.json",
-      "referenceNumber": "158",
+      "referenceNumber": "159",
       "name": "Eiffel Forum License v2.0",
       "licenseId": "EFL-2.0",
       "seeAlso": [
@@ -1550,7 +1562,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EPL-1.0.json",
-      "referenceNumber": "211",
+      "referenceNumber": "212",
       "name": "Eclipse Public License 1.0",
       "licenseId": "EPL-1.0",
       "seeAlso": [
@@ -1564,7 +1576,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EPL-2.0.json",
-      "referenceNumber": "131",
+      "referenceNumber": "132",
       "name": "Eclipse Public License 2.0",
       "licenseId": "EPL-2.0",
       "seeAlso": [
@@ -1578,7 +1590,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EUDatagrid.json",
-      "referenceNumber": "189",
+      "referenceNumber": "190",
       "name": "EU DataGrid Software License",
       "licenseId": "EUDatagrid",
       "seeAlso": [
@@ -1591,7 +1603,7 @@
       "reference": "./EUPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/EUPL-1.0.json",
-      "referenceNumber": "170",
+      "referenceNumber": "171",
       "name": "European Union Public License 1.0",
       "licenseId": "EUPL-1.0",
       "seeAlso": [
@@ -1605,7 +1617,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EUPL-1.1.json",
-      "referenceNumber": "89",
+      "referenceNumber": "90",
       "name": "European Union Public License 1.1",
       "licenseId": "EUPL-1.1",
       "seeAlso": [
@@ -1620,7 +1632,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EUPL-1.2.json",
-      "referenceNumber": "379",
+      "referenceNumber": "380",
       "name": "European Union Public License 1.2",
       "licenseId": "EUPL-1.2",
       "seeAlso": [
@@ -1636,7 +1648,7 @@
       "reference": "./Entessa.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Entessa.json",
-      "referenceNumber": "96",
+      "referenceNumber": "97",
       "name": "Entessa Public License v1.0",
       "licenseId": "Entessa",
       "seeAlso": [
@@ -1648,7 +1660,7 @@
       "reference": "./ErlPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ErlPL-1.1.json",
-      "referenceNumber": "154",
+      "referenceNumber": "155",
       "name": "Erlang Public License v1.1",
       "licenseId": "ErlPL-1.1",
       "seeAlso": [
@@ -1660,7 +1672,7 @@
       "reference": "./Eurosym.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Eurosym.json",
-      "referenceNumber": "110",
+      "referenceNumber": "111",
       "name": "Eurosym License",
       "licenseId": "Eurosym",
       "seeAlso": [
@@ -1673,7 +1685,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/FSFAP.json",
-      "referenceNumber": "111",
+      "referenceNumber": "112",
       "name": "FSF All Permissive License",
       "licenseId": "FSFAP",
       "seeAlso": [
@@ -1685,7 +1697,7 @@
       "reference": "./FSFUL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/FSFUL.json",
-      "referenceNumber": "190",
+      "referenceNumber": "191",
       "name": "FSF Unlimited License",
       "licenseId": "FSFUL",
       "seeAlso": [
@@ -1697,7 +1709,7 @@
       "reference": "./FSFULLR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/FSFULLR.json",
-      "referenceNumber": "42",
+      "referenceNumber": "43",
       "name": "FSF Unlimited License (with License Retention)",
       "licenseId": "FSFULLR",
       "seeAlso": [
@@ -1710,7 +1722,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/FTL.json",
-      "referenceNumber": "237",
+      "referenceNumber": "238",
       "name": "Freetype Project License",
       "licenseId": "FTL",
       "seeAlso": [
@@ -1723,7 +1735,7 @@
       "reference": "./Fair.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Fair.json",
-      "referenceNumber": "294",
+      "referenceNumber": "295",
       "name": "Fair License",
       "licenseId": "Fair",
       "seeAlso": [
@@ -1736,7 +1748,7 @@
       "reference": "./Frameworx-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Frameworx-1.0.json",
-      "referenceNumber": "381",
+      "referenceNumber": "382",
       "name": "Frameworx Open License 1.0",
       "licenseId": "Frameworx-1.0",
       "seeAlso": [
@@ -1748,7 +1760,7 @@
       "reference": "./FreeImage.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/FreeImage.json",
-      "referenceNumber": "274",
+      "referenceNumber": "275",
       "name": "FreeImage Public License v1.0",
       "licenseId": "FreeImage",
       "seeAlso": [
@@ -1761,7 +1773,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.1.json",
-      "referenceNumber": "95",
+      "referenceNumber": "96",
       "name": "GNU Free Documentation License v1.1",
       "licenseId": "GFDL-1.1",
       "seeAlso": [
@@ -1774,7 +1786,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-only.json",
-      "referenceNumber": "99",
+      "referenceNumber": "100",
       "name": "GNU Free Documentation License v1.1 only",
       "licenseId": "GFDL-1.1-only",
       "seeAlso": [
@@ -1787,7 +1799,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-or-later.json",
-      "referenceNumber": "343",
+      "referenceNumber": "344",
       "name": "GNU Free Documentation License v1.1 or later",
       "licenseId": "GFDL-1.1-or-later",
       "seeAlso": [
@@ -1800,7 +1812,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.2.json",
-      "referenceNumber": "194",
+      "referenceNumber": "195",
       "name": "GNU Free Documentation License v1.2",
       "licenseId": "GFDL-1.2",
       "seeAlso": [
@@ -1813,7 +1825,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-only.json",
-      "referenceNumber": "233",
+      "referenceNumber": "234",
       "name": "GNU Free Documentation License v1.2 only",
       "licenseId": "GFDL-1.2-only",
       "seeAlso": [
@@ -1826,7 +1838,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-or-later.json",
-      "referenceNumber": "212",
+      "referenceNumber": "213",
       "name": "GNU Free Documentation License v1.2 or later",
       "licenseId": "GFDL-1.2-or-later",
       "seeAlso": [
@@ -1839,7 +1851,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.3.json",
-      "referenceNumber": "109",
+      "referenceNumber": "110",
       "name": "GNU Free Documentation License v1.3",
       "licenseId": "GFDL-1.3",
       "seeAlso": [
@@ -1852,7 +1864,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-only.json",
-      "referenceNumber": "68",
+      "referenceNumber": "69",
       "name": "GNU Free Documentation License v1.3 only",
       "licenseId": "GFDL-1.3-only",
       "seeAlso": [
@@ -1877,7 +1889,7 @@
       "reference": "./GL2PS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/GL2PS.json",
-      "referenceNumber": "121",
+      "referenceNumber": "122",
       "name": "GL2PS License",
       "licenseId": "GL2PS",
       "seeAlso": [
@@ -1889,7 +1901,7 @@
       "reference": "./GPL-1.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-1.0.json",
-      "referenceNumber": "77",
+      "referenceNumber": "78",
       "name": "GNU General Public License v1.0 only",
       "licenseId": "GPL-1.0",
       "seeAlso": [
@@ -1901,7 +1913,7 @@
       "reference": "./GPL-1.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-1.0+.json",
-      "referenceNumber": "172",
+      "referenceNumber": "173",
       "name": "GNU General Public License v1.0 or later",
       "licenseId": "GPL-1.0+",
       "seeAlso": [
@@ -1925,7 +1937,7 @@
       "reference": "./GPL-1.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/GPL-1.0-or-later.json",
-      "referenceNumber": "350",
+      "referenceNumber": "351",
       "name": "GNU General Public License v1.0 or later",
       "licenseId": "GPL-1.0-or-later",
       "seeAlso": [
@@ -1938,7 +1950,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0.json",
-      "referenceNumber": "144",
+      "referenceNumber": "145",
       "name": "GNU General Public License v2.0 only",
       "licenseId": "GPL-2.0",
       "seeAlso": [
@@ -1952,7 +1964,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0+.json",
-      "referenceNumber": "73",
+      "referenceNumber": "74",
       "name": "GNU General Public License v2.0 or later",
       "licenseId": "GPL-2.0+",
       "seeAlso": [
@@ -1966,7 +1978,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-only.json",
-      "referenceNumber": "230",
+      "referenceNumber": "231",
       "name": "GNU General Public License v2.0 only",
       "licenseId": "GPL-2.0-only",
       "seeAlso": [
@@ -1980,7 +1992,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-or-later.json",
-      "referenceNumber": "55",
+      "referenceNumber": "56",
       "name": "GNU General Public License v2.0 or later",
       "licenseId": "GPL-2.0-or-later",
       "seeAlso": [
@@ -1993,7 +2005,7 @@
       "reference": "./GPL-2.0-with-GCC-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-GCC-exception.json",
-      "referenceNumber": "114",
+      "referenceNumber": "115",
       "name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
       "licenseId": "GPL-2.0-with-GCC-exception",
       "seeAlso": [
@@ -2005,7 +2017,7 @@
       "reference": "./GPL-2.0-with-autoconf-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-autoconf-exception.json",
-      "referenceNumber": "349",
+      "referenceNumber": "350",
       "name": "GNU General Public License v2.0 w/Autoconf exception",
       "licenseId": "GPL-2.0-with-autoconf-exception",
       "seeAlso": [
@@ -2017,7 +2029,7 @@
       "reference": "./GPL-2.0-with-bison-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-bison-exception.json",
-      "referenceNumber": "370",
+      "referenceNumber": "371",
       "name": "GNU General Public License v2.0 w/Bison exception",
       "licenseId": "GPL-2.0-with-bison-exception",
       "seeAlso": [
@@ -2029,7 +2041,7 @@
       "reference": "./GPL-2.0-with-classpath-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-classpath-exception.json",
-      "referenceNumber": "59",
+      "referenceNumber": "60",
       "name": "GNU General Public License v2.0 w/Classpath exception",
       "licenseId": "GPL-2.0-with-classpath-exception",
       "seeAlso": [
@@ -2041,7 +2053,7 @@
       "reference": "./GPL-2.0-with-font-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-font-exception.json",
-      "referenceNumber": "367",
+      "referenceNumber": "368",
       "name": "GNU General Public License v2.0 w/Font exception",
       "licenseId": "GPL-2.0-with-font-exception",
       "seeAlso": [
@@ -2054,7 +2066,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0.json",
-      "referenceNumber": "239",
+      "referenceNumber": "240",
       "name": "GNU General Public License v3.0 only",
       "licenseId": "GPL-3.0",
       "seeAlso": [
@@ -2068,7 +2080,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0+.json",
-      "referenceNumber": "71",
+      "referenceNumber": "72",
       "name": "GNU General Public License v3.0 or later",
       "licenseId": "GPL-3.0+",
       "seeAlso": [
@@ -2082,7 +2094,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0-only.json",
-      "referenceNumber": "203",
+      "referenceNumber": "204",
       "name": "GNU General Public License v3.0 only",
       "licenseId": "GPL-3.0-only",
       "seeAlso": [
@@ -2096,7 +2108,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0-or-later.json",
-      "referenceNumber": "193",
+      "referenceNumber": "194",
       "name": "GNU General Public License v3.0 or later",
       "licenseId": "GPL-3.0-or-later",
       "seeAlso": [
@@ -2109,7 +2121,7 @@
       "reference": "./GPL-3.0-with-GCC-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0-with-GCC-exception.json",
-      "referenceNumber": "218",
+      "referenceNumber": "219",
       "name": "GNU General Public License v3.0 w/GCC Runtime Library exception",
       "licenseId": "GPL-3.0-with-GCC-exception",
       "seeAlso": [
@@ -2121,7 +2133,7 @@
       "reference": "./GPL-3.0-with-autoconf-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0-with-autoconf-exception.json",
-      "referenceNumber": "232",
+      "referenceNumber": "233",
       "name": "GNU General Public License v3.0 w/Autoconf exception",
       "licenseId": "GPL-3.0-with-autoconf-exception",
       "seeAlso": [
@@ -2133,7 +2145,7 @@
       "reference": "./Giftware.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Giftware.json",
-      "referenceNumber": "362",
+      "referenceNumber": "363",
       "name": "Giftware License",
       "licenseId": "Giftware",
       "seeAlso": [
@@ -2145,7 +2157,7 @@
       "reference": "./Glide.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Glide.json",
-      "referenceNumber": "366",
+      "referenceNumber": "367",
       "name": "3dfx Glide License",
       "licenseId": "Glide",
       "seeAlso": [
@@ -2157,7 +2169,7 @@
       "reference": "./Glulxe.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Glulxe.json",
-      "referenceNumber": "90",
+      "referenceNumber": "91",
       "name": "Glulxe License",
       "licenseId": "Glulxe",
       "seeAlso": [
@@ -2170,7 +2182,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/HPND.json",
-      "referenceNumber": "261",
+      "referenceNumber": "262",
       "name": "Historical Permission Notice and Disclaimer",
       "licenseId": "HPND",
       "seeAlso": [
@@ -2182,7 +2194,7 @@
       "reference": "./HPND-sell-variant.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/HPND-sell-variant.json",
-      "referenceNumber": "142",
+      "referenceNumber": "143",
       "name": "Historical Permission Notice and Disclaimer - sell variant",
       "licenseId": "HPND-sell-variant",
       "seeAlso": [
@@ -2194,7 +2206,7 @@
       "reference": "./HaskellReport.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/HaskellReport.json",
-      "referenceNumber": "119",
+      "referenceNumber": "120",
       "name": "Haskell Language Report License",
       "licenseId": "HaskellReport",
       "seeAlso": [
@@ -2206,7 +2218,7 @@
       "reference": "./IBM-pibs.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/IBM-pibs.json",
-      "referenceNumber": "204",
+      "referenceNumber": "205",
       "name": "IBM PowerPC Initialization and Boot Software",
       "licenseId": "IBM-pibs",
       "seeAlso": [
@@ -2218,7 +2230,7 @@
       "reference": "./ICU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ICU.json",
-      "referenceNumber": "191",
+      "referenceNumber": "192",
       "name": "ICU License",
       "licenseId": "ICU",
       "seeAlso": [
@@ -2231,7 +2243,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/IJG.json",
-      "referenceNumber": "54",
+      "referenceNumber": "55",
       "name": "Independent JPEG Group License",
       "licenseId": "IJG",
       "seeAlso": [
@@ -2244,7 +2256,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/IPA.json",
-      "referenceNumber": "309",
+      "referenceNumber": "310",
       "name": "IPA Font License",
       "licenseId": "IPA",
       "seeAlso": [
@@ -2257,7 +2269,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/IPL-1.0.json",
-      "referenceNumber": "30",
+      "referenceNumber": "31",
       "name": "IBM Public License v1.0",
       "licenseId": "IPL-1.0",
       "seeAlso": [
@@ -2270,7 +2282,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ISC.json",
-      "referenceNumber": "107",
+      "referenceNumber": "108",
       "name": "ISC License",
       "licenseId": "ISC",
       "seeAlso": [
@@ -2283,7 +2295,7 @@
       "reference": "./ImageMagick.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ImageMagick.json",
-      "referenceNumber": "228",
+      "referenceNumber": "229",
       "name": "ImageMagick License",
       "licenseId": "ImageMagick",
       "seeAlso": [
@@ -2296,7 +2308,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Imlib2.json",
-      "referenceNumber": "254",
+      "referenceNumber": "255",
       "name": "Imlib2 License",
       "licenseId": "Imlib2",
       "seeAlso": [
@@ -2309,7 +2321,7 @@
       "reference": "./Info-ZIP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Info-ZIP.json",
-      "referenceNumber": "101",
+      "referenceNumber": "102",
       "name": "Info-ZIP License",
       "licenseId": "Info-ZIP",
       "seeAlso": [
@@ -2322,7 +2334,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Intel.json",
-      "referenceNumber": "164",
+      "referenceNumber": "165",
       "name": "Intel Open Source License",
       "licenseId": "Intel",
       "seeAlso": [
@@ -2334,7 +2346,7 @@
       "reference": "./Intel-ACPI.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Intel-ACPI.json",
-      "referenceNumber": "86",
+      "referenceNumber": "87",
       "name": "Intel ACPI Software License Agreement",
       "licenseId": "Intel-ACPI",
       "seeAlso": [
@@ -2346,7 +2358,7 @@
       "reference": "./Interbase-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Interbase-1.0.json",
-      "referenceNumber": "81",
+      "referenceNumber": "82",
       "name": "Interbase Public License v1.0",
       "licenseId": "Interbase-1.0",
       "seeAlso": [
@@ -2358,7 +2370,7 @@
       "reference": "./JPNIC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/JPNIC.json",
-      "referenceNumber": "102",
+      "referenceNumber": "103",
       "name": "Japan Network Information Center License",
       "licenseId": "JPNIC",
       "seeAlso": [
@@ -2370,7 +2382,7 @@
       "reference": "./JSON.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/JSON.json",
-      "referenceNumber": "364",
+      "referenceNumber": "365",
       "name": "JSON License",
       "licenseId": "JSON",
       "seeAlso": [
@@ -2382,7 +2394,7 @@
       "reference": "./JasPer-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/JasPer-2.0.json",
-      "referenceNumber": "236",
+      "referenceNumber": "237",
       "name": "JasPer License",
       "licenseId": "JasPer-2.0",
       "seeAlso": [
@@ -2394,7 +2406,7 @@
       "reference": "./LAL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LAL-1.2.json",
-      "referenceNumber": "372",
+      "referenceNumber": "373",
       "name": "Licence Art Libre 1.2",
       "licenseId": "LAL-1.2",
       "seeAlso": [
@@ -2406,7 +2418,7 @@
       "reference": "./LAL-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LAL-1.3.json",
-      "referenceNumber": "153",
+      "referenceNumber": "154",
       "name": "Licence Art Libre 1.3",
       "licenseId": "LAL-1.3",
       "seeAlso": [
@@ -2418,7 +2430,7 @@
       "reference": "./LGPL-2.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.0.json",
-      "referenceNumber": "265",
+      "referenceNumber": "266",
       "name": "GNU Library General Public License v2 only",
       "licenseId": "LGPL-2.0",
       "seeAlso": [
@@ -2430,7 +2442,7 @@
       "reference": "./LGPL-2.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.0+.json",
-      "referenceNumber": "51",
+      "referenceNumber": "52",
       "name": "GNU Library General Public License v2 or later",
       "licenseId": "LGPL-2.0+",
       "seeAlso": [
@@ -2442,7 +2454,7 @@
       "reference": "./LGPL-2.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.0-only.json",
-      "referenceNumber": "273",
+      "referenceNumber": "274",
       "name": "GNU Library General Public License v2 only",
       "licenseId": "LGPL-2.0-only",
       "seeAlso": [
@@ -2454,7 +2466,7 @@
       "reference": "./LGPL-2.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.0-or-later.json",
-      "referenceNumber": "214",
+      "referenceNumber": "215",
       "name": "GNU Library General Public License v2 or later",
       "licenseId": "LGPL-2.0-or-later",
       "seeAlso": [
@@ -2467,7 +2479,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.1.json",
-      "referenceNumber": "163",
+      "referenceNumber": "164",
       "name": "GNU Lesser General Public License v2.1 only",
       "licenseId": "LGPL-2.1",
       "seeAlso": [
@@ -2481,7 +2493,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.1+.json",
-      "referenceNumber": "63",
+      "referenceNumber": "64",
       "name": "GNU Library General Public License v2.1 or later",
       "licenseId": "LGPL-2.1+",
       "seeAlso": [
@@ -2509,7 +2521,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.1-or-later.json",
-      "referenceNumber": "333",
+      "referenceNumber": "334",
       "name": "GNU Lesser General Public License v2.1 or later",
       "licenseId": "LGPL-2.1-or-later",
       "seeAlso": [
@@ -2523,7 +2535,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-3.0.json",
-      "referenceNumber": "207",
+      "referenceNumber": "208",
       "name": "GNU Lesser General Public License v3.0 only",
       "licenseId": "LGPL-3.0",
       "seeAlso": [
@@ -2537,7 +2549,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-3.0+.json",
-      "referenceNumber": "149",
+      "referenceNumber": "150",
       "name": "GNU Lesser General Public License v3.0 or later",
       "licenseId": "LGPL-3.0+",
       "seeAlso": [
@@ -2551,7 +2563,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-3.0-only.json",
-      "referenceNumber": "251",
+      "referenceNumber": "252",
       "name": "GNU Lesser General Public License v3.0 only",
       "licenseId": "LGPL-3.0-only",
       "seeAlso": [
@@ -2565,7 +2577,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-3.0-or-later.json",
-      "referenceNumber": "298",
+      "referenceNumber": "299",
       "name": "GNU Lesser General Public License v3.0 or later",
       "licenseId": "LGPL-3.0-or-later",
       "seeAlso": [
@@ -2578,7 +2590,7 @@
       "reference": "./LGPLLR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LGPLLR.json",
-      "referenceNumber": "100",
+      "referenceNumber": "101",
       "name": "Lesser General Public License For Linguistic Resources",
       "licenseId": "LGPLLR",
       "seeAlso": [
@@ -2590,7 +2602,7 @@
       "reference": "./LPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LPL-1.0.json",
-      "referenceNumber": "87",
+      "referenceNumber": "88",
       "name": "Lucent Public License Version 1.0",
       "licenseId": "LPL-1.0",
       "seeAlso": [
@@ -2603,7 +2615,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LPL-1.02.json",
-      "referenceNumber": "128",
+      "referenceNumber": "129",
       "name": "Lucent Public License v1.02",
       "licenseId": "LPL-1.02",
       "seeAlso": [
@@ -2616,7 +2628,7 @@
       "reference": "./LPPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.0.json",
-      "referenceNumber": "256",
+      "referenceNumber": "257",
       "name": "LaTeX Project Public License v1.0",
       "licenseId": "LPPL-1.0",
       "seeAlso": [
@@ -2628,7 +2640,7 @@
       "reference": "./LPPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.1.json",
-      "referenceNumber": "306",
+      "referenceNumber": "307",
       "name": "LaTeX Project Public License v1.1",
       "licenseId": "LPPL-1.1",
       "seeAlso": [
@@ -2641,7 +2653,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.2.json",
-      "referenceNumber": "384",
+      "referenceNumber": "385",
       "name": "LaTeX Project Public License v1.2",
       "licenseId": "LPPL-1.2",
       "seeAlso": [
@@ -2654,7 +2666,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.3a.json",
-      "referenceNumber": "302",
+      "referenceNumber": "303",
       "name": "LaTeX Project Public License v1.3a",
       "licenseId": "LPPL-1.3a",
       "seeAlso": [
@@ -2666,7 +2678,7 @@
       "reference": "./LPPL-1.3c.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.3c.json",
-      "referenceNumber": "322",
+      "referenceNumber": "323",
       "name": "LaTeX Project Public License v1.3c",
       "licenseId": "LPPL-1.3c",
       "seeAlso": [
@@ -2679,7 +2691,7 @@
       "reference": "./Latex2e.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Latex2e.json",
-      "referenceNumber": "280",
+      "referenceNumber": "281",
       "name": "Latex2e License",
       "licenseId": "Latex2e",
       "seeAlso": [
@@ -2691,7 +2703,7 @@
       "reference": "./Leptonica.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Leptonica.json",
-      "referenceNumber": "156",
+      "referenceNumber": "157",
       "name": "Leptonica License",
       "licenseId": "Leptonica",
       "seeAlso": [
@@ -2703,7 +2715,7 @@
       "reference": "./LiLiQ-P-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LiLiQ-P-1.1.json",
-      "referenceNumber": "371",
+      "referenceNumber": "372",
       "name": "Licence Libre du Québec – Permissive version 1.1",
       "licenseId": "LiLiQ-P-1.1",
       "seeAlso": [
@@ -2716,7 +2728,7 @@
       "reference": "./LiLiQ-R-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LiLiQ-R-1.1.json",
-      "referenceNumber": "283",
+      "referenceNumber": "284",
       "name": "Licence Libre du Québec – Réciprocité version 1.1",
       "licenseId": "LiLiQ-R-1.1",
       "seeAlso": [
@@ -2729,7 +2741,7 @@
       "reference": "./LiLiQ-Rplus-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LiLiQ-Rplus-1.1.json",
-      "referenceNumber": "136",
+      "referenceNumber": "137",
       "name": "Licence Libre du Québec – Réciprocité forte version 1.1",
       "licenseId": "LiLiQ-Rplus-1.1",
       "seeAlso": [
@@ -2742,7 +2754,7 @@
       "reference": "./Libpng.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Libpng.json",
-      "referenceNumber": "98",
+      "referenceNumber": "99",
       "name": "libpng License",
       "licenseId": "Libpng",
       "seeAlso": [
@@ -2767,7 +2779,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/MIT.json",
-      "referenceNumber": "198",
+      "referenceNumber": "199",
       "name": "MIT License",
       "licenseId": "MIT",
       "seeAlso": [
@@ -2818,7 +2830,7 @@
       "reference": "./MIT-enna.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MIT-enna.json",
-      "referenceNumber": "24",
+      "referenceNumber": "25",
       "name": "enna License",
       "licenseId": "MIT-enna",
       "seeAlso": [
@@ -2830,7 +2842,7 @@
       "reference": "./MIT-feh.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MIT-feh.json",
-      "referenceNumber": "37",
+      "referenceNumber": "38",
       "name": "feh License",
       "licenseId": "MIT-feh",
       "seeAlso": [
@@ -2842,7 +2854,7 @@
       "reference": "./MITNFA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MITNFA.json",
-      "referenceNumber": "291",
+      "referenceNumber": "292",
       "name": "MIT +no-false-attribs license",
       "licenseId": "MITNFA",
       "seeAlso": [
@@ -2854,7 +2866,7 @@
       "reference": "./MPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MPL-1.0.json",
-      "referenceNumber": "48",
+      "referenceNumber": "49",
       "name": "Mozilla Public License 1.0",
       "licenseId": "MPL-1.0",
       "seeAlso": [
@@ -2868,7 +2880,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/MPL-1.1.json",
-      "referenceNumber": "301",
+      "referenceNumber": "302",
       "name": "Mozilla Public License 1.1",
       "licenseId": "MPL-1.1",
       "seeAlso": [
@@ -2882,7 +2894,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/MPL-2.0.json",
-      "referenceNumber": "231",
+      "referenceNumber": "232",
       "name": "Mozilla Public License 2.0",
       "licenseId": "MPL-2.0",
       "seeAlso": [
@@ -2895,7 +2907,7 @@
       "reference": "./MPL-2.0-no-copyleft-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MPL-2.0-no-copyleft-exception.json",
-      "referenceNumber": "300",
+      "referenceNumber": "301",
       "name": "Mozilla Public License 2.0 (no copyleft exception)",
       "licenseId": "MPL-2.0-no-copyleft-exception",
       "seeAlso": [
@@ -2909,7 +2921,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/MS-PL.json",
-      "referenceNumber": "331",
+      "referenceNumber": "332",
       "name": "Microsoft Public License",
       "licenseId": "MS-PL",
       "seeAlso": [
@@ -2923,7 +2935,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/MS-RL.json",
-      "referenceNumber": "277",
+      "referenceNumber": "278",
       "name": "Microsoft Reciprocal License",
       "licenseId": "MS-RL",
       "seeAlso": [
@@ -2936,7 +2948,7 @@
       "reference": "./MTLL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MTLL.json",
-      "referenceNumber": "178",
+      "referenceNumber": "179",
       "name": "Matrix Template Library License",
       "licenseId": "MTLL",
       "seeAlso": [
@@ -2948,7 +2960,7 @@
       "reference": "./MakeIndex.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MakeIndex.json",
-      "referenceNumber": "184",
+      "referenceNumber": "185",
       "name": "MakeIndex License",
       "licenseId": "MakeIndex",
       "seeAlso": [
@@ -2960,7 +2972,7 @@
       "reference": "./MirOS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MirOS.json",
-      "referenceNumber": "296",
+      "referenceNumber": "297",
       "name": "MirOS License",
       "licenseId": "MirOS",
       "seeAlso": [
@@ -2972,7 +2984,7 @@
       "reference": "./Motosoto.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Motosoto.json",
-      "referenceNumber": "313",
+      "referenceNumber": "314",
       "name": "Motosoto License",
       "licenseId": "Motosoto",
       "seeAlso": [
@@ -2984,7 +2996,7 @@
       "reference": "./Multics.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Multics.json",
-      "referenceNumber": "62",
+      "referenceNumber": "63",
       "name": "Multics License",
       "licenseId": "Multics",
       "seeAlso": [
@@ -2996,7 +3008,7 @@
       "reference": "./Mup.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Mup.json",
-      "referenceNumber": "347",
+      "referenceNumber": "348",
       "name": "Mup License",
       "licenseId": "Mup",
       "seeAlso": [
@@ -3008,7 +3020,7 @@
       "reference": "./NASA-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NASA-1.3.json",
-      "referenceNumber": "85",
+      "referenceNumber": "86",
       "name": "NASA Open Source Agreement 1.3",
       "licenseId": "NASA-1.3",
       "seeAlso": [
@@ -3021,7 +3033,7 @@
       "reference": "./NBPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NBPL-1.0.json",
-      "referenceNumber": "354",
+      "referenceNumber": "355",
       "name": "Net Boolean Public License v1",
       "licenseId": "NBPL-1.0",
       "seeAlso": [
@@ -3034,7 +3046,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/NCSA.json",
-      "referenceNumber": "57",
+      "referenceNumber": "58",
       "name": "University of Illinois/NCSA Open Source License",
       "licenseId": "NCSA",
       "seeAlso": [
@@ -3047,7 +3059,7 @@
       "reference": "./NGPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NGPL.json",
-      "referenceNumber": "70",
+      "referenceNumber": "71",
       "name": "Nethack General Public License",
       "licenseId": "NGPL",
       "seeAlso": [
@@ -3059,7 +3071,7 @@
       "reference": "./NLOD-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NLOD-1.0.json",
-      "referenceNumber": "206",
+      "referenceNumber": "207",
       "name": "Norwegian Licence for Open Government Data",
       "licenseId": "NLOD-1.0",
       "seeAlso": [
@@ -3071,7 +3083,7 @@
       "reference": "./NLPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NLPL.json",
-      "referenceNumber": "339",
+      "referenceNumber": "340",
       "name": "No Limit Public License",
       "licenseId": "NLPL",
       "seeAlso": [
@@ -3084,7 +3096,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/NOSL.json",
-      "referenceNumber": "375",
+      "referenceNumber": "376",
       "name": "Netizen Open Source License",
       "licenseId": "NOSL",
       "seeAlso": [
@@ -3097,7 +3109,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/NPL-1.0.json",
-      "referenceNumber": "324",
+      "referenceNumber": "325",
       "name": "Netscape Public License v1.0",
       "licenseId": "NPL-1.0",
       "seeAlso": [
@@ -3110,7 +3122,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/NPL-1.1.json",
-      "referenceNumber": "182",
+      "referenceNumber": "183",
       "name": "Netscape Public License v1.1",
       "licenseId": "NPL-1.1",
       "seeAlso": [
@@ -3122,7 +3134,7 @@
       "reference": "./NPOSL-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NPOSL-3.0.json",
-      "referenceNumber": "219",
+      "referenceNumber": "220",
       "name": "Non-Profit Open Software License 3.0",
       "licenseId": "NPOSL-3.0",
       "seeAlso": [
@@ -3134,7 +3146,7 @@
       "reference": "./NRL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NRL.json",
-      "referenceNumber": "52",
+      "referenceNumber": "53",
       "name": "NRL License",
       "licenseId": "NRL",
       "seeAlso": [
@@ -3146,7 +3158,7 @@
       "reference": "./NTP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NTP.json",
-      "referenceNumber": "258",
+      "referenceNumber": "259",
       "name": "NTP License",
       "licenseId": "NTP",
       "seeAlso": [
@@ -3158,7 +3170,7 @@
       "reference": "./Naumen.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Naumen.json",
-      "referenceNumber": "275",
+      "referenceNumber": "276",
       "name": "Naumen Public License",
       "licenseId": "Naumen",
       "seeAlso": [
@@ -3170,7 +3182,7 @@
       "reference": "./Net-SNMP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Net-SNMP.json",
-      "referenceNumber": "281",
+      "referenceNumber": "282",
       "name": "Net-SNMP License",
       "licenseId": "Net-SNMP",
       "seeAlso": [
@@ -3182,7 +3194,7 @@
       "reference": "./NetCDF.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NetCDF.json",
-      "referenceNumber": "45",
+      "referenceNumber": "46",
       "name": "NetCDF license",
       "licenseId": "NetCDF",
       "seeAlso": [
@@ -3194,7 +3206,7 @@
       "reference": "./Newsletr.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Newsletr.json",
-      "referenceNumber": "276",
+      "referenceNumber": "277",
       "name": "Newsletr License",
       "licenseId": "Newsletr",
       "seeAlso": [
@@ -3207,7 +3219,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Nokia.json",
-      "referenceNumber": "323",
+      "referenceNumber": "324",
       "name": "Nokia Open Source License",
       "licenseId": "Nokia",
       "seeAlso": [
@@ -3219,7 +3231,7 @@
       "reference": "./Noweb.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Noweb.json",
-      "referenceNumber": "357",
+      "referenceNumber": "358",
       "name": "Noweb License",
       "licenseId": "Noweb",
       "seeAlso": [
@@ -3232,7 +3244,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Nunit.json",
-      "referenceNumber": "285",
+      "referenceNumber": "286",
       "name": "Nunit License",
       "licenseId": "Nunit",
       "seeAlso": [
@@ -3244,7 +3256,7 @@
       "reference": "./OCCT-PL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OCCT-PL.json",
-      "referenceNumber": "279",
+      "referenceNumber": "280",
       "name": "Open CASCADE Technology Public License",
       "licenseId": "OCCT-PL",
       "seeAlso": [
@@ -3256,7 +3268,7 @@
       "reference": "./OCLC-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OCLC-2.0.json",
-      "referenceNumber": "108",
+      "referenceNumber": "109",
       "name": "OCLC Research Public License 2.0",
       "licenseId": "OCLC-2.0",
       "seeAlso": [
@@ -3269,7 +3281,7 @@
       "reference": "./ODC-By-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ODC-By-1.0.json",
-      "referenceNumber": "141",
+      "referenceNumber": "142",
       "name": "Open Data Commons Attribution License v1.0",
       "licenseId": "ODC-By-1.0",
       "seeAlso": [
@@ -3282,7 +3294,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ODbL-1.0.json",
-      "referenceNumber": "243",
+      "referenceNumber": "244",
       "name": "ODC Open Database License v1.0",
       "licenseId": "ODbL-1.0",
       "seeAlso": [
@@ -3295,7 +3307,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OFL-1.0.json",
-      "referenceNumber": "150",
+      "referenceNumber": "151",
       "name": "SIL Open Font License 1.0",
       "licenseId": "OFL-1.0",
       "seeAlso": [
@@ -3308,7 +3320,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OFL-1.1.json",
-      "referenceNumber": "311",
+      "referenceNumber": "312",
       "name": "SIL Open Font License 1.1",
       "licenseId": "OFL-1.1",
       "seeAlso": [
@@ -3321,7 +3333,7 @@
       "reference": "./OGL-UK-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OGL-UK-1.0.json",
-      "referenceNumber": "113",
+      "referenceNumber": "114",
       "name": "Open Government Licence v1.0",
       "licenseId": "OGL-UK-1.0",
       "seeAlso": [
@@ -3333,7 +3345,7 @@
       "reference": "./OGL-UK-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OGL-UK-2.0.json",
-      "referenceNumber": "286",
+      "referenceNumber": "287",
       "name": "Open Government Licence v2.0",
       "licenseId": "OGL-UK-2.0",
       "seeAlso": [
@@ -3345,7 +3357,7 @@
       "reference": "./OGL-UK-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OGL-UK-3.0.json",
-      "referenceNumber": "223",
+      "referenceNumber": "224",
       "name": "Open Government Licence v3.0",
       "licenseId": "OGL-UK-3.0",
       "seeAlso": [
@@ -3357,7 +3369,7 @@
       "reference": "./OGTSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OGTSL.json",
-      "referenceNumber": "122",
+      "referenceNumber": "123",
       "name": "Open Group Test Suite License",
       "licenseId": "OGTSL",
       "seeAlso": [
@@ -3370,7 +3382,7 @@
       "reference": "./OLDAP-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-1.1.json",
-      "referenceNumber": "94",
+      "referenceNumber": "95",
       "name": "Open LDAP Public License v1.1",
       "licenseId": "OLDAP-1.1",
       "seeAlso": [
@@ -3382,7 +3394,7 @@
       "reference": "./OLDAP-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-1.2.json",
-      "referenceNumber": "187",
+      "referenceNumber": "188",
       "name": "Open LDAP Public License v1.2",
       "licenseId": "OLDAP-1.2",
       "seeAlso": [
@@ -3394,7 +3406,7 @@
       "reference": "./OLDAP-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-1.3.json",
-      "referenceNumber": "103",
+      "referenceNumber": "104",
       "name": "Open LDAP Public License v1.3",
       "licenseId": "OLDAP-1.3",
       "seeAlso": [
@@ -3406,7 +3418,7 @@
       "reference": "./OLDAP-1.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-1.4.json",
-      "referenceNumber": "29",
+      "referenceNumber": "30",
       "name": "Open LDAP Public License v1.4",
       "licenseId": "OLDAP-1.4",
       "seeAlso": [
@@ -3418,7 +3430,7 @@
       "reference": "./OLDAP-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.0.json",
-      "referenceNumber": "263",
+      "referenceNumber": "264",
       "name": "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
       "licenseId": "OLDAP-2.0",
       "seeAlso": [
@@ -3430,7 +3442,7 @@
       "reference": "./OLDAP-2.0.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.0.1.json",
-      "referenceNumber": "344",
+      "referenceNumber": "345",
       "name": "Open LDAP Public License v2.0.1",
       "licenseId": "OLDAP-2.0.1",
       "seeAlso": [
@@ -3442,7 +3454,7 @@
       "reference": "./OLDAP-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.1.json",
-      "referenceNumber": "151",
+      "referenceNumber": "152",
       "name": "Open LDAP Public License v2.1",
       "licenseId": "OLDAP-2.1",
       "seeAlso": [
@@ -3454,7 +3466,7 @@
       "reference": "./OLDAP-2.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.json",
-      "referenceNumber": "355",
+      "referenceNumber": "356",
       "name": "Open LDAP Public License v2.2",
       "licenseId": "OLDAP-2.2",
       "seeAlso": [
@@ -3466,7 +3478,7 @@
       "reference": "./OLDAP-2.2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.1.json",
-      "referenceNumber": "334",
+      "referenceNumber": "335",
       "name": "Open LDAP Public License v2.2.1",
       "licenseId": "OLDAP-2.2.1",
       "seeAlso": [
@@ -3478,7 +3490,7 @@
       "reference": "./OLDAP-2.2.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.2.json",
-      "referenceNumber": "196",
+      "referenceNumber": "197",
       "name": "Open LDAP Public License 2.2.2",
       "licenseId": "OLDAP-2.2.2",
       "seeAlso": [
@@ -3491,7 +3503,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.3.json",
-      "referenceNumber": "161",
+      "referenceNumber": "162",
       "name": "Open LDAP Public License v2.3",
       "licenseId": "OLDAP-2.3",
       "seeAlso": [
@@ -3503,7 +3515,7 @@
       "reference": "./OLDAP-2.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.4.json",
-      "referenceNumber": "65",
+      "referenceNumber": "66",
       "name": "Open LDAP Public License v2.4",
       "licenseId": "OLDAP-2.4",
       "seeAlso": [
@@ -3515,7 +3527,7 @@
       "reference": "./OLDAP-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.5.json",
-      "referenceNumber": "180",
+      "referenceNumber": "181",
       "name": "Open LDAP Public License v2.5",
       "licenseId": "OLDAP-2.5",
       "seeAlso": [
@@ -3527,7 +3539,7 @@
       "reference": "./OLDAP-2.6.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.6.json",
-      "referenceNumber": "60",
+      "referenceNumber": "61",
       "name": "Open LDAP Public License v2.6",
       "licenseId": "OLDAP-2.6",
       "seeAlso": [
@@ -3540,7 +3552,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.7.json",
-      "referenceNumber": "120",
+      "referenceNumber": "121",
       "name": "Open LDAP Public License v2.7",
       "licenseId": "OLDAP-2.7",
       "seeAlso": [
@@ -3552,7 +3564,7 @@
       "reference": "./OLDAP-2.8.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.8.json",
-      "referenceNumber": "36",
+      "referenceNumber": "37",
       "name": "Open LDAP Public License v2.8",
       "licenseId": "OLDAP-2.8",
       "seeAlso": [
@@ -3564,7 +3576,7 @@
       "reference": "./OML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OML.json",
-      "referenceNumber": "64",
+      "referenceNumber": "65",
       "name": "Open Market License",
       "licenseId": "OML",
       "seeAlso": [
@@ -3576,7 +3588,7 @@
       "reference": "./OPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OPL-1.0.json",
-      "referenceNumber": "338",
+      "referenceNumber": "339",
       "name": "Open Public License v1.0",
       "licenseId": "OPL-1.0",
       "seeAlso": [
@@ -3589,7 +3601,7 @@
       "reference": "./OSET-PL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OSET-PL-2.1.json",
-      "referenceNumber": "288",
+      "referenceNumber": "289",
       "name": "OSET Public License version 2.1",
       "licenseId": "OSET-PL-2.1",
       "seeAlso": [
@@ -3603,7 +3615,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-1.0.json",
-      "referenceNumber": "83",
+      "referenceNumber": "84",
       "name": "Open Software License 1.0",
       "licenseId": "OSL-1.0",
       "seeAlso": [
@@ -3616,7 +3628,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-1.1.json",
-      "referenceNumber": "329",
+      "referenceNumber": "330",
       "name": "Open Software License 1.1",
       "licenseId": "OSL-1.1",
       "seeAlso": [
@@ -3642,7 +3654,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-2.1.json",
-      "referenceNumber": "23",
+      "referenceNumber": "24",
       "name": "Open Software License 2.1",
       "licenseId": "OSL-2.1",
       "seeAlso": [
@@ -3656,7 +3668,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-3.0.json",
-      "referenceNumber": "97",
+      "referenceNumber": "98",
       "name": "Open Software License 3.0",
       "licenseId": "OSL-3.0",
       "seeAlso": [
@@ -3670,7 +3682,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OpenSSL.json",
-      "referenceNumber": "246",
+      "referenceNumber": "247",
       "name": "OpenSSL License",
       "licenseId": "OpenSSL",
       "seeAlso": [
@@ -3694,7 +3706,7 @@
       "reference": "./PHP-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/PHP-3.0.json",
-      "referenceNumber": "377",
+      "referenceNumber": "378",
       "name": "PHP License v3.0",
       "licenseId": "PHP-3.0",
       "seeAlso": [
@@ -3708,7 +3720,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/PHP-3.01.json",
-      "referenceNumber": "312",
+      "referenceNumber": "313",
       "name": "PHP License v3.01",
       "licenseId": "PHP-3.01",
       "seeAlso": [
@@ -3720,7 +3732,7 @@
       "reference": "./Plexus.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Plexus.json",
-      "referenceNumber": "222",
+      "referenceNumber": "223",
       "name": "Plexus Classworlds License",
       "licenseId": "Plexus",
       "seeAlso": [
@@ -3732,7 +3744,7 @@
       "reference": "./PostgreSQL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/PostgreSQL.json",
-      "referenceNumber": "244",
+      "referenceNumber": "245",
       "name": "PostgreSQL License",
       "licenseId": "PostgreSQL",
       "seeAlso": [
@@ -3746,7 +3758,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Python-2.0.json",
-      "referenceNumber": "34",
+      "referenceNumber": "35",
       "name": "Python License 2.0",
       "licenseId": "Python-2.0",
       "seeAlso": [
@@ -3759,7 +3771,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/QPL-1.0.json",
-      "referenceNumber": "26",
+      "referenceNumber": "27",
       "name": "Q Public License 1.0",
       "licenseId": "QPL-1.0",
       "seeAlso": [
@@ -3772,7 +3784,7 @@
       "reference": "./Qhull.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Qhull.json",
-      "referenceNumber": "66",
+      "referenceNumber": "67",
       "name": "Qhull License",
       "licenseId": "Qhull",
       "seeAlso": [
@@ -3784,7 +3796,7 @@
       "reference": "./RHeCos-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RHeCos-1.1.json",
-      "referenceNumber": "146",
+      "referenceNumber": "147",
       "name": "Red Hat eCos Public License v1.1",
       "licenseId": "RHeCos-1.1",
       "seeAlso": [
@@ -3796,7 +3808,7 @@
       "reference": "./RPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RPL-1.1.json",
-      "referenceNumber": "266",
+      "referenceNumber": "267",
       "name": "Reciprocal Public License 1.1",
       "licenseId": "RPL-1.1",
       "seeAlso": [
@@ -3808,7 +3820,7 @@
       "reference": "./RPL-1.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RPL-1.5.json",
-      "referenceNumber": "224",
+      "referenceNumber": "225",
       "name": "Reciprocal Public License 1.5",
       "licenseId": "RPL-1.5",
       "seeAlso": [
@@ -3821,7 +3833,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/RPSL-1.0.json",
-      "referenceNumber": "270",
+      "referenceNumber": "271",
       "name": "RealNetworks Public Source License v1.0",
       "licenseId": "RPSL-1.0",
       "seeAlso": [
@@ -3834,7 +3846,7 @@
       "reference": "./RSA-MD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RSA-MD.json",
-      "referenceNumber": "80",
+      "referenceNumber": "81",
       "name": "RSA Message-Digest License ",
       "licenseId": "RSA-MD",
       "seeAlso": [
@@ -3846,7 +3858,7 @@
       "reference": "./RSCPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RSCPL.json",
-      "referenceNumber": "208",
+      "referenceNumber": "209",
       "name": "Ricoh Source Code Public License",
       "licenseId": "RSCPL",
       "seeAlso": [
@@ -3859,7 +3871,7 @@
       "reference": "./Rdisc.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Rdisc.json",
-      "referenceNumber": "292",
+      "referenceNumber": "293",
       "name": "Rdisc License",
       "licenseId": "Rdisc",
       "seeAlso": [
@@ -3872,7 +3884,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Ruby.json",
-      "referenceNumber": "260",
+      "referenceNumber": "261",
       "name": "Ruby License",
       "licenseId": "Ruby",
       "seeAlso": [
@@ -3884,7 +3896,7 @@
       "reference": "./SAX-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SAX-PD.json",
-      "referenceNumber": "137",
+      "referenceNumber": "138",
       "name": "Sax Public Domain Notice",
       "licenseId": "SAX-PD",
       "seeAlso": [
@@ -3908,7 +3920,7 @@
       "reference": "./SGI-B-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SGI-B-1.0.json",
-      "referenceNumber": "88",
+      "referenceNumber": "89",
       "name": "SGI Free Software License B v1.0",
       "licenseId": "SGI-B-1.0",
       "seeAlso": [
@@ -3920,7 +3932,7 @@
       "reference": "./SGI-B-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SGI-B-1.1.json",
-      "referenceNumber": "238",
+      "referenceNumber": "239",
       "name": "SGI Free Software License B v1.1",
       "licenseId": "SGI-B-1.1",
       "seeAlso": [
@@ -3933,7 +3945,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/SGI-B-2.0.json",
-      "referenceNumber": "269",
+      "referenceNumber": "270",
       "name": "SGI Free Software License B v2.0",
       "licenseId": "SGI-B-2.0",
       "seeAlso": [
@@ -3946,7 +3958,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/SISSL.json",
-      "referenceNumber": "72",
+      "referenceNumber": "73",
       "name": "Sun Industry Standards Source License v1.1",
       "licenseId": "SISSL",
       "seeAlso": [
@@ -3972,7 +3984,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/SMLNJ.json",
-      "referenceNumber": "293",
+      "referenceNumber": "294",
       "name": "Standard ML of New Jersey License",
       "licenseId": "SMLNJ",
       "seeAlso": [
@@ -3984,7 +3996,7 @@
       "reference": "./SMPPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SMPPL.json",
-      "referenceNumber": "124",
+      "referenceNumber": "125",
       "name": "Secure Messaging Protocol Public License",
       "licenseId": "SMPPL",
       "seeAlso": [
@@ -3996,7 +4008,7 @@
       "reference": "./SNIA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SNIA.json",
-      "referenceNumber": "227",
+      "referenceNumber": "228",
       "name": "SNIA Public License 1.1",
       "licenseId": "SNIA",
       "seeAlso": [
@@ -4009,7 +4021,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/SPL-1.0.json",
-      "referenceNumber": "53",
+      "referenceNumber": "54",
       "name": "Sun Public License v1.0",
       "licenseId": "SPL-1.0",
       "seeAlso": [
@@ -4021,7 +4033,7 @@
       "reference": "./SWL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SWL.json",
-      "referenceNumber": "205",
+      "referenceNumber": "206",
       "name": "Scheme Widget Library (SWL) Software License Agreement",
       "licenseId": "SWL",
       "seeAlso": [
@@ -4045,7 +4057,7 @@
       "reference": "./Sendmail.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Sendmail.json",
-      "referenceNumber": "148",
+      "referenceNumber": "149",
       "name": "Sendmail License",
       "licenseId": "Sendmail",
       "seeAlso": [
@@ -4058,7 +4070,7 @@
       "reference": "./Sendmail-8.23.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Sendmail-8.23.json",
-      "referenceNumber": "40",
+      "referenceNumber": "41",
       "name": "Sendmail License 8.23",
       "licenseId": "Sendmail-8.23",
       "seeAlso": [
@@ -4071,7 +4083,7 @@
       "reference": "./SimPL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SimPL-2.0.json",
-      "referenceNumber": "181",
+      "referenceNumber": "182",
       "name": "Simple Public License 2.0",
       "licenseId": "SimPL-2.0",
       "seeAlso": [
@@ -4084,7 +4096,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Sleepycat.json",
-      "referenceNumber": "287",
+      "referenceNumber": "288",
       "name": "Sleepycat License",
       "licenseId": "Sleepycat",
       "seeAlso": [
@@ -4096,7 +4108,7 @@
       "reference": "./Spencer-86.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Spencer-86.json",
-      "referenceNumber": "310",
+      "referenceNumber": "311",
       "name": "Spencer License 86",
       "licenseId": "Spencer-86",
       "seeAlso": [
@@ -4108,7 +4120,7 @@
       "reference": "./Spencer-94.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Spencer-94.json",
-      "referenceNumber": "28",
+      "referenceNumber": "29",
       "name": "Spencer License 94",
       "licenseId": "Spencer-94",
       "seeAlso": [
@@ -4120,7 +4132,7 @@
       "reference": "./Spencer-99.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Spencer-99.json",
-      "referenceNumber": "378",
+      "referenceNumber": "379",
       "name": "Spencer License 99",
       "licenseId": "Spencer-99",
       "seeAlso": [
@@ -4133,7 +4145,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/StandardML-NJ.json",
-      "referenceNumber": "216",
+      "referenceNumber": "217",
       "name": "Standard ML of New Jersey License",
       "licenseId": "StandardML-NJ",
       "seeAlso": [
@@ -4145,7 +4157,7 @@
       "reference": "./SugarCRM-1.1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SugarCRM-1.1.3.json",
-      "referenceNumber": "289",
+      "referenceNumber": "290",
       "name": "SugarCRM Public License v1.1.3",
       "licenseId": "SugarCRM-1.1.3",
       "seeAlso": [
@@ -4157,7 +4169,7 @@
       "reference": "./TAPR-OHL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TAPR-OHL-1.0.json",
-      "referenceNumber": "264",
+      "referenceNumber": "265",
       "name": "TAPR Open Hardware License v1.0",
       "licenseId": "TAPR-OHL-1.0",
       "seeAlso": [
@@ -4169,7 +4181,7 @@
       "reference": "./TCL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TCL.json",
-      "referenceNumber": "262",
+      "referenceNumber": "263",
       "name": "TCL/TK License",
       "licenseId": "TCL",
       "seeAlso": [
@@ -4182,7 +4194,7 @@
       "reference": "./TCP-wrappers.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TCP-wrappers.json",
-      "referenceNumber": "271",
+      "referenceNumber": "272",
       "name": "TCP Wrappers License",
       "licenseId": "TCP-wrappers",
       "seeAlso": [
@@ -4194,7 +4206,7 @@
       "reference": "./TMate.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TMate.json",
-      "referenceNumber": "250",
+      "referenceNumber": "251",
       "name": "TMate Open Source License",
       "licenseId": "TMate",
       "seeAlso": [
@@ -4206,7 +4218,7 @@
       "reference": "./TORQUE-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TORQUE-1.1.json",
-      "referenceNumber": "168",
+      "referenceNumber": "169",
       "name": "TORQUE v2.5+ Software License v1.1",
       "licenseId": "TORQUE-1.1",
       "seeAlso": [
@@ -4218,7 +4230,7 @@
       "reference": "./TOSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TOSL.json",
-      "referenceNumber": "353",
+      "referenceNumber": "354",
       "name": "Trusster Open Source License",
       "licenseId": "TOSL",
       "seeAlso": [
@@ -4230,7 +4242,7 @@
       "reference": "./TU-Berlin-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TU-Berlin-1.0.json",
-      "referenceNumber": "365",
+      "referenceNumber": "366",
       "name": "Technische Universitaet Berlin License 1.0",
       "licenseId": "TU-Berlin-1.0",
       "seeAlso": [
@@ -4242,7 +4254,7 @@
       "reference": "./TU-Berlin-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TU-Berlin-2.0.json",
-      "referenceNumber": "383",
+      "referenceNumber": "384",
       "name": "Technische Universitaet Berlin License 2.0",
       "licenseId": "TU-Berlin-2.0",
       "seeAlso": [
@@ -4255,7 +4267,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/UPL-1.0.json",
-      "referenceNumber": "202",
+      "referenceNumber": "203",
       "name": "Universal Permissive License v1.0",
       "licenseId": "UPL-1.0",
       "seeAlso": [
@@ -4279,7 +4291,7 @@
       "reference": "./Unicode-DFS-2016.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Unicode-DFS-2016.json",
-      "referenceNumber": "374",
+      "referenceNumber": "375",
       "name": "Unicode License Agreement - Data Files and Software (2016)",
       "licenseId": "Unicode-DFS-2016",
       "seeAlso": [
@@ -4291,7 +4303,7 @@
       "reference": "./Unicode-TOU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Unicode-TOU.json",
-      "referenceNumber": "69",
+      "referenceNumber": "70",
       "name": "Unicode Terms of Use",
       "licenseId": "Unicode-TOU",
       "seeAlso": [
@@ -4304,7 +4316,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Unlicense.json",
-      "referenceNumber": "290",
+      "referenceNumber": "291",
       "name": "The Unlicense",
       "licenseId": "Unlicense",
       "seeAlso": [
@@ -4316,7 +4328,7 @@
       "reference": "./VOSTROM.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/VOSTROM.json",
-      "referenceNumber": "225",
+      "referenceNumber": "226",
       "name": "VOSTROM Public License for Open Source",
       "licenseId": "VOSTROM",
       "seeAlso": [
@@ -4328,7 +4340,7 @@
       "reference": "./VSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/VSL-1.0.json",
-      "referenceNumber": "177",
+      "referenceNumber": "178",
       "name": "Vovida Software License v1.0",
       "licenseId": "VSL-1.0",
       "seeAlso": [
@@ -4341,7 +4353,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Vim.json",
-      "referenceNumber": "130",
+      "referenceNumber": "131",
       "name": "Vim License",
       "licenseId": "Vim",
       "seeAlso": [
@@ -4354,7 +4366,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/W3C.json",
-      "referenceNumber": "345",
+      "referenceNumber": "346",
       "name": "W3C Software Notice and License (2002-12-31)",
       "licenseId": "W3C",
       "seeAlso": [
@@ -4367,7 +4379,7 @@
       "reference": "./W3C-19980720.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/W3C-19980720.json",
-      "referenceNumber": "319",
+      "referenceNumber": "320",
       "name": "W3C Software Notice and License (1998-07-20)",
       "licenseId": "W3C-19980720",
       "seeAlso": [
@@ -4379,7 +4391,7 @@
       "reference": "./W3C-20150513.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/W3C-20150513.json",
-      "referenceNumber": "50",
+      "referenceNumber": "51",
       "name": "W3C Software Notice and Document License (2015-05-13)",
       "licenseId": "W3C-20150513",
       "seeAlso": [
@@ -4392,7 +4404,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/WTFPL.json",
-      "referenceNumber": "361",
+      "referenceNumber": "362",
       "name": "Do What The F*ck You Want To Public License",
       "licenseId": "WTFPL",
       "seeAlso": [
@@ -4404,7 +4416,7 @@
       "reference": "./Watcom-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Watcom-1.0.json",
-      "referenceNumber": "174",
+      "referenceNumber": "175",
       "name": "Sybase Open Watcom Public License 1.0",
       "licenseId": "Watcom-1.0",
       "seeAlso": [
@@ -4416,7 +4428,7 @@
       "reference": "./Wsuipa.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Wsuipa.json",
-      "referenceNumber": "132",
+      "referenceNumber": "133",
       "name": "Wsuipa License",
       "licenseId": "Wsuipa",
       "seeAlso": [
@@ -4429,7 +4441,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/X11.json",
-      "referenceNumber": "185",
+      "referenceNumber": "186",
       "name": "X11 License",
       "licenseId": "X11",
       "seeAlso": [
@@ -4442,7 +4454,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/XFree86-1.1.json",
-      "referenceNumber": "240",
+      "referenceNumber": "241",
       "name": "XFree86 License 1.1",
       "licenseId": "XFree86-1.1",
       "seeAlso": [
@@ -4454,7 +4466,7 @@
       "reference": "./XSkat.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/XSkat.json",
-      "referenceNumber": "93",
+      "referenceNumber": "94",
       "name": "XSkat License",
       "licenseId": "XSkat",
       "seeAlso": [
@@ -4466,7 +4478,7 @@
       "reference": "./Xerox.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Xerox.json",
-      "referenceNumber": "160",
+      "referenceNumber": "161",
       "name": "Xerox License",
       "licenseId": "Xerox",
       "seeAlso": [
@@ -4478,7 +4490,7 @@
       "reference": "./Xnet.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Xnet.json",
-      "referenceNumber": "380",
+      "referenceNumber": "381",
       "name": "X.Net License",
       "licenseId": "Xnet",
       "seeAlso": [
@@ -4490,7 +4502,7 @@
       "reference": "./YPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/YPL-1.0.json",
-      "referenceNumber": "171",
+      "referenceNumber": "172",
       "name": "Yahoo! Public License v1.0",
       "licenseId": "YPL-1.0",
       "seeAlso": [
@@ -4503,7 +4515,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/YPL-1.1.json",
-      "referenceNumber": "56",
+      "referenceNumber": "57",
       "name": "Yahoo! Public License v1.1",
       "licenseId": "YPL-1.1",
       "seeAlso": [
@@ -4515,7 +4527,7 @@
       "reference": "./ZPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ZPL-1.1.json",
-      "referenceNumber": "352",
+      "referenceNumber": "353",
       "name": "Zope Public License 1.1",
       "licenseId": "ZPL-1.1",
       "seeAlso": [
@@ -4528,7 +4540,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ZPL-2.0.json",
-      "referenceNumber": "76",
+      "referenceNumber": "77",
       "name": "Zope Public License 2.0",
       "licenseId": "ZPL-2.0",
       "seeAlso": [
@@ -4542,7 +4554,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ZPL-2.1.json",
-      "referenceNumber": "340",
+      "referenceNumber": "341",
       "name": "Zope Public License 2.1",
       "licenseId": "ZPL-2.1",
       "seeAlso": [
@@ -4554,7 +4566,7 @@
       "reference": "./Zed.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Zed.json",
-      "referenceNumber": "245",
+      "referenceNumber": "246",
       "name": "Zed License",
       "licenseId": "Zed",
       "seeAlso": [
@@ -4567,7 +4579,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Zend-2.0.json",
-      "referenceNumber": "195",
+      "referenceNumber": "196",
       "name": "Zend License v2.0",
       "licenseId": "Zend-2.0",
       "seeAlso": [
@@ -4580,7 +4592,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Zimbra-1.3.json",
-      "referenceNumber": "39",
+      "referenceNumber": "40",
       "name": "Zimbra Public License v1.3",
       "licenseId": "Zimbra-1.3",
       "seeAlso": [
@@ -4592,7 +4604,7 @@
       "reference": "./Zimbra-1.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Zimbra-1.4.json",
-      "referenceNumber": "235",
+      "referenceNumber": "236",
       "name": "Zimbra Public License v1.4",
       "licenseId": "Zimbra-1.4",
       "seeAlso": [
@@ -4605,7 +4617,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Zlib.json",
-      "referenceNumber": "316",
+      "referenceNumber": "317",
       "name": "zlib License",
       "licenseId": "Zlib",
       "seeAlso": [
@@ -4618,7 +4630,7 @@
       "reference": "./bzip2-1.0.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/bzip2-1.0.5.json",
-      "referenceNumber": "197",
+      "referenceNumber": "198",
       "name": "bzip2 and libbzip2 License v1.0.5",
       "licenseId": "bzip2-1.0.5",
       "seeAlso": [
@@ -4630,7 +4642,7 @@
       "reference": "./bzip2-1.0.6.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/bzip2-1.0.6.json",
-      "referenceNumber": "299",
+      "referenceNumber": "300",
       "name": "bzip2 and libbzip2 License v1.0.6",
       "licenseId": "bzip2-1.0.6",
       "seeAlso": [
@@ -4642,7 +4654,7 @@
       "reference": "./copyleft-next-0.3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/copyleft-next-0.3.0.json",
-      "referenceNumber": "173",
+      "referenceNumber": "174",
       "name": "copyleft-next 0.3.0",
       "licenseId": "copyleft-next-0.3.0",
       "seeAlso": [
@@ -4654,7 +4666,7 @@
       "reference": "./copyleft-next-0.3.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/copyleft-next-0.3.1.json",
-      "referenceNumber": "342",
+      "referenceNumber": "343",
       "name": "copyleft-next 0.3.1",
       "licenseId": "copyleft-next-0.3.1",
       "seeAlso": [
@@ -4666,7 +4678,7 @@
       "reference": "./curl.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/curl.json",
-      "referenceNumber": "257",
+      "referenceNumber": "258",
       "name": "curl License",
       "licenseId": "curl",
       "seeAlso": [
@@ -4678,7 +4690,7 @@
       "reference": "./diffmark.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/diffmark.json",
-      "referenceNumber": "360",
+      "referenceNumber": "361",
       "name": "diffmark license",
       "licenseId": "diffmark",
       "seeAlso": [
@@ -4690,7 +4702,7 @@
       "reference": "./dvipdfm.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/dvipdfm.json",
-      "referenceNumber": "140",
+      "referenceNumber": "141",
       "name": "dvipdfm License",
       "licenseId": "dvipdfm",
       "seeAlso": [
@@ -4703,7 +4715,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/eCos-2.0.json",
-      "referenceNumber": "325",
+      "referenceNumber": "326",
       "name": "eCos license version 2.0",
       "licenseId": "eCos-2.0",
       "seeAlso": [
@@ -4715,7 +4727,7 @@
       "reference": "./eGenix.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/eGenix.json",
-      "referenceNumber": "201",
+      "referenceNumber": "202",
       "name": "eGenix.com Public License 1.1.0",
       "licenseId": "eGenix",
       "seeAlso": [
@@ -4728,7 +4740,7 @@
       "reference": "./gSOAP-1.3b.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/gSOAP-1.3b.json",
-      "referenceNumber": "341",
+      "referenceNumber": "342",
       "name": "gSOAP Public License v1.3b",
       "licenseId": "gSOAP-1.3b",
       "seeAlso": [
@@ -4754,7 +4766,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/iMatix.json",
-      "referenceNumber": "337",
+      "referenceNumber": "338",
       "name": "iMatix Standard Function Library Agreement",
       "licenseId": "iMatix",
       "seeAlso": [
@@ -4766,7 +4778,7 @@
       "reference": "./libpng-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/libpng-2.0.json",
-      "referenceNumber": "74",
+      "referenceNumber": "75",
       "name": "PNG Reference Library version 2",
       "licenseId": "libpng-2.0",
       "seeAlso": [
@@ -4778,7 +4790,7 @@
       "reference": "./libtiff.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/libtiff.json",
-      "referenceNumber": "217",
+      "referenceNumber": "218",
       "name": "libtiff License",
       "licenseId": "libtiff",
       "seeAlso": [
@@ -4790,7 +4802,7 @@
       "reference": "./mpich2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/mpich2.json",
-      "referenceNumber": "314",
+      "referenceNumber": "315",
       "name": "mpich2 License",
       "licenseId": "mpich2",
       "seeAlso": [
@@ -4802,7 +4814,7 @@
       "reference": "./psfrag.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/psfrag.json",
-      "referenceNumber": "242",
+      "referenceNumber": "243",
       "name": "psfrag License",
       "licenseId": "psfrag",
       "seeAlso": [
@@ -4814,7 +4826,7 @@
       "reference": "./psutils.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/psutils.json",
-      "referenceNumber": "123",
+      "referenceNumber": "124",
       "name": "psutils License",
       "licenseId": "psutils",
       "seeAlso": [
@@ -4826,7 +4838,7 @@
       "reference": "./wxWindows.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/wxWindows.json",
-      "referenceNumber": "84",
+      "referenceNumber": "85",
       "name": "wxWindows Library License",
       "licenseId": "wxWindows",
       "seeAlso": [
@@ -4839,7 +4851,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/xinetd.json",
-      "referenceNumber": "143",
+      "referenceNumber": "144",
       "name": "xinetd License",
       "licenseId": "xinetd",
       "seeAlso": [
@@ -4851,7 +4863,7 @@
       "reference": "./xpp.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/xpp.json",
-      "referenceNumber": "272",
+      "referenceNumber": "273",
       "name": "XPP License",
       "licenseId": "xpp",
       "seeAlso": [
@@ -4863,7 +4875,7 @@
       "reference": "./zlib-acknowledgement.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/zlib-acknowledgement.json",
-      "referenceNumber": "317",
+      "referenceNumber": "318",
       "name": "zlib/libpng License with Acknowledgement",
       "licenseId": "zlib-acknowledgement",
       "seeAlso": [
@@ -4872,5 +4884,5 @@
       "isOsiApproved": false
     }
   ],
-  "releaseDate": "2019-03-27"
+  "releaseDate": "2019-05-02"
 }

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = py27, py36, flake8
+envlist = py27, py36, py37, flake8
 
 [travis]
 python =
+    3.7: py37
     3.6: py36
     2.7: py27
 


### PR DESCRIPTION
##### SUMMARY
Updates for 0.5.0 release

0.5.0 (2019-04-15)
------------------

* WARNING: Mazer now requires a Ansible Galaxy server that provides the 'v2' style REST API.
  At time of release, that includes galaxy-dev.ansible.com and galaxy-qa.ansible.com
* WARNING: Support for directly installing 'traditional' style roles from Ansible Galaxy
  is no longer supported. ie, 'mazer install geerlingguy.ntp' will no longer work.
  However, roles can still be installed if they are included in a collection
* WARNING: The config file items and cli options for specifying install paths
           have changed and may break existing configs and scripts.
* The cli option '--content-root' is now '--collections-path'
* The short cli option '-C' is now shorthand for '--collections-path' instead
  of '--content-root'
* The config item 'content_root' has been replaced with 'collections_path'
* The config item 'global_content_root' has been replaced with 'global_collections_path'
* The new 'collections_path' value no longer needs to end with 'ansible_collections'
* The new 'global_collections_path' value no longer needs to end with 'ansible_collections'
* The new 'collections_path' defaults to '~/.ansible/collections'.
  Note that this replaces the previous 'content_root' config item that
  defaulted to '~/.ansible/collections/ansible_collections'
* The new 'global_collections_path' defaults to '/usr/share/ansible/collections'.
  Note that this replaces the previous 'global_content_root' config item that
  defaulted to '/usr/share/ansible/collections/ansible_collections'
* 'mazer install' with default 'collections_path' ('~/.ansible/collections') will
  still install to '~/.ansible/collections/ansible_collections', but install
  will add the require trailing 'ansible_collections' automatically.
* 'mazer install --global' with default 'globale_collections_path'
  ('/usr/share/ansible/collections') will still install to
  '/usr/share/ansible/collections/ansible_collections', but
  'install --global' will add the require trailing
  'ansible_collections' automatically.
* The REST API client now uses 'requests' python module instead of the 'url' module bundle from ansible.
* Add cli '--config' option to specify a path to an alternative config file.
* Add support for 'MAZER_HOME' environment variable. MAZER_HOME defaults to ~/.ansible and
  specifies where mazer looks for it's config (mazer.yml and mazer-logging.yml)
* `216 Use Galaxy REST API v2 <https://github.com/ansible/mazer/issues/216>`_.
* `239 Rename content-root to collections-path to be consistent with ansible <https://github.com/ansible/mazer/issues/239>`_.
* `228 For envs w/no LANG/locale/text encoding, assume utf8 <https://github.com/ansible/mazer/issues/228>`_.
* `236 Partial fix for scm_url installs <https://github.com/ansible/mazer/issues/236>`_.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


