### PR TITLE
Fix 'install --force'  (fix #266)

### DIFF
--- a/ansible_galaxy/actions/install.py
+++ b/ansible_galaxy/actions/install.py
@@ -191,7 +191,8 @@ def install_repository_specs_loop(galaxy_context,
         if not requirements_list:
             break
 
-        display_callback('Installing:', level='info')
+        display_callback('', level='info')
+        display_callback('Collection specs to install:', level='info')
 
         for req in requirements_list:
             if req.repository_spec:
@@ -210,11 +211,10 @@ def install_repository_specs_loop(galaxy_context,
                                                            no_deps=no_deps,
                                                            force_overwrite=force_overwrite)
 
-        display_callback('Installed:', level='info')
-
         for just_installed_repo in just_installed_repositories:
-            display_callback('  %s to %s' % (just_installed_repo.repository_spec,
-                                             just_installed_repo.path),
+            display_callback('  Installed: %s (to %s)' %
+                             (just_installed_repo.repository_spec,
+                              just_installed_repo.path),
                              level='info')
 
         # set the repository_specs to search for to whatever the install reported as being needed yet
@@ -366,6 +366,9 @@ def install_repository(galaxy_context,
 
     log.debug('About to find() requested requirement_spec_to_install: %s', requirement_spec_to_install)
 
+    display_callback('', level='info')
+    display_callback('Installing spec: %s' % requirement_spec_to_install.label, level='info')
+
     # We dont have anything that matches the RequirementSpec installed
     fetcher = fetch_factory.get(galaxy_context=galaxy_context,
                                 requirement_spec=requirement_spec_to_install)
@@ -409,7 +412,7 @@ def install_repository(galaxy_context,
 
     log.debug('found_repository_spec: %s', found_repository_spec)
 
-    display_callback('Found %s for spec %s' % (found_repository_spec, requirement_spec_to_install.label))
+    display_callback('  Found: %s (for spec %s)' % (found_repository_spec, requirement_spec_to_install.label))
 
     # See if the found collection spec is already installed and either warn or 'force_overwrite'
     # to remove existing first.
@@ -476,7 +479,7 @@ def install_repository(galaxy_context,
 
         # bail if we are not overwriting already installed content
         if not force_overwrite:
-            display_callback('%s is already installed at %s' %
+            display_callback('  %s is already installed at %s' %
                              (repo_label,
                               already_installed_repository.path),
                              level='warning')
@@ -485,7 +488,7 @@ def install_repository(galaxy_context,
 
             return None
 
-        display_callback('Removing previously installed %s from %s' %
+        display_callback('  Removing: %s (previously installed to %s)' %
                          (repo_label,
                           already_installed_repository.path),
                          level='info')

--- a/ansible_galaxy/repository_archive.py
+++ b/ansible_galaxy/repository_archive.py
@@ -144,6 +144,8 @@ def install(repository_archive, repository_spec, destination_info, display_callb
     if destination_info.editable:
         all_installed_files = []
     else:
+        log.debug('destination_info.force_overrite: %s', destination_info.force_overwrite)
+
         all_installed_files = extract(repository_spec,
                                       collections_path=destination_info.collections_path,
                                       extract_archive_to_dir=destination_info.path,


### PR DESCRIPTION
##### SUMMARY
Fix some issues with 'install --force', like the cases in #266 

install alikins.collection_inspect,0.0.46
```
(mazer040test) [newswoop:F29:collection_inspect (master % u=)]$ mazer install --server http://localhost:8000 alikins.collection_inspect,0.0.46
Collections to install:
  alikins.collection_inspect,==0.0.46
Found alikins.collection_inspect,0.0.46 for spec alikins.collection_inspect,==0.0.46
Installed:
  alikins.collection_inspect,0.0.46 to /home/adrian/.ansible/collections/ansible_collections/alikins/collection_inspect
```

try to install latest version of alikins.collection_inspect (0.0.48) and fail that alikins.collection_inspect is already installed

```
(mazer040test) [newswoop:F29:collection_inspect (master % u=)]$ mazer install --server http://localhost:8000 alikins.collection_inspect
Collections to install:
  alikins.collection_inspect,*
Found alikins.collection_inspect,0.0.48 for spec alikins.collection_inspect,*
WARNING| alikins.collection_inspect,0.0.46 is already installed at /home/adrian/.ansible/collections/ansible_collections/alikins/collection_inspect
Installed:
```

'force' install latest version of alikins.collection_inspect (0.0.48), removing 0.0.46, and installing 0.0.48

```
(mazer040test) [newswoop:F29:collection_inspect (master % u=)]$ mazer install --force --server http://localhost:8000 alikins.collection_inspect
Collections to install:
  alikins.collection_inspect,*
Found alikins.collection_inspect,0.0.48 for spec alikins.collection_inspect,*
Removing previously installed alikins.collection_inspect,0.0.46 from /home/adrian/.ansible/collections/ansible_collections/alikins/collection_inspect
Installed:
  alikins.collection_inspect,0.0.48 to /home/adrian/.ansible/collections/ansible_collections/alikins/collection_inspect

```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.5.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 5.0.5-200.fc29.x86_64, #1 SMP Wed Mar 27 20:58:04 UTC 2019, x86_64
executable_location = /home/adrian/venvs/mazer_0.4.0_py36/bin/mazer
python_version = 3.6.8 (default, Jan 27 2019, 09:00:23) [GCC 8.2.1 20181215 (Red Hat 8.2.1-6)]
python_executable = /home/adrian/venvs/mazer_0.4.0_py36/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

