### PR TITLE
Add user-agent and request-id headers to artifact download requests

### DIFF
--- a/ansible_galaxy/download.py
+++ b/ansible_galaxy/download.py
@@ -1,9 +1,11 @@
 import logging
 import tempfile
+import uuid
 
 import requests
 
 from ansible_galaxy import exceptions
+from ansible_galaxy import user_agent
 
 log = logging.getLogger(__name__)
 
@@ -18,9 +20,16 @@ def fetch_url(archive_url, validate_certs=True):
     #       content downloads could support any thing the rest code does
     #       (ie, any TLS cert setup, proxy config, auth options, etc)
     # WHEN: if we change the underlying http client impl at least
+
+    request_headers = {}
+    request_id = uuid.uuid4().hex
+    request_headers['X-Request-ID'] = request_id
+    request_headers['User-Agent'] = user_agent.user_agent()
+
     try:
         log.debug('Downloading archive_url: %s', archive_url)
-        resp = requests.get(archive_url, verify=validate_certs, stream=True)
+        resp = requests.get(archive_url, verify=validate_certs,
+                            headers=request_headers, stream=True)
 
         temp_file = tempfile.NamedTemporaryFile(delete=False,
                                                 prefix='tmp-ansible-galaxy-content-archive-',

--- a/ansible_galaxy/rest_api.py
+++ b/ansible_galaxy/rest_api.py
@@ -23,31 +23,19 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import logging
-import sys
 import uuid
 
 import requests
 
 from six.moves.urllib.parse import quote as urlquote
 
-from ansible_galaxy import __version__ as mazer_version
 from ansible_galaxy import exceptions
+from ansible_galaxy import user_agent
 
 log = logging.getLogger(__name__)
 http_log = logging.getLogger('%s.(http).(general)' % __name__)
 request_log = logging.getLogger('%s.(http).(request)' % __name__)
 response_log = logging.getLogger('%s.(http).(response)' % __name__)
-
-USER_AGENT_FORMAT = 'Mazer/{version} ({platform}; python:{py_major}.{py_minor}.{py_micro}) ansible_galaxy/{version}'
-
-
-def user_agent():
-    user_agent_data = {'version': mazer_version,
-                       'platform': sys.platform,
-                       'py_major': sys.version_info.major,
-                       'py_minor': sys.version_info.minor,
-                       'py_micro': sys.version_info.micro}
-    return USER_AGENT_FORMAT.format(**user_agent_data)
 
 
 def response_slug(response):
@@ -88,7 +76,7 @@ class RestClient(object):
 
         log.debug('http_context: %s', http_context)
 
-        self.user_agent = user_agent()
+        self.user_agent = user_agent.user_agent()
 
         log.debug('User Agent: %s', self.user_agent)
 

--- a/ansible_galaxy/user_agent.py
+++ b/ansible_galaxy/user_agent.py
@@ -1,0 +1,16 @@
+import sys
+
+from ansible_galaxy import __version__ as mazer_version
+
+USER_AGENT_FORMAT = 'Mazer/{version} ({platform}; python:{py_major}.{py_minor}.{py_micro}) ansible_galaxy/{version}'
+
+
+def user_agent():
+    '''Return a user-agent including mazer version, platform, and python version'''
+
+    user_agent_data = {'version': mazer_version,
+                       'platform': sys.platform,
+                       'py_major': sys.version_info.major,
+                       'py_minor': sys.version_info.minor,
+                       'py_micro': sys.version_info.micro}
+    return USER_AGENT_FORMAT.format(**user_agent_data)

--- a/tests/ansible_galaxy/test_rest_api.py
+++ b/tests/ansible_galaxy/test_rest_api.py
@@ -1,13 +1,11 @@
 import io
 import logging
-import sys
 
 import pytest
 
 import requests
 from six import text_type
 
-import ansible_galaxy
 from ansible_galaxy import exceptions
 from ansible_galaxy import multipart_form
 from ansible_galaxy.models.context import GalaxyContext
@@ -232,7 +230,7 @@ def test_galaxy_api_publish_file_conflict_409(galaxy_api_mocked, requests_mock, 
                        status_code=409,
                        json=err_409_conflict_json)
 
-    with pytest.raises(ansible_galaxy.exceptions.GalaxyPublishError) as exc_info:
+    with pytest.raises(exceptions.GalaxyPublishError) as exc_info:
         galaxy_api_mocked.publish_file(form=file_upload_form, publish_api_key=None)
 
     log.debug('exc_info:%s', exc_info)
@@ -248,7 +246,7 @@ def test_galaxy_api_publish_file_unauthorized_401(galaxy_api_mocked, requests_mo
                        json=err_401_unauthorized_json)
 
     bad_publish_api_key = '1f107deadbeefcafee0863829264d5211a'
-    with pytest.raises(ansible_galaxy.exceptions.GalaxyPublishError) as exc_info:
+    with pytest.raises(exceptions.GalaxyPublishError) as exc_info:
         galaxy_api_mocked.publish_file(form=file_upload_form, publish_api_key=bad_publish_api_key)
 
     log.debug('exc_info:%s', exc_info)
@@ -265,7 +263,7 @@ def test_galaxy_api_publish_file_request_error(galaxy_api_mocked, requests_mock,
 
     publish_api_key = '1f107befb89e0863829264d5241111a'
 
-    with pytest.raises(ansible_galaxy.exceptions.GalaxyClientAPIConnectionError) as exc_info:
+    with pytest.raises(exceptions.GalaxyClientAPIConnectionError) as exc_info:
         galaxy_api_mocked.publish_file(form=file_upload_form, publish_api_key=publish_api_key)
 
     log.debug('exc_info:%s', exc_info)
@@ -738,11 +736,3 @@ def test_galaxy_api_get_collection_detail_SSLError(mocker, galaxy_api, requests_
         galaxy_api.get_collection_detail('some-test-namespace', 'some-test-name')
 
     log.debug('exc_info: %s', exc_info)
-
-
-def test_user_agent():
-    res = rest_api.user_agent()
-    assert res.startswith('Mazer/%s' % ansible_galaxy.__version__)
-    assert sys.platform in res
-    assert 'python:' in res
-    assert 'ansible_galaxy' in res

--- a/tests/ansible_galaxy/test_user_agent.py
+++ b/tests/ansible_galaxy/test_user_agent.py
@@ -1,0 +1,15 @@
+import logging
+import sys
+
+import ansible_galaxy
+from ansible_galaxy import user_agent
+
+log = logging.getLogger(__name__)
+
+
+def test_user_agent():
+    res = user_agent.user_agent()
+    assert res.startswith('Mazer/%s' % ansible_galaxy.__version__)
+    assert sys.platform in res
+    assert 'python:' in res
+    assert 'ansible_galaxy' in res


### PR DESCRIPTION
##### SUMMARY
Add useragent and req id headers to download

download.fetch_url() wasn't setting User-Agent
or request_id headers on it's requests. And since
it also doesn't use/reuse the request.Session from
rest_api.RestClient(), it wasn't sending those headers
for the artifact downloads.

So add a request_id and the user_agent from new
user_agent module to requests.

This is needed to finish https://github.com/ansible/galaxy/pull/1789 which
is impl of https://github.com/ansible/galaxy/issues/1769

##### ISSUE TYPE
 - Bugfix Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.5.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 5.0.5-200.fc29.x86_64, #1 SMP Wed Mar 27 20:58:04 UTC 2019, x86_64
executable_location = /home/adrian/venvs/mazer_0.4.0_py36/bin/mazer
python_version = 3.6.8 (default, Jan 27 2019, 09:00:23) [GCC 8.2.1 20181215 (Red Hat 8.2.1-6)]
python_executable = /home/adrian/venvs/mazer_0.4.0_py36/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

