### PR TITLE
For download tmp files, include 'real' artifact name in tmp name

### DIFF
--- a/ansible_galaxy/fetch/galaxy_url.py
+++ b/ansible_galaxy/fetch/galaxy_url.py
@@ -182,15 +182,19 @@ class GalaxyUrlFetch(base.BaseFetch):
         # download_url = _build_download_url(external_url=external_url, version=_content_version)
         # TODO: error handling if there is no download_url
 
+        expected_filename = find_results.get('artifact', {}).get('filename', None)
+
         log.debug('repository_spec=%s', self.requirement_spec)
         log.debug('download_url=%s', download_url)
+        log.debug('expected_filename=%s', expected_filename)
 
         # for including in any error messages or logging for this fetch
         self.remote_resource = download_url
 
         # can raise GalaxyDownloadError
         repository_archive_path = download.fetch_url(download_url,
-                                                     validate_certs=self.validate_certs)
+                                                     validate_certs=self.validate_certs,
+                                                     filename=expected_filename)
 
         self.local_path = repository_archive_path
 


### PR DESCRIPTION
Let download.fetch_url() be passed a filename.
galaxy_url fetcher will pass it a filename based
the 'artifact' section of the collectionDetail.

In that case, the tmp file name used for the collection
artifact download will end with the 'real' filename.

It will be in the format:

  `$TMPDIR/ns-n-1.2.3.tar.gz::$RANDOM-tmp-mazer-artifact-download`

If there is no expected filename, it will be:

 `$TMPDIR/UNKNOWN-UNKNOWN-UNKNOWN.tar.gz::$RANDOM-tmp-mazer-artifact-download`

Make it a little easier to clean up if something goes wrong.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 1.0.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 5.0.5-200.fc29.x86_64, #1 SMP Wed Mar 27 20:58:04 UTC 2019, x86_64
executable_location = /home/adrian/venvs/mazer_0.4.0_py36/bin/mazer
python_version = 3.6.8 (default, Jan 27 2019, 09:00:23) [GCC 8.2.1 20181215 (Red Hat 8.2.1-6)]
python_executable = /home/adrian/venvs/mazer_0.4.0_py36/bin/python


```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

