### PR TITLE
 Use collection artifact detail view api, validate sha256 of downloaded artifacts

### DIFF
--- a/ansible_galaxy/actions/install.py
+++ b/ansible_galaxy/actions/install.py
@@ -440,7 +440,7 @@ def install_repository(galaxy_context,
     #
 
     repository_spec_to_install = found_repository_spec
-    log.debug('About to download repository requested by %s: %s', requirement_spec_to_install, repository_spec_to_install)
+    log.debug('About to download collection requested by %s: %s', requirement_spec_to_install, repository_spec_to_install)
 
     if find_results['custom'].get('collection_is_deprecated', False):
         display_callback("The collection '%s' is deprecated." % (found_repository_spec.label),
@@ -454,6 +454,11 @@ def install_repository(galaxy_context,
         log.debug('fetch_results: %s', fetch_results)
         # fetch_results will include a 'archive_path' pointing to where the artifact
         # was saved to locally.
+    except exceptions.GalaxyArtifactChksumError as exc:
+        log.error(exc)
+        msg = "While fetching %s, the checksum of the fetched artifact (%s) did not match the expected checksum %s" \
+            % (found_repository_spec, exc.artifact_path, exc.expected)
+        raise exceptions.GalaxyClientError(msg)
     except exceptions.GalaxyError as e:
         # fetch error probably should just go to a FAILED state, at least until
         # we have to implement retries

--- a/ansible_galaxy/collection_artifact.py
+++ b/ansible_galaxy/collection_artifact.py
@@ -2,8 +2,10 @@ import logging
 
 import attr
 
+from ansible_galaxy import exceptions
 from ansible_galaxy import repository
 from ansible_galaxy import repository_archive
+from ansible_galaxy.utils import chksums
 
 log = logging.getLogger(__name__)
 
@@ -28,3 +30,16 @@ def load_data_from_collection_artifact(repository_spec_string):
     # FIXME: we already have a valid RepositorySpec, but we dict'ify it here
     #        so existing code that assumes a dict continues to work
     return attr.asdict(spec_data)
+
+
+def validate_artifact(artifact_path, expected_chksum):
+    '''Check the sha256sum of file at `artifact_path` against `expected_chksum`
+
+    Raise a GalaxyArtifactChksumError if they don't match.
+    '''
+    actual = chksums.sha256sum_from_path(artifact_path)
+
+    if actual != expected_chksum:
+        raise exceptions.GalaxyArtifactChksumError(artifact_path=artifact_path,
+                                                   expected=expected_chksum,
+                                                   actual=actual)

--- a/ansible_galaxy/exceptions/__init__.py
+++ b/ansible_galaxy/exceptions/__init__.py
@@ -124,6 +124,21 @@ class GalaxyArchiveError(GalaxyClientError):
         self.archive_path = archive_path
 
 
+class GalaxyArtifactChksumError(GalaxyClientError):
+    '''Raised when an artifacts chksum isn't expected indicating corrupt or incomplete artifact'''
+
+    def __init__(self, *args, **kwargs):
+        artifact_path = kwargs.pop('artifact_path', None)
+        expected = kwargs.pop('expected', None)
+        actual = kwargs.pop('actual', None)
+
+        super(GalaxyArtifactChksumError, self).__init__(*args, **kwargs)
+
+        self.artifact_path = artifact_path
+        self.expected = expected
+        self.actual = actual
+
+
 class GalaxyPublishError(GalaxyClientError):
     ''' Raised for errors related to publish command '''
 

--- a/ansible_galaxy/fetch/editable.py
+++ b/ansible_galaxy/fetch/editable.py
@@ -63,6 +63,7 @@ class EditableFetch(object):
                              'real_path': real_path,
                              'symlinked_repo_root': dst_repo_root}
         results['content'] = find_results['content']
+        results['artifact'] = {}
 
         return results
 

--- a/ansible_galaxy/fetch/galaxy_url.py
+++ b/ansible_galaxy/fetch/galaxy_url.py
@@ -151,6 +151,9 @@ class GalaxyUrlFetch(base.BaseFetch):
         if not download_url:
             raise exceptions.GalaxyError('no external_url info on the Repository object from %s' % self.requirement_spec.label)
 
+        artifact_detail = best_collectionversion_detail_data.get('artifact', {})
+        log.debug('artifact_detail: %s', artifact_detail)
+
         # collectionversion_metadata = best_collectionversion_detail_data.get('metadata', None)
         # log.debug('collectionversion_metadata: %s', collectionversion_metadata)
 
@@ -159,6 +162,9 @@ class GalaxyUrlFetch(base.BaseFetch):
         results = {'content': {'galaxy_namespace': namespace,
                                'repo_name': collection_name,
                                'version': best_version},
+                   'artifact': {'sha256': artifact_detail['sha256'],
+                                'filename': artifact_detail['filename'],
+                                'size': artifact_detail['size']},
                    'custom': {'download_url': download_url,
                               'collection_is_deprecated': collection_is_deprecated},
                    }
@@ -203,5 +209,6 @@ class GalaxyUrlFetch(base.BaseFetch):
         # we know the original and the final url after redirects
         results['custom'] = find_results['custom']
         results['content'] = find_results['content']
+        results['artifact'] = find_results['artifact']
 
         return results

--- a/ansible_galaxy/fetch/galaxy_url.py
+++ b/ansible_galaxy/fetch/galaxy_url.py
@@ -4,6 +4,7 @@ import semantic_version
 from six.moves.urllib.parse import quote as urlquote
 
 # mv details of this here
+from ansible_galaxy import collection_artifact
 from ansible_galaxy import exceptions
 from ansible_galaxy import download
 from ansible_galaxy.fetch import base
@@ -194,6 +195,10 @@ class GalaxyUrlFetch(base.BaseFetch):
         self.local_path = repository_archive_path
 
         log.debug('repository_archive_path=%s', repository_archive_path)
+
+        # validate the sha256sum of the downloaded artifact against the expected value
+        expected_chksum = find_results['artifact'].get('sha256')
+        collection_artifact.validate_artifact(self.local_path,  expected_chksum)
 
         # TODO: This is indication that a fetcher is wrong abstraction. A fetch
         #       can resolve a name/spec, find metadata about the content including avail versions,

--- a/ansible_galaxy/fetch/local_file.py
+++ b/ansible_galaxy/fetch/local_file.py
@@ -1,8 +1,10 @@
 
 import logging
+import os
 
 from ansible_galaxy import repository
 from ansible_galaxy import repository_archive
+from ansible_galaxy.utils import chksums
 
 
 log = logging.getLogger(__name__)
@@ -25,6 +27,10 @@ class LocalFileFetch(object):
                                # a bit to pull that out.
                                # TODO/FIXME: helper method/wrapper for making this less coupled
                                'version': str(vspec)},
+                   'artifact': {'filename': os.path.basename(self.local_path),
+                                'sha256': chksums.sha256sum_from_path(self.local_path),
+                                'size': os.path.getsize(self.local_path)},
+                   'custom': {},
                    }
         return results
 
