### PR TITLE
Fix 'mazer install /path/to/ns.n.1.2.3.tar.gz'

### DIFF
--- a/ansible_galaxy/models/requirement_spec.py
+++ b/ansible_galaxy/models/requirement_spec.py
@@ -52,7 +52,7 @@ class RequirementSpec(object):
                 if version_needs_aka(str(ver)):
                     data['version'] = normalize_version_string(ver)
                     data['version_aka'] = ver
-                version_spec_str = data['version']
+                version_spec_str = str(data['version'])
             else:
                 # No version_spec, and version is None, that means match anything
                 version_spec_str = '*'


### PR DESCRIPTION
##### SUMMARY
Fix 'mazer install /path/to/ns.n.1.2.3.tar.gz'

For installing an artifact, the version comes out of the
parsed manifest collection_info, and is a semantic_version.Version

version_spec_str is... a str, so str() the version when we are
building a version_spec_str from an actual semantic_version.Version


<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request
 - Docs Pull Request


##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

