### PR TITLE
Show warning if users install deprecated collections (Fix #245)

### DIFF
--- a/ansible_galaxy/actions/install.py
+++ b/ansible_galaxy/actions/install.py
@@ -385,6 +385,10 @@ def install_repository(galaxy_context,
     repository_spec_to_install = found_repository_spec
     log.debug('About to download repository requested by %s: %s', requirement_spec_to_install, repository_spec_to_install)
 
+    if find_results['custom'].get('collection_is_deprecated', False):
+        display_callback("The collection '%s' is deprecated." % (found_repository_spec.label),
+                         level='warning')
+
     # FETCH state
     try:
         fetch_results = install.fetch(fetcher,

--- a/ansible_galaxy/fetch/galaxy_url.py
+++ b/ansible_galaxy/fetch/galaxy_url.py
@@ -90,6 +90,8 @@ class GalaxyUrlFetch(base.BaseFetch):
 
         versions_list_url = collection_detail_data.get('versions_url', None)
 
+        collection_is_deprecated = collection_detail_data.get('deprecated', False)
+
         # TODO: if versions ends up with a 'related' we could follow it instead of specific
         #       get_collection_version_list()
         # example results
@@ -157,7 +159,8 @@ class GalaxyUrlFetch(base.BaseFetch):
         results = {'content': {'galaxy_namespace': namespace,
                                'repo_name': collection_name,
                                'version': best_version},
-                   'custom': {'download_url': download_url},
+                   'custom': {'download_url': download_url,
+                              'collection_is_deprecated': collection_is_deprecated},
                    }
 
         return results


### PR DESCRIPTION

##### SUMMARY
Show warning if users install deprecated collections

Display a warning to stderr if user is installing
a collection from galaxy and galaxy considers it
deprecated.

Add 'collection_is_deprecated' to GalaxyFetch.find()
results.

Fixes: #245


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.5.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 5.0.5-200.fc29.x86_64, #1 SMP Wed Mar 27 20:58:04 UTC 2019, x86_64
executable_location = /home/adrian/venvs/mazer_0.4.0_py36/bin/mazer
python_version = 3.6.8 (default, Jan 27 2019, 09:00:23) [GCC 8.2.1 20181215 (Red Hat 8.2.1-6)]
python_executable = /home/adrian/venvs/mazer_0.4.0_py36/bin/python

```