@@ -44,6 +50,7 @@ class LocalFileFetch(object):
 
         results['custom'] = {'local_path': self.local_path}
         results['content'] = find_results['content']
+        results['artifact'] = find_results['artifact']
         results['content']['fetched_name'] = repo.repository_spec.name
 
         return results

--- a/ansible_galaxy/fetch/remote_url.py
+++ b/ansible_galaxy/fetch/remote_url.py
@@ -24,6 +24,7 @@ class RemoteUrlFetch(base.BaseFetch):
     def find(self):
         results = {'content': {'galaxy_namespace': self.requirement_spec.namespace,
                                'repo_name': self.requirement_spec.name},
+                   'custom': {},
                    }
 
         return results
@@ -42,7 +43,8 @@ class RemoteUrlFetch(base.BaseFetch):
         log.debug('repository_archive_path=%s', repository_archive_path)
 
         results = {'archive_path': repository_archive_path,
-                   'fetch_method': self.fetch_method}
+                   'fetch_method': self.fetch_method,
+                   'artifact': {}}
         results['content'] = find_results['content']
         results['custom'] = {'remote_url': self.remote_url,
                              'validate_certs': self.validate_certs}

--- a/ansible_galaxy/fetch/scm_url.py
+++ b/ansible_galaxy/fetch/scm_url.py
@@ -22,6 +22,7 @@ class ScmUrlFetch(base.BaseFetch):
     def find(self):
         results = {'content': {'galaxy_namespace': self.requirement_spec.namespace,
                                'repo_name': self.requirement_spec.name},
+                   'custom': {},
                    }
         results['custom'] = {'scm_url': self.requirement_spec.src}
 
@@ -39,6 +40,7 @@ class ScmUrlFetch(base.BaseFetch):
 
         results = {'archive_path': repository_archive_path,
                    'download_url': self.requirement_spec.src,
+                   'artifact': {},
                    'fetch_method': self.fetch_method}
         results['content'] = find_results['content']
         results['custom'] = find_results.get('custom', {})

