### PR TITLE
Add 'api_key' config item (fixes #249)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,16 @@ server:
   #
   ignore_certs: false
 
+  # This is the API key used when the Galaxy API needs to authenticate
+  # a request. For example, for the POST request made when using the
+  # 'publish' sub command to upload collection artifacts.
+  # 'api_key' here is equilivent to the cli '--api-key'
+  #
+  # The default value is unset or None.
+  #
+  # The API key can be found at https://galaxy.ansible.com/me/preferences
+  api_key: da39a3ee5e6b4b0d3255bfef95601890afd80709
+
 # When installing content like ansible collection globally (using the '-g/--global' flag),
 # mazer will install into sub directories of this path.
 #

--- a/ansible_galaxy/actions/publish.py
+++ b/ansible_galaxy/actions/publish.py
@@ -15,7 +15,6 @@ log = logging.getLogger(__name__)
 
 def _publish(galaxy_context,
              archive_path,
-             publish_api_key=None,
              display_callback=None):
 
     results = {
@@ -24,6 +23,8 @@ def _publish(galaxy_context,
     }
 
     api = GalaxyAPI(galaxy_context)
+
+    publish_api_key = galaxy_context.server.get('api_key', None)
 
     data = {
         'sha256': chksums.sha256sum_from_path(archive_path),
@@ -53,11 +54,10 @@ def _publish(galaxy_context,
     return results
 
 
-def publish(galaxy_context, archive_path, publish_api_key, display_callback):
+def publish(galaxy_context, archive_path, display_callback):
 
     results = _publish(galaxy_context,
                        archive_path,
-                       publish_api_key=publish_api_key,
                        display_callback=display_callback)
 
     log.debug('cli publish action results: %s', results)

--- a/ansible_galaxy/config/defaults.py
+++ b/ansible_galaxy/config/defaults.py
@@ -21,7 +21,8 @@ def get_config_path():
 DEFAULTS = [
     ('server',
      {'url': 'https://galaxy.ansible.com',
-      'ignore_certs': False}
+      'ignore_certs': False,
+      'api_key': None}
      ),
 
     # In order of priority

--- a/ansible_galaxy/models/context.py
+++ b/ansible_galaxy/models/context.py
@@ -33,7 +33,8 @@ class GalaxyContext(object):
 
     def __init__(self, collections_path=None, server=None):
         self.server = server or {'url': None,
-                                 'ignore_certs': False}
+                                 'ignore_certs': False,
+                                 'api_key': None}
         self.collections_path = collections_path
 
     def __repr__(self):

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -186,8 +186,8 @@ class GalaxyCLI(cli.CLI):
             # use ignore certs from options if available, but fallback to configured ignore_certs
             server['ignore_certs'] = options.ignore_certs
 
-        if getattr(options, 'api_key', None):
-            server['api_key'] = options.api_key
+        if getattr(options, 'publish_api_key', None):
+            server['api_key'] = options.publish_api_key
 
         log.debug('server[api_key]: %s', server.get('api_key'))
         galaxy_context = GalaxyContext(server=server, collections_path=collections_path)
@@ -302,7 +302,6 @@ class GalaxyCLI(cli.CLI):
 
         return publish.publish(galaxy_context,
                                self.args[0],
-                               self.options.publish_api_key,
                                display_callback=self.display)
 
     def execute_remove(self):

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -177,7 +177,6 @@ class GalaxyCLI(cli.CLI):
         collections_path = os.path.abspath(os.path.expanduser(raw_collections_path))
 
         server = config.server.copy()
-        log.debug('server1: %s', server)
 
         if getattr(options, 'server_url', None):
             server['url'] = options.server_url
@@ -189,7 +188,6 @@ class GalaxyCLI(cli.CLI):
         if getattr(options, 'publish_api_key', None):
             server['api_key'] = options.publish_api_key
 
-        log.debug('server[api_key]: %s', server.get('api_key'))
         galaxy_context = GalaxyContext(server=server, collections_path=collections_path)
 
         return galaxy_context
@@ -202,7 +200,6 @@ class GalaxyCLI(cli.CLI):
 
         super(GalaxyCLI, self).run()
 
-        log.debug('config file: %s', self.config_file_path)
         self.config = config.load(self.config_file_path)
 
         log.debug('configuration: %s', json.dumps(self.config.as_dict(), indent=None))

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -177,6 +177,7 @@ class GalaxyCLI(cli.CLI):
         collections_path = os.path.abspath(os.path.expanduser(raw_collections_path))
 
         server = config.server.copy()
+        log.debug('server1: %s', server)
 
         if getattr(options, 'server_url', None):
             server['url'] = options.server_url
@@ -185,6 +186,10 @@ class GalaxyCLI(cli.CLI):
             # use ignore certs from options if available, but fallback to configured ignore_certs
             server['ignore_certs'] = options.ignore_certs
 
+        if getattr(options, 'api_key', None):
+            server['api_key'] = options.api_key
+
+        log.debug('server[api_key]: %s', server.get('api_key'))
         galaxy_context = GalaxyContext(server=server, collections_path=collections_path)
 
         return galaxy_context
@@ -197,6 +202,7 @@ class GalaxyCLI(cli.CLI):
 
         super(GalaxyCLI, self).run()
 
+        log.debug('config file: %s', self.config_file_path)
         self.config = config.load(self.config_file_path)
 
         log.debug('configuration: %s', json.dumps(self.config.as_dict(), indent=None))

--- a/tests/ansible_galaxy/actions/test_publish_action.py
+++ b/tests/ansible_galaxy/actions/test_publish_action.py
@@ -1,6 +1,8 @@
 import logging
 import os
 
+import pytest
+
 from ansible_galaxy.actions import publish
 from ansible_galaxy.models.context import GalaxyContext
 
@@ -9,6 +11,13 @@ log = logging.getLogger(__name__)
 
 def display_callback(msg, **kwargs):
     log.debug(msg)
+
+
+@pytest.fixture
+def mock_get_api(requests_mock):
+    requests_mock.get('http://notreal.invalid:8000/api/',
+                      status_code=200,
+                      json={'current_version': 'v1'})
 
 
 def test_publish(galaxy_context, mocker):
@@ -20,36 +29,68 @@ def test_publish(galaxy_context, mocker):
     assert res == 0
 
 
-def test__publish(galaxy_context, mocker):
-    mocker.patch('ansible_galaxy.actions.publish.GalaxyAPI.publish_file',
-                 return_value={"task": "/api/v2/collection-imports/8675309"})
-    res = publish._publish(galaxy_context, "/dev/null", display_callback)
+def test__publish(galaxy_context, mock_get_api, requests_mock):
+    faux_api_key = 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
+    context = GalaxyContext(collections_path=galaxy_context.collections_path,
+                            server={'url': 'http://notreal.invalid:8000',
+                                    'ignore_certs': False,
+                                    'api_key': faux_api_key})
+    log.debug('galaxy_context: %s', context)
+
+    response_body_202 = {"task": "/api/v2/collection-imports/8675309"}
+    post_mock = requests_mock.post('http://notreal.invalid:8000/api/v2/collections/',
+                                   status_code=202,
+                                   json=response_body_202)
+    res = publish._publish(context, "/dev/null", display_callback)
 
     log.debug('res: %s', res)
+
+    assert post_mock.last_request.headers['Authorization'] == 'Token %s' % faux_api_key
+    assert post_mock.last_request.headers['Content-type'].startswith('multipart/form-data;')
+
     assert res['errors'] == []
     assert res['success'] is True
     assert res['response_data']['task'] == "/api/v2/collection-imports/8675309"
 
 
-def test__publish_api_error(galaxy_context, mocker, requests_mock):
+def test__publish_api_key_is_none(galaxy_context, mock_get_api, requests_mock):
     context = GalaxyContext(collections_path=galaxy_context.collections_path,
                             server={'url': 'http://notreal.invalid:8000',
-                                    'ignore_certs': False})
+                                    'ignore_certs': False,
+                                    'api_key': None})
+    log.debug('galaxy_context: %s', context)
+
+    response_body_202 = {}
+    post_mock = requests_mock.post('http://notreal.invalid:8000/api/v2/collections/',
+                                   status_code=202,
+                                   json=response_body_202)
+
+    publish._publish(context, "/dev/null", display_callback)
+
+    assert 'Authorization' not in post_mock.last_request.headers
+
+
+def test__publish_api_error(galaxy_context, mock_get_api, requests_mock):
+    faux_api_key = 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
+    context = GalaxyContext(collections_path=galaxy_context.collections_path,
+                            server={'url': 'http://notreal.invalid:8000',
+                                    'ignore_certs': False,
+                                    'api_key': faux_api_key})
     log.debug('galaxy_context: %s', context)
 
     err_409_conflict_json = {'code': 'conflict.collection_exists', 'message': 'Collection "testing-ansible_testing_content-4.0.4" already exists.'}
-    requests_mock.get('http://notreal.invalid:8000/api/',
-                      status_code=200,
-                      json={'current_version': 'v1'})
-
-    requests_mock.post('http://notreal.invalid:8000/api/v2/collections/',
-                       status_code=409,
-                       reason='Conflict',
-                       json=err_409_conflict_json)
+    post_mock = requests_mock.post('http://notreal.invalid:8000/api/v2/collections/',
+                                   status_code=409,
+                                   reason='Conflict',
+                                   json=err_409_conflict_json)
 
     res = publish._publish(context, "/dev/null", display_callback)
 
     log.debug('res: %s', res)
+
+    assert post_mock.last_request.headers['Authorization'] == 'Token %s' % faux_api_key
+    assert post_mock.last_request.headers['Content-type'].startswith('multipart/form-data;')
+
     assert res['errors'] == ['Error publishing null to http://notreal.invalid:8000/api/v2/collections/ '
                              + '- Collection "testing-ansible_testing_content-4.0.4" already exists.']
     assert res['success'] is False

--- a/tests/ansible_galaxy/actions/test_publish_action.py
+++ b/tests/ansible_galaxy/actions/test_publish_action.py
@@ -12,22 +12,18 @@ def display_callback(msg, **kwargs):
 
 
 def test_publish(galaxy_context, mocker):
-    publish_api_key = "doesnt_matter_not_used"
-
     mocker.patch('ansible_galaxy.actions.publish.GalaxyAPI.publish_file',
                  return_value={"task": "/api/v2/collection-imports/123456789"})
-    res = publish.publish(galaxy_context, "/dev/null", publish_api_key, display_callback)
+    res = publish.publish(galaxy_context, "/dev/null", display_callback)
 
     log.debug('res: %s', res)
     assert res == 0
 
 
 def test__publish(galaxy_context, mocker):
-    publish_api_key = "doesnt_matter_not_used"
-
     mocker.patch('ansible_galaxy.actions.publish.GalaxyAPI.publish_file',
                  return_value={"task": "/api/v2/collection-imports/8675309"})
-    res = publish._publish(galaxy_context, "/dev/null", publish_api_key, display_callback)
+    res = publish._publish(galaxy_context, "/dev/null", display_callback)
 
     log.debug('res: %s', res)
     assert res['errors'] == []
@@ -36,8 +32,6 @@ def test__publish(galaxy_context, mocker):
 
 
 def test__publish_api_error(galaxy_context, mocker, requests_mock):
-    publish_api_key = "doesnt_matter_not_used"
-
     context = GalaxyContext(collections_path=galaxy_context.collections_path,
                             server={'url': 'http://notreal.invalid:8000',
                                     'ignore_certs': False})
@@ -53,7 +47,7 @@ def test__publish_api_error(galaxy_context, mocker, requests_mock):
                        reason='Conflict',
                        json=err_409_conflict_json)
 
