### PR TITLE
Improve 'mazer list' output, add fully qualified output. Fixes #196

### DIFF
--- a/ansible_galaxy/actions/list.py
+++ b/ansible_galaxy/actions/list.py
@@ -86,14 +86,14 @@ def _list(galaxy_context,
         return repo_list
 
     for repo_item in repo_list:
-        repo_msg = "repo={installed_repository.repository_spec.label}, type=repository, version={installed_repository.repository_spec.version}"
+        repo_msg = "collection={installed_repository.repository_spec.label}, type=collection, version={installed_repository.repository_spec.version}"
         display_callback(repo_msg.format(**repo_item))
 
         if not list_content:
             continue
 
         for content_item_type_key, content_items_data in repo_item['content_items'].items():
-            content_msg = "repo={installed_repository.repository_spec.label}, type={type}, name={name}, " + \
+            content_msg = "collection={installed_repository.repository_spec.label}, type={type}, name={name}, " + \
                 "version={installed_repository.repository_spec.version}"
             # content_msg = "    type={type}, name={name}, " + \
             #    "version={installed_repository.repository_spec.version}"

--- a/ansible_galaxy/actions/list.py
+++ b/ansible_galaxy/actions/list.py
@@ -162,6 +162,7 @@ def list_action(galaxy_context,
                 list_content=False,
                 lockfile_format=False,
                 lockfile_freeze=False,
+                fully_qualified=False,
                 output_format=None,
                 display_callback=None):
     '''Run _list action and return an exit code suitable for process exit'''
@@ -171,8 +172,8 @@ def list_action(galaxy_context,
         output_format = OutputFormat.LOCKFILE
     if lockfile_freeze:
         output_format = OutputFormat.LOCKFILE_FREEZE
-
-    output_format = OutputFormat.FULLY_QUALIFIED
+    if fully_qualified:
+        output_format = OutputFormat.FULLY_QUALIFIED
 
     _list(galaxy_context,
           repository_spec_match_filter=repository_spec_match_filter,

--- a/ansible_galaxy/installed_content_item_db.py
+++ b/ansible_galaxy/installed_content_item_db.py
@@ -63,10 +63,15 @@ def repository_content_iterator(repository, content_item_type, content_item_path
         # in the future.
         content_item_name = os.path.splitext(file_name)[0]
 
+        is_plugin = True
+        if content_item_type in ('roles', 'modules'):
+            is_plugin = False
+
         content_item = ContentItem(namespace=repo_namespace,
                                    name=content_item_name,
                                    path=file_name,
                                    content_item_type=content_item_type,
+                                   is_plugin=is_plugin,
                                    version=repository.repository_spec.version)
 
         log.debug('Found %s "%s" at %s', content_item, content_item.name, file_name)

--- a/ansible_galaxy/models/content_item.py
+++ b/ansible_galaxy/models/content_item.py
@@ -15,6 +15,7 @@ class ContentItem(object):
     content_item_type = attr.ib(default=None)
     version = attr.ib(default=None)
     path = attr.ib(default=None)
+    is_plugin = attr.ib(default=False)
 
     @property
     def label(self):

--- a/ansible_galaxy/models/repository_spec.py
+++ b/ansible_galaxy/models/repository_spec.py
@@ -47,6 +47,10 @@ class RepositorySpec(object):
     def label(self):
         return '%s.%s' % (self.namespace, self.name)
 
+    @property
+    def ns_n_v(self):
+        return '%s,%s' % (self.label, self.version)
+
     @classmethod
     def from_dict(cls, data):
         instance = cls(namespace=data['namespace'],

--- a/ansible_galaxy_cli/cli/galaxy.py
+++ b/ansible_galaxy_cli/cli/galaxy.py
@@ -115,6 +115,8 @@ class GalaxyCLI(cli.CLI):
                                    help="List installed collections in collections lockfile format")
             self.parser.add_option('--freeze', dest='list_lockfile_freeze', default=False, action='store_true',
                                    help="List installed collections in collections lockfile format with frozen versions")
+            self.parser.add_option('--full', dest='list_fully_qualified', default=False, action='store_true',
+                                   help="List installed collections using fully qualifed names as used in playbooks")
         elif self.action == "version":
             self.parser.set_usage("usage: %prog version")
 
@@ -355,6 +357,7 @@ class GalaxyCLI(cli.CLI):
                                        list_content=list_content,
                                        lockfile_format=self.options.list_lockfile_format,
                                        lockfile_freeze=self.options.list_lockfile_freeze,
+                                       fully_qualified=self.options.list_fully_qualified,
                                        display_callback=self.display)
 
     def execute_version(self):


### PR DESCRIPTION
##### SUMMARY
Improve 'mazer list' output, add fully qualified output. 

Fixes #196

Add 'list --full' to list fully qualified collection names.
Make the default output more human readable, especially the '--content' output.

ie, list the collection and content names as they would be
referenced from a playbook.

Also include the 'python path' name for plugins/module_utils.

For ex:

To show collections content with the full names you need to use from a playbook,
use 'mazer list --content --full'

```
$ mazer list --content --full
 alikins.collection_inspect,0.0.48
  - roles
    - alikins.collection_inspect.test_collection_inspect
  - modules
    - alikins.collection_inspect.collection_inspect_no_module_utils
    - alikins.collection_inspect.collection_inspect
    - alikins.collection_inspect.get_collection_inspect
  - callback
    - alikins.collection_inspect.collection_inspect
      - (python path) ansible_collections.alikins.collection_inspect.plugins.callback.collection_inspect
  - lookup
    - alikins.collection_inspect.collection_inspect
      - (python path) ansible_collections.alikins.collection_inspect.plugins.lookup.collection_inspect
  - vars
    - alikins.collection_inspect.collection_inspect
      - (python path) ansible_collections.alikins.collection_inspect.plugins.vars.collection_inspect
  - action
    - alikins.collection_inspect.collection_inspect
      - (python path) ansible_collections.alikins.collection_inspect.plugins.action.collection_inspect
  - filter
    - alikins.collection_inspect.collection_inspect
      - (python path) ansible_collections.alikins.collection_inspect.plugins.filter.collection_inspect
  - module_utils
    - alikins.collection_inspect.collection_inspect
      - (python path) ansible_collections.alikins.collection_inspect.plugins.module_utils.collection_inspect
```

The new default 'mazer list' format
```
(mazer_0.4.0_py36) [newswoop:F29:mazer (list_output_collection_196 %)]$ mazer list
alikins.collection_inspect,0.0.48
alikins.collection_ntp,0.1.182
alikins.collection_reqs_test,2.1113.57
```

The 'mazer list --content' output
(mazer_0.4.0_py36) [newswoop:F29:mazer (list_output_collection_196 %)]$ mazer list --content
alikins.collection_inspect,0.0.48
  - roles
    - test_collection_inspect
  - modules
    - collection_inspect_no_module_utils
    - collection_inspect
    - get_collection_inspect
  - callback
    - collection_inspect
  - lookup
    - collection_inspect
  - vars
    - collection_inspect
  - action
    - collection_inspect
  - filter
    - collection_inspect
  - module_utils
    - collection_inspect
alikins.collection_ntp,0.1.182
  - roles
    - ntp
alikins.collection_reqs_test,2.1113.57
  - roles
    - cole_role
    - bole_role
    - aole_role
  - modules
    - newmodule
    - my_sample_module
  - callback
    - faux
  - vars
    - mars_bars
  - action
    - faux_debug
    - inaction
  - inventory
    - zero
  - filter
    - vague_name
    - air_quote
  - module_utils
    - whatever
    - search_discuss
    - test_ci
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 0.5.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 5.0.5-200.fc29.x86_64, #1 SMP Wed Mar 27 20:58:04 UTC 2019, x86_64
executable_location = /home/adrian/venvs/mazer_0.4.0_py36/bin/mazer
python_version = 3.6.8 (default, Jan 27 2019, 09:00:23) [GCC 8.2.1 20181215 (Red Hat 8.2.1-6)]
python_executable = /home/adrian/venvs/mazer_0.4.0_py36/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

