### PR TITLE
Improve `install` message formatting (rel to #255)

### DIFF
--- a/ansible_galaxy/install.py
+++ b/ansible_galaxy/install.py
@@ -155,10 +155,6 @@ def install(galaxy_context,
 
     just_installed_spec_and_results.append((repository_spec, res))
 
-    if display_callback:
-        display_callback("- The repository %s was successfully installed to %s" % (repository_spec.label,
-                                                                                   galaxy_context.collections_path))
-
     # rm any temp files created when getting the content archive
     # TODO: use some sort of callback?
     fetcher.cleanup()

--- a/ansible_galaxy/models/repository_spec.py
+++ b/ansible_galaxy/models/repository_spec.py
@@ -60,4 +60,4 @@ class RepositorySpec(object):
         return instance
 
     def __str__(self):
-        return '{label}-{version}'.format(label=self.label, version=self.version)
+        return '{label},{version}'.format(label=self.label, version=self.version)

--- a/ansible_galaxy/models/requirement_spec.py
+++ b/ansible_galaxy/models/requirement_spec.py
@@ -35,7 +35,7 @@ class RequirementSpec(object):
 
     @property
     def label(self):
-        return '%s.%s (version_spec: %s)' % (self.namespace, self.name, str(self.version_spec))
+        return '%s.%s,%s' % (self.namespace, self.name, str(self.version_spec))
 
     @classmethod
     def from_dict(cls, data):

--- a/ansible_galaxy/repository_archive.py
+++ b/ansible_galaxy/repository_archive.py
@@ -31,7 +31,7 @@ def extract(repository_spec,
         # TODO: better error
         raise exceptions.GalaxyError('While installing a collection , no namespace was found. Try providing one with --namespace')
 
-    log.debug('About to extract "%s" to collections_path %s', repository_spec.label, collections_path)
+    log.debug('About to extract "%s" to collections_path %s', repository_spec, collections_path)
 
     tar_members = tar_file.members
 

--- a/tests/ansible_galaxy/fetch/test_galaxy_url.py
+++ b/tests/ansible_galaxy/fetch/test_galaxy_url.py
@@ -111,8 +111,9 @@ def test_galaxy_url_fetch_find_no_repo_data(galaxy_url_fetch, galaxy_context, re
 
     # galaxy_url_fetch = galaxy_url.GalaxyUrlFetch(requirement_spec=req_spec, galaxy_context=context)
     # - sorry, some_namespace.some_name (version_spec: ==9.3.245) was not found on http://galaxy.invalid/.
+    # - sorry, some_namespace.some_name,==9.3.245 was not found on http://example.invalid.
     with pytest.raises(exceptions.GalaxyClientError,
-                       match='- sorry, some_namespace.some_name.*version_spec.*was not found on http://example.invalid') as exc_info:
+                       match='- sorry, some_namespace.some_name,.* was not found on http://example.invalid') as exc_info:
         galaxy_url_fetch.find()
 
     log.debug('exc_info:%s', exc_info)

--- a/tests/ansible_galaxy/test_repository_version.py
+++ b/tests/ansible_galaxy/test_repository_version.py
@@ -19,7 +19,7 @@ def test_get_content_version_none():
                      'name': 'some_name',
                      'version': None}
     req_spec = RequirementSpec.from_dict(req_spec_data)
-    with pytest.raises(exceptions.GalaxyError, match="The list of available versions for some_namespace.some_name.*version_spec.*is empty"):
+    with pytest.raises(exceptions.GalaxyError, match="The list of available versions for some_namespace.some_name,.* is empty"):
         repository_version.get_repository_version({}, req_spec, [])
 
 


### PR DESCRIPTION
##### SUMMARY
Related to #255, the output shown by 'install' subcommand obscure what
was going on. Mostly by not including version info in places where the output
references particular versions.

In general, the install output is hard to read.

For an example based on #255:

Before
```
(mazer040test) [newswoop:F29:collection_inspect (master % u=)]$ rm -rf /tmp/coltest2/* && mazer install --collections-path=/tmp/coltest2 --server http://galaxy-qa.ansible.com orionuser1.collection_dep_a_bvsivsmc
Installing orionuser1.collection_dep_a_bvsivsmc (version_spec: *)
- The repository orionuser1.collection_dep_a_bvsivsmc was successfully installed to /tmp/coltest2
Installing requirement orionuser1.collection_dep_a_dpvsiwdd (version_spec: ==1.0.0) (required by orionuser1.collection_dep_a_bvsivsmc)
Installing requirement orionuser1.collection_dep_a_kmcnjmib (version_spec: ==1.0.0) (required by orionuser1.collection_dep_a_bvsivsmc)
- The repository orionuser1.collection_dep_a_dpvsiwdd was successfully installed to /tmp/coltest2
- The repository orionuser1.collection_dep_a_kmcnjmib was successfully installed to /tmp/coltest2
Installing requirement orionuser1.collection_dep_a_vstghmmb (version_spec: ==2.0.0) (required by orionuser1.collection_dep_a_dpvsiwdd)
Installing requirement orionuser1.collection_dep_a_vstghmmb (version_spec: ==1.0.0) (required by orionuser1.collection_dep_a_kmcnjmib)
- The repository orionuser1.collection_dep_a_vstghmmb was successfully installed to /tmp/coltest2
WARNING| - orionuser1.collection_dep_a_vstghmmb was NOT installed successfully: The Galaxy content /tmp/coltest2/ansible_collections/orionuser1/collection_dep_a_vstghmmb/README.md appears to already exist. 
The Galaxy content /tmp/coltest2/ansible_collections/orionuser1/collection_dep_a_vstghmmb/README.md appears to already exist.:
- you can use --ignore-errors to skip failed collections and finish processing the list.
```

After
```
(mazer040test) [newswoop:F29:collection_inspect (master % u=)]$ rm -rf /tmp/coltest2/* && mazer install --collections-path=/tmp/coltest2 --server http://galaxy-qa.ansible.com orionuser1.collection_dep_a_bvsivsmc
Installing:
  orionuser1.collection_dep_a_bvsivsmc (version_spec: *)
Installed:
  orionuser1.collection_dep_a_bvsivsmc,1.0.0 to /tmp/coltest2/ansible_collections/orionuser1/collection_dep_a_bvsivsmc
Installing:
  orionuser1.collection_dep_a_dpvsiwdd (version_spec: ==1.0.0) (required by orionuser1.collection_dep_a_bvsivsmc,1.0.0)
  orionuser1.collection_dep_a_kmcnjmib (version_spec: ==1.0.0) (required by orionuser1.collection_dep_a_bvsivsmc,1.0.0)
Installed:
  orionuser1.collection_dep_a_dpvsiwdd,1.0.0 to /tmp/coltest2/ansible_collections/orionuser1/collection_dep_a_dpvsiwdd
  orionuser1.collection_dep_a_kmcnjmib,1.0.0 to /tmp/coltest2/ansible_collections/orionuser1/collection_dep_a_kmcnjmib
Installing:
  orionuser1.collection_dep_a_vstghmmb (version_spec: ==2.0.0) (required by orionuser1.collection_dep_a_dpvsiwdd,1.0.0)
  orionuser1.collection_dep_a_vstghmmb (version_spec: ==1.0.0) (required by orionuser1.collection_dep_a_kmcnjmib,1.0.0)
WARNING| - orionuser1.collection_dep_a_vstghmmb,1.0.0 was NOT installed successfully: The Galaxy content /tmp/coltest2/ansible_collections/orionuser1/collection_dep_a_vstghmmb/README.md appears to already exist. 
The Galaxy content /tmp/coltest2/ansible_collections/orionuser1/collection_dep_a_vstghmmb/README.md appears to already exist.:
- you can use --ignore-errors to skip failed collections and finish processing the list.

```

And for an example without errors:

Before
```
(mazer040test) [newswoop:F29:collection_inspect (master % u=)]$ rm -rf /tmp/coltest2/* && mazer install --collections-path=/tmp/coltest2 --server http://galaxy-qa.ansible.com alikins.collection_reqs_test
Installing alikins.collection_reqs_test (version_spec: *)
- The repository alikins.collection_reqs_test was successfully installed to /tmp/coltest2
Installing requirement alikins.collection_inspect (version_spec: *) (required by alikins.collection_reqs_test)
Installing requirement alikins.collection_ntp (version_spec: >=0.1.6) (required by alikins.collection_reqs_test)
- The repository alikins.collection_inspect was successfully installed to /tmp/coltest2
- The repository alikins.collection_ntp was successfully installed to /tmp/coltest2
```

After
```
(mazer040test) [newswoop:F29:collection_inspect (master % u=)]$ rm -rf /tmp/coltest2/* && mazer install --collections-path=/tmp/coltest2 --server http://galaxy-qa.ansible.com alikins.collection_reqs_test
Installing:
  alikins.collection_reqs_test (version_spec: *)
Installed:
  alikins.collection_reqs_test,2.1113.57 to /tmp/coltest2/ansible_collections/alikins/collection_reqs_test
Installing:
  alikins.collection_inspect (version_spec: *) (required by alikins.collection_reqs_test,2.1113.57)
  alikins.collection_ntp (version_spec: >=0.1.6) (required by alikins.collection_reqs_test,2.1113.57)
Installed:
  alikins.collection_inspect,0.0.42 to /tmp/coltest2/ansible_collections/alikins/collection_inspect
  alikins.collection_ntp,0.1.181 to /tmp/coltest2/ansible_collections/alikins/collection_ntp
```
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.5.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 5.0.5-200.fc29.x86_64, #1 SMP Wed Mar 27 20:58:04 UTC 2019, x86_64
executable_location = /home/adrian/venvs/mazer040test/bin/mazer
python_version = 3.6.8 (default, Jan 27 2019, 09:00:23) [GCC 8.2.1 20181215 (Red Hat 8.2.1-6)]
python_executable = /home/adrian/venvs/mazer040test/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