-    res = publish._publish(context, "/dev/null", publish_api_key, display_callback)
+    res = publish._publish(context, "/dev/null", display_callback)
 
     log.debug('res: %s', res)
     assert res['errors'] == ['Error publishing null to http://notreal.invalid:8000/api/v2/collections/ '
@@ -70,8 +64,7 @@ def test_publish_api_errors(mocker):
     mock_display_callback = mocker.Mock()
 
     context = None
-    publish_api_key = None
-    res = publish.publish(context, "/dev/null", publish_api_key, mock_display_callback)
+    res = publish.publish(context, "/dev/null", mock_display_callback)
 
     log.debug('res: %s', res)
 

--- a/tests/ansible_galaxy/models/test_context.py
+++ b/tests/ansible_galaxy/models/test_context.py
@@ -47,6 +47,7 @@ def test_context_from_empty_server():
     log.debug('server: %s', galaxy_context.server)
     assert galaxy_context.server['url'] is None
     assert galaxy_context.server['ignore_certs'] is False
+    assert galaxy_context.server['api_key'] is None
 
 
 def test_context_server_none_collections_path_none():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,9 @@ def inject_mazer_home(monkeypatch):
 def galaxy_context(tmpdir):
     # FIXME: mock
     server = {'url': 'http://localhost:8000',
-              'ignore_certs': False}
+              'ignore_certs': False,
+              'api_key': None,
+              }
     collections_path = tmpdir.mkdir('collections')
 
     from ansible_galaxy.models.context import GalaxyContext


### PR DESCRIPTION
##### SUMMARY
Add 'api_key' to default config server dict

Fixes: #249 

example mazer.yml
``` yaml
server:
  ignore_certs: false
  url: https://galaxy-qa.ansible.com
  api_key: da39a3ee5e6b4b0d3255bfef95601890afd80709

collections_path: ~/.ansible/collections/
global_collections_path: /usr/share/ansible/collections/
```

##### ISSUE TYPE
 - Feature Pull Request



##### MAZER VERSION

```
name = mazer
version = 0.5.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 5.0.5-200.fc29.x86_64, #1 SMP Wed Mar 27 20:58:04 UTC 2019, x86_64
executable_location = /home/adrian/venvs/mazer_0.4.0_py36/bin/mazer
python_version = 3.6.8 (default, Jan 27 2019, 09:00:23) [GCC 8.2.1 20181215 (Red Hat 8.2.1-6)]
python_executable = /home/adrian/venvs/mazer_0.4.0_py36/bin/python

```

