### PR TITLE
Tweaks for default log level (Fixes #267)

### DIFF
--- a/ansible_galaxy/actions/install.py
+++ b/ansible_galaxy/actions/install.py
@@ -326,7 +326,7 @@ def install_repositories(galaxy_context,
             if requirement_to_install.repository_spec:
                 required_by_blurb = ' (required by %s)' % requirement_to_install.repository_spec.label
 
-            log.info('Installed: %s %s to %s%s',
+            log.info('Installed %s,%s to %s%s',
                      installed_repo.label,
                      installed_repo.repository_spec.version,
                      installed_repo.path,

--- a/ansible_galaxy/actions/version.py
+++ b/ansible_galaxy/actions/version.py
@@ -1,46 +1,12 @@
 import logging
-import os
 import sys
 
-from ansible_galaxy.utils.text import to_text
+from ansible_galaxy import mazer_version
 
 log = logging.getLogger(__name__)
 
-VERSION_FIELDS = ('name', 'version', 'config_file', 'uname', 'executable_location', 'python_version', 'python_executable')
-
-
-def version_data(config_file_path, cli_version, argv):
-    data = {}
-
-    data['name'] = 'mazer'
-    data['version'] = cli_version
-    data['executable_location'] = argv[0]
-    data['uname'] = u', '.join(os.uname())
-
-    sys_ver = u"%s" % ''.join(sys.version.splitlines())
-
-    data['python_version'] = sys_ver
-    data['python_executable'] = sys.executable
-
-    if config_file_path:
-        data['config_file'] = to_text(config_file_path)
-    else:
-        data['config_file'] = u'No config file found; using defaults'
-
-    return data
-
-
-def version_repr(version_data):
-    lines = []
-
-    for field in VERSION_FIELDS:
-        lines.append(u'%s = %s' % (field, version_data.get(field, '')))
-
-    buf = u'\n'.join(lines)
-    return buf
-
 
 def version(config_file_path, cli_version, display_callback=None):
-    version_buf = version_repr(version_data(config_file_path, cli_version, sys.argv))
+    version_buf = mazer_version.version_repr(mazer_version.version_data(config_file_path, cli_version, sys.argv))
     display_callback(version_buf)
     return 0

--- a/ansible_galaxy/display.py
+++ b/ansible_galaxy/display.py
@@ -10,14 +10,14 @@ log = logging.getLogger(__name__)
 
 INFO_LEVEL = {
     'prefix': '',
-    'log_level': logging.INFO,
+    'log_level': logging.DEBUG,
     'stream': sys.stdout,
 }
 
 DISPLAY_LEVEL_MAP = {
     'warning': {
         'prefix': 'WARNING| ',
-        'log_level': logging.WARNING,
+        'log_level': logging.DEBUG,
         'stream': sys.stderr
     },
     'info': INFO_LEVEL

--- a/ansible_galaxy/mazer_version.py
+++ b/ansible_galaxy/mazer_version.py
@@ -1,0 +1,40 @@
+import logging
+import os
+import sys
+
+from ansible_galaxy.utils.text import to_text
+
+log = logging.getLogger(__name__)
+
+VERSION_FIELDS = ('name', 'version', 'config_file', 'uname', 'executable_location', 'python_version', 'python_executable')
+
+
+def version_data(config_file_path, cli_version, argv):
+    data = {}
+
+    data['name'] = 'mazer'
+    data['version'] = cli_version
+    data['executable_location'] = argv[0]
+    data['uname'] = u', '.join(os.uname())
+
+    sys_ver = u"%s" % ''.join(sys.version.splitlines())
+
+    data['python_version'] = sys_ver
+    data['python_executable'] = sys.executable
+
+    if config_file_path:
+        data['config_file'] = to_text(config_file_path)
+    else:
+        data['config_file'] = u'No config file found; using defaults'
+
+    return data
+
+
+def version_repr(version_data):
+    lines = []
+
+    for field in VERSION_FIELDS:
+        lines.append(u'%s = %s' % (field, version_data.get(field, '')))
+
+    buf = u'\n'.join(lines)
+    return buf

--- a/ansible_galaxy/rest_api.py
+++ b/ansible_galaxy/rest_api.py
@@ -112,9 +112,9 @@ class RestClient(object):
         pre_request_slug = '"%s %s" %s' % (http_method, url, request_id)
 
         # log the http request_slug with request_id to the main log and
-        # to the http log, both at INFO level for now.
+        # to the http log.
         http_log.info('%s', pre_request_slug)
-        self.log.info('%s', pre_request_slug)
+        self.log.debug('%s', pre_request_slug)
 
         # request_log.debug('%s headers=%s', pre_request_slug, request_headers)
 
@@ -142,7 +142,6 @@ class RestClient(object):
 
         # Log info about the request/response for debug
         log.debug('resp.request: %s', resp.request)
-        # log.debug('resp.request.headers: %s', resp.request.headers)
         log.debug('resp: %s', resp)
 
         slug = response_slug(resp)

--- a/ansible_galaxy_cli/cli/__init__.py
+++ b/ansible_galaxy_cli/cli/__init__.py
@@ -161,9 +161,9 @@ class CLI(six.with_metaclass(ABCMeta, object)):
         log.debug('self.args: %s', self.args)
 
         if self.config_file_path:
-            log.info(u"Using %s as config file", to_text(self.config_file_path))
+            log.debug(u"Using %s as config file", to_text(self.config_file_path))
         else:
-            log.info(u"No config file found; using defaults")
+            log.debug(u"No config file found; using defaults")
 
     def validate_conflicts(self, vault_opts=False, runas_opts=False, fork_opts=False, vault_rekey_opts=False):
         ''' check for conflicting options '''

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -40,6 +40,7 @@ from ansible_galaxy.config import config
 
 from ansible_galaxy import matchers
 from ansible_galaxy import rest_api
+from ansible_galaxy import mazer_version
 
 from ansible_galaxy.models.context import GalaxyContext
 from ansible_galaxy.models.build_context import BuildContext
@@ -219,9 +220,20 @@ class GalaxyCLI(cli.CLI):
 
         log.debug('galaxy context: %s', galaxy_context)
 
-        log.debug('execute action: %s', self.action)
         log.debug('execute action with options: %s', self.options)
         log.debug('execute action with args: %s', self.args)
+
+        version_info = mazer_version.version_data(config_file_path=self.config_file_path,
+                                                  cli_version=galaxy_cli_version,
+                                                  argv=sys.argv)
+
+        log.info('exe="%s" version=%s config_file="%s" collections_path="%s" server=%s action=%s',
+                 version_info['executable_location'],
+                 version_info['version'],
+                 version_info['config_file'],
+                 galaxy_context.collections_path,
+                 galaxy_context.server['url'],
+                 self.action)
 
         return self.execute()
 

--- a/ansible_galaxy_cli/logger/default-mazer-logging.yml
+++ b/ansible_galaxy_cli/logger/default-mazer-logging.yml
@@ -21,12 +21,14 @@ handlers:
     stream: ext://sys.stderr
   file:
     class: ansible_galaxy_cli.logger.setup.ExpandTildeWatchedFileHandler
-    filename: "~/.ansible/mazer.log"
+    # Sets log filename to MAZER_HOME (~/.ansible) + basename ('~/.ansible/mazer.log' by default)
+    basename: "mazer.log"
     formatter: file_verbose
     level: DEBUG
   http_file:
     class: ansible_galaxy_cli.logger.setup.ExpandTildeWatchedFileHandler
-    filename: "~/.ansible/mazer-http.log"
+    # Sets log filename to MAZER_HOME (~/.ansible) + basename ('~/.ansible/mazer-http.log' by default)
+    basename: "mazer-http.log"
     formatter: file_verbose
     level: DEBUG
 loggers:

--- a/ansible_galaxy_cli/logger/default-mazer-logging.yml
+++ b/ansible_galaxy_cli/logger/default-mazer-logging.yml
@@ -24,13 +24,13 @@ handlers:
     # Sets log filename to MAZER_HOME (~/.ansible) + basename ('~/.ansible/mazer.log' by default)
     basename: "mazer.log"
     formatter: file_verbose
-    level: DEBUG
+    level: INFO
   http_file:
     class: ansible_galaxy_cli.logger.setup.ExpandTildeWatchedFileHandler
     # Sets log filename to MAZER_HOME (~/.ansible) + basename ('~/.ansible/mazer-http.log' by default)
     basename: "mazer-http.log"
     formatter: file_verbose
-    level: DEBUG
+    level: INFO
 loggers:
   ansible_galaxy:
     handlers:

--- a/ansible_galaxy_cli/logger/default-mazer-logging.yml
+++ b/ansible_galaxy_cli/logger/default-mazer-logging.yml
@@ -52,7 +52,7 @@ loggers:
     level: INFO
     propagate: false
     handlers:
-      - file
+      - http_file
     # to log verbose debug level logging to http_file handler:
     # level: DEBUG
     # handlers:

--- a/ansible_galaxy_cli/logger/setup.py
+++ b/ansible_galaxy_cli/logger/setup.py
@@ -39,9 +39,17 @@ FALLBACK_LOGGING_CONFIG = {
 
 
 class ExpandTildeWatchedFileHandler(logging.handlers.WatchedFileHandler):
-    '''A variant of WatchedFileHandler that will expand ~/ in it's filename param'''
+    '''A variant of WatchedFileHandler that will expand ~/ in it's filename param
+
+    Params:
+        basename: The basename of the log file (optional). Default is 'mazer.log'
+                  This is joined with MAZER_HOME to set the default log path.
+        filename: The full filename of the log file (optional). Default is
+                  MAZER_HOME/$basename (~/.ansible/mazer.log).
+    '''
     def __init__(self, *args, **kwargs):
-        orig_filename = kwargs.pop('filename', '~/.ansible/mazer.log')
+        basename = kwargs.pop('basename', 'mazer.log')
+        orig_filename = kwargs.pop('filename', os.path.join(defaults.MAZER_HOME, basename))
         kwargs['filename'] = os.path.expandvars(os.path.expanduser(orig_filename))
         logdir = os.path.dirname(kwargs['filename'])
         if not os.path.exists(logdir):

--- a/ansible_galaxy_cli/logger/setup.py
+++ b/ansible_galaxy_cli/logger/setup.py
@@ -8,7 +8,7 @@ import yaml
 from ansible_galaxy.config import defaults
 
 DEFAULT_CONSOLE_LEVEL = os.getenv('MAZER_LOG_LEVEL', 'WARNING').upper()
-DEFAULT_LEVEL = 'DEBUG'
+DEFAULT_LEVEL = 'INFO'
 
 DEFAULT_LOGGING_CONFIG_YAML = os.path.join(os.path.dirname(__file__), 'default-mazer-logging.yml')
 

--- a/ansible_galaxy_cli/main.py
+++ b/ansible_galaxy_cli/main.py
@@ -44,7 +44,7 @@ def main(args=None):
 
         return os.EX_CONFIG
     except exceptions.GalaxyError as e:
-        log.exception(e)
+        log.debug(e, exc_info=True)
         stderr_log.error(e)
 
         # exit with EX_SOFTWARE on generic error

--- a/ansible_galaxy_cli/main.py
+++ b/ansible_galaxy_cli/main.py
@@ -59,6 +59,6 @@ def main(args=None):
         log.error('Uncaught exception, existing with exit code: %s', exit_code)
         raise
 
-    log.debug('exit code: %s', exit_code)
+    log.info('exit code: %s', exit_code)
     # do any return code setup we need here
     return exit_code

--- a/tests/ansible_galaxy/actions/test_version.py
+++ b/tests/ansible_galaxy/actions/test_version.py
@@ -5,27 +5,6 @@ from ansible_galaxy.actions import version
 log = logging.getLogger(__name__)
 
 
-def test_version_data():
-    config_path = '/dev/null/some/faux/mazer.yml'
-    cli_version = '1.2.3'
-    args = ['/bin/mazer', 'version']
-
-    res = version.version_data(config_file_path=config_path,
-                               cli_version=cli_version,
-                               argv=args)
-
-    log.debug('res: %s', res)
-
-    assert isinstance(res, dict)
-
-    for field in version.VERSION_FIELDS:
-        assert field in res
-
-    assert res['config_file'] == config_path
-    assert res['version'] == cli_version
-    assert res['executable_location'] == args[0]
-
-
 def test_version():
     config_path = '/dev/null/some/faux/mazer.yml'
     cli_version = '1.2.3'
@@ -47,24 +26,3 @@ def test_version():
 
     lines = display_items[0].splitlines()
     assert 'mazer' in lines[0]
-
-
-def test_version_repr():
-    config_path = '/dev/null/some/faux/mazer.yml'
-    cli_version = '1.2.3'
-    args = ['/bin/mazer', 'version']
-
-    data = version.version_data(config_file_path=config_path,
-                                cli_version=cli_version,
-                                argv=args)
-
-    res = version.version_repr(data)
-    assert 'mazer.yml' in res
-
-
-def test_version_repr_empty_data():
-    data = {}
-    res = version.version_repr(data)
-
-    assert 'name =' in res
-    assert 'version =' in res

--- a/tests/ansible_galaxy/test_mazer_version.py
+++ b/tests/ansible_galaxy/test_mazer_version.py
@@ -1,0 +1,48 @@
+
+import logging
+
+from ansible_galaxy import mazer_version
+
+log = logging.getLogger(__name__)
+
+
+def test_version_data():
+    config_path = '/dev/null/some/faux/mazer.yml'
+    cli_version = '1.2.3'
+    args = ['/bin/mazer', 'version']
+
+    res = mazer_version.version_data(config_file_path=config_path,
+                                     cli_version=cli_version,
+                                     argv=args)
+
+    log.debug('res: %s', res)
+
+    assert isinstance(res, dict)
+
+    for field in mazer_version.VERSION_FIELDS:
+        assert field in res
+
+    assert res['config_file'] == config_path
+    assert res['version'] == cli_version
+    assert res['executable_location'] == args[0]
+
+
+def test_version_repr():
+    config_path = '/dev/null/some/faux/mazer.yml'
+    cli_version = '1.2.3'
+    args = ['/bin/mazer', 'version']
+
+    data = mazer_version.version_data(config_file_path=config_path,
+                                      cli_version=cli_version,
+                                      argv=args)
+
+    res = mazer_version.version_repr(data)
+    assert 'mazer.yml' in res
+
+
+def test_version_repr_empty_data():
+    data = {}
+    res = mazer_version.version_repr(data)
+
+    assert 'name =' in res
+    assert 'version =' in res


### PR DESCRIPTION
##### SUMMARY
Various tweaks for #267 

Fixes #267 

Better format for info log msgs for installs

Only log display_callback msgs at DEBUG level

Log GalaxyErrors exc info that make it to main at debug

On cli startup, log a info line with basic info
And 'info' level log the exit code.

For ex:
```
[2019-05-30 11:17:51,249 28223 I] ansible_galaxy_cli.cli.galaxy run:236 - exe="/home/adrian/venvs/mazer040test/bin/mazer" version=0.5.0 config_file="/home/adrian/.ansible/mazer.yml"  collections_path="/home/adrian/.ansible/collections" server=http://localhost:8000 action=install
```

Move impl of `mazer version` from actions->mazer_version
Move the impl details of collecting the mazer version info
for `mazer version` to ansible_galaxy.mazer_version so that
other modules can use it (namely, ansible_galaxy.cli.galaxy
for logging info at cli startup)

By default, only log http info to mazer-http.log

Set default logging level to INFO

Let log handler set basename rel to MAZER_HOME.
So a logging config (the default logging config in particular)
can provide a 'basename' arg for
ExpandTildeWatchedFileHandler that will be used relative to
MAZER_HOME.

So:
```
    $ mkdir /tmp/mazer_home
    $ MAZER_HOME=/tmp/mazer_home mazer install testing.foo
```

Will use any config in /tmp/mazer_home/, plus by default install
collections to MAZER_HOME/collections, will also now log by
default to MAZER_HOME/mazer.log and MAZER_HOME/mazer-http.log

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```

name = mazer
version = 0.5.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 5.0.5-200.fc29.x86_64, #1 SMP Wed Mar 27 20:58:04 UTC 2019, x86_64
executable_location = /home/adrian/venvs/mazer_0.4.0_py36/bin/mazer
python_version = 3.6.8 (default, Jan 27 2019, 09:00:23) [GCC 8.2.1 20181215 (Red Hat 8.2.1-6)]
python_executable = /home/adrian/venvs/mazer_0.4.0_py36/bin/python

```