--- a/tests/ansible_galaxy/exceptions/test_exceptions.py
+++ b/tests/ansible_galaxy/exceptions/test_exceptions.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 import logging
 
+import pytest
+
 from ansible_galaxy import exceptions
 from ansible_galaxy.utils.text import to_text
 
@@ -16,6 +18,20 @@ def test_galaxy_error():
 def test_galaxy_download_error_no_args():
     exc = exceptions.GalaxyDownloadError()
     log.debug('exc: %s', exc)
+
+
+def test_chksum_error():
+    exc = exceptions.GalaxyArtifactChksumError('some msg')
+    log.debug('exc: %s', exc)
+
+    assert isinstance(exc, exceptions.GalaxyArtifactChksumError)
+
+
+def test_raise_chksum_error():
+    with pytest.raises(exceptions.GalaxyArtifactChksumError, match='some_msg') as exc_info:
+        raise exceptions.GalaxyArtifactChksumError('some_msg')
+
+    log.debug('exc_info: %s', exc_info)
 
 
 # Format: byte representation, text representation, encoding of byte representation

--- a/tests/ansible_galaxy/test_collection_artifact.py
+++ b/tests/ansible_galaxy/test_collection_artifact.py
@@ -1,0 +1,56 @@
+import logging
+
+import pytest
+
+from ansible_galaxy import collection_artifact
+from ansible_galaxy import exceptions
+
+log = logging.getLogger(__name__)
+
+EMPTY_SHA = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+
+
+def test_validate_artifact_empty(tmpdir):
+    temp_dir = tmpdir.mkdir('mazer_collectio_artifact_unit_test')
+    file_name = "example_empty_file"
+    temp_file = temp_dir.join(file_name)
+
+    with open(temp_file.strpath, 'w') as tfd:
+        tfd.close()
+
+    collection_artifact.validate_artifact(temp_file.strpath, EMPTY_SHA)
+
+
+def test_validate_artifact_hello_world(tmpdir):
+    temp_dir = tmpdir.mkdir('mazer_collectio_artifact_unit_test')
+    file_name = "example_empty_file"
+    temp_file = temp_dir.join(file_name)
+
+    with open(temp_file.strpath, 'w') as tfd:
+        tfd.write('hello world\n')
+        tfd.close()
+
+    HELLO_SHA = 'a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447'
+    collection_artifact.validate_artifact(temp_file.strpath, HELLO_SHA)
+
+
+def test_validate_artifact_bogus(tmpdir):
+    temp_dir = tmpdir.mkdir('mazer_collectio_artifact_unit_test')
+    file_name = "example_empty_file"
+    temp_file = temp_dir.join(file_name)
+
+    with open(temp_file.strpath, 'w') as tfd:
+        tfd.write('hello world\n')
+        tfd.close()
+
+    # 'hello' file is not empty of course, so sha check should fail
+    with pytest.raises(exceptions.GalaxyArtifactChksumError) as exc_info:
+        collection_artifact.validate_artifact(temp_file.strpath, EMPTY_SHA)
+
+    log.debug('exc_info: %s', exc_info)
+
+    exc = exc_info.value
+
+    assert exc.artifact_path == temp_file.strpath
+    assert exc.expected == EMPTY_SHA
+    assert exc.actual == 'a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447'


### PR DESCRIPTION
##### SUMMARY
This adds use of the Galaxy collection artifact detail view

The artifact detail data is based on the ArtifactDetail from the Galaxy REST API. ie, results of
     GET /api/v2/collections/{namespace}/{name}/versions/{version}/artifact/
    Or the 'artifact' field of:
      GET /api/v2/collections/{namespace}/{name}/versions/{version}

The 'artifact' dict should contain 'sha256', 'filename', and 'size'.

This pr also uses the 'sha256' value to validate that downloaded artifacts sha256 sum matches their expected sha256. Checksum failures will raise GalaxyArtifactChksumError.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 1.0.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 5.0.5-200.fc29.x86_64, #1 SMP Wed Mar 27 20:58:04 UTC 2019, x86_64
executable_location = /home/adrian/venvs/mazer_0.4.0_py36/bin/mazer
python_version = 3.6.8 (default, Jan 27 2019, 09:00:23) [GCC 8.2.1 20181215 (Red Hat 8.2.1-6)]
python_executable = /home/adrian/venvs/mazer_0.4.0_py36/bin/python
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

