### PR TITLE
Requirement spec cmp error 255

### DIFF
--- a/ansible_galaxy/models/requirement_spec.py
+++ b/ansible_galaxy/models/requirement_spec.py
@@ -19,7 +19,8 @@ class RequirementSpec(object):
     namespace = attr.ib()
     name = attr.ib()
     version_spec = attr.ib(type=semantic_version.Spec, default=semantic_version.Spec('*'),
-                           converter=convert_string_to_version_spec)
+                           converter=convert_string_to_version_spec,
+                           cmp=False)
 
     # This is for supporting 'v1.0.0' etc. In that case the version_spec is '==1.0.0' and
     # version_aka is 'v1.0.0'. Need to track it because it is used to build github download

--- a/tests/ansible_galaxy/models/test_requirement_model.py
+++ b/tests/ansible_galaxy/models/test_requirement_model.py
@@ -48,3 +48,34 @@ def test_repository_spec_requirement_spec_cmp():
 
     assert req.repository_spec == repo_spec1
     assert req.requirement_spec == req_spec
+
+
+def test_repository_spec_requirement_spec_sortable():
+    repo_spec1 = repository_spec.RepositorySpec(namespace='ns',
+                                                name='n',
+                                                version='3.4.5')
+
+    req_spec = requirement_spec.RequirementSpec(namespace='ns',
+                                                name='n',
+                                                version_spec='==3.4.5')
+
+    req_spec2 = requirement_spec.RequirementSpec(namespace='ns',
+                                                 name='n',
+                                                 version_spec='*')
+
+    req1 = requirement.Requirement(repository_spec=repo_spec1, requirement_spec=req_spec,
+                                   op=requirement.RequirementOps.EQ)
+
+    req2 = requirement.Requirement(repository_spec=repo_spec1, requirement_spec=req_spec2,
+                                   op=requirement.RequirementOps.EQ)
+
+    log.debug('req1: %s', req1)
+    log.debug('req2: %s', req2)
+    log.debug('repo_spec1: %s', repo_spec1)
+    log.debug('req_spec: %s', req_spec)
+
+    reqs = [req1, req2]
+
+    res = sorted(reqs)
+
+    log.debug('res: %s', res)


### PR DESCRIPTION
##### SUMMARY
Make version_spec not part of ReqSpec attr cmp

semantic_version.Spec() does not have comparison methods
(ie, `<` or `__lt__`) so it should not be used for when
comparing two RequirementSpec objects.

So set the version_spec attr to cmp=False so RequirementSpec
doesn't use it for compare (and so cmps of Requirement that
then compare RequirementSpec dont use version_spec for cmp)

Add unit test for sorting/cmp on Requirement

Fixes: #255 


##### ISSUE TYPE
 - Bugfix Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.5.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 5.0.5-200.fc29.x86_64, #1 SMP Wed Mar 27 20:58:04 UTC 2019, x86_64
executable_location = /home/adrian/venvs/mazer_0.4.0_py36/bin/mazer
python_version = 3.6.8 (default, Jan 27 2019, 09:00:23) [GCC 8.2.1 20181215 (Red Hat 8.2.1-6)]
python_executable = /home/adrian/venvs/mazer_0.4.0_py36/bin/python

```

