### PR TITLE
Stop ignoring artifact download failures (404's etc)

### DIFF
--- a/ansible_galaxy/download.py
+++ b/ansible_galaxy/download.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import tempfile
 import uuid
 
@@ -10,7 +11,7 @@ from ansible_galaxy import user_agent
 log = logging.getLogger(__name__)
 
 
-def fetch_url(archive_url, validate_certs=True, filename=None):
+def fetch_url(archive_url, validate_certs=True, filename=None, dest_dir=None, chunk_size=None):
     """
     Downloads the archived content from github to a temp location
     """
@@ -20,37 +21,46 @@ def fetch_url(archive_url, validate_certs=True, filename=None):
     request_headers['X-Request-ID'] = request_id
     request_headers['User-Agent'] = user_agent.user_agent()
 
+    log.debug('Downloading archive_url: %s', archive_url)
+
     try:
-        log.debug('Downloading archive_url: %s', archive_url)
         resp = requests.get(archive_url, verify=validate_certs,
                             headers=request_headers, stream=True)
-
-        # so tmp filenames begin with the expected artifact filename before '::', except
-        # if we don't know it, then it's the UNKNOWN...
-        _prefix = filename or 'UNKNOWN-UNKNOWN-UNKNOWN.tar.gz'
-        prefix = '%s::' % _prefix
-
-        # TODO: add a configured spool or cache dir and/or default to using
-        #       one in MAZER_HOME or maybe ANSIBLE_TMP?
-        temp_file = tempfile.NamedTemporaryFile(delete=False,
-                                                suffix='-tmp-mazer-artifact-download',
-                                                prefix=prefix)
-
-        if resp.history:
-            for redirect in resp.history:
-                log.debug('Original request for %s redirected. %s is redirected to %s',
-                          archive_url, redirect.url, redirect.headers['Location'])
-
-        # TODO: test for short reads
-        for chunk in resp.iter_content(chunk_size=None):
-            temp_file.write(chunk)
-
-        temp_file.close()
-
-        return temp_file.name
     except Exception as e:
-        # FIXME: there is a ton of reasons a download and save could fail so could likely provided better errors here
         log.exception(e)
         raise exceptions.GalaxyDownloadError(e, url=archive_url)
+
+    # Let tmp filenames begin with the expected artifact filename before '::', except
+    # if we don't know it, then it's the UNKNOWN...
+    _prefix = filename or 'UNKNOWN-UNKNOWN-UNKNOWN.tar.gz'
+    prefix = '%s::' % _prefix
+
+    # TODO: add a configured spool or cache dir and/or default to using
+    #       one in MAZER_HOME or maybe ANSIBLE_TMP?
+    temp_fd = tempfile.NamedTemporaryFile(delete=False,
+                                          suffix='-tmp-mazer-artifact-download',
+                                          prefix=prefix)
+
+    try:
+        resp.raise_for_status()
+    except requests.exceptions.HTTPError as http_exc:
+        temp_fd.close()
+        os.unlink(temp_fd.name)
+
+        raise exceptions.GalaxyDownloadError(http_exc,
+                                             url=http_exc.response.url)
+
+    if resp.history:
+        for redirect in resp.history:
+            log.debug('Original request for %s redirected. %s is redirected to %s',
+                      archive_url, redirect.url, redirect.headers['Location'])
+
+    for chunk in resp.iter_content(chunk_size=chunk_size):
+        log.debug('read chunk')
+        temp_fd.write(chunk)
+
+    temp_fd.close()
+
+    return temp_fd.name
 
     return False

--- a/tests/ansible_galaxy/test_download.py
+++ b/tests/ansible_galaxy/test_download.py
@@ -1,0 +1,44 @@
+import io
+import logging
+import os
+
+import pytest
+
+from ansible_galaxy import download
+from ansible_galaxy import exceptions
+
+log = logging.getLogger(__name__)
+
+
+def test_fetch_url_404(tmpdir, requests_mock):
+    url = 'http://example.invalid/download/some_ns-some_name-1.2.3.tar.gz'
+
+    some_content = b'''<html><head>oopsie</head>\n<body>\nHey, couldn't find that.\n</body>\n'''
+
+    requests_mock.get(url,
+                      status_code=404,
+                      reason='Not Found',
+                      content=some_content)
+
+    with pytest.raises(exceptions.GalaxyDownloadError, match='.*download/some_ns-some_name-1.2.3.tar.gz.*') as exc_info:
+        download.fetch_url(url)
+
+    log.debug('exc_info: %s', exc_info)
+
+
+def test_fetch_bytes_200(requests_mock):
+    url = 'http://example.invalid/download/some_ns-some_name-1.2.3.tar.gz'
+    some_fd = io.BytesIO(b'Some thing like an error page.\nThis is not a tar file\n\n')
+
+    requests_mock.get(url,
+                      status_code=200,
+                      reason='OK',
+                      body=some_fd,
+                      )
+
+    # NOTE: have to pass in chunk_size, just to get requests_mock to work, otherwise
+    #       it gets stuck waiting on response.body to closer/eof and gets stuck.
+    res = download.fetch_url(url, chunk_size=128)
+
+    log.debug('res: %s', res)
+    os.unlink(res)


### PR DESCRIPTION

##### SUMMARY
Stop ignoring artifact download failures (404's etc)

Restructure download.fetch_url() a bit, and use raise_for_status()
to trigger exceptions on any errors. Since this was ported to
requests, errors for downloads have been ignored (at least
until we attempt to read/install the results of the download request
and they are not valid collection artifacts)

Fixes #272

##### ISSUE TYPE

 - Bugfix Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 1.0.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 5.0.5-200.fc29.x86_64, #1 SMP Wed Mar 27 20:58:04 UTC 2019, x86_64
executable_location = /home/adrian/venvs/mazer_0.4.0_py36/bin/mazer
python_version = 3.6.8 (default, Jan 27 2019, 09:00:23) [GCC 8.2.1 20181215 (Red Hat 8.2.1-6)]
python_executable = /home/adrian/venvs/mazer_0.4.0_py36/bin/python

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

