### PR TITLE
Handle mazer.yml with with server null instead of dict #283

### DIFF
--- a/ansible_galaxy/config/config.py
+++ b/ansible_galaxy/config/config.py
@@ -25,10 +25,10 @@ class Config(object):
     @classmethod
     def from_dict(cls, data):
         inst = cls()
-        inst.server = data.get('server', inst.server)
-        inst.collections_path = data.get('collections_path', inst.collections_path)
-        inst.global_collections_path = data.get('global_collections_path', inst.global_collections_path)
-        inst.options = data.get('options', inst.options)
+        inst.server = data.get('server') or inst.server
+        inst.collections_path = data.get('collections_path') or inst.collections_path
+        inst.global_collections_path = data.get('global_collections_path') or inst.global_collections_path
+        inst.options = data.get('options') or inst.options
         return inst
 
 

--- a/tests/ansible_galaxy/config/test_config.py
+++ b/tests/ansible_galaxy/config/test_config.py
@@ -56,6 +56,27 @@ def test_config_from_dict():
     assert config_.options['some_option'] == 'some_option_value'
 
 
+def test_config_from_dict_with_none_values():
+    config_data = OrderedDict([
+        ('server', None),
+        ('collections_path', None),
+        ('globals_collections_path', None),
+        ('options', None),
+    ])
+
+    config_ = config.Config.from_dict(config_data)
+    assert_object(config_)
+
+    # If the yaml/config_data has None values for server/options, should
+    # get empty dicts instead
+    # See https://github.com/ansible/mazer/issues/283
+    assert config_.server == {}
+    assert config_.options == {}
+    # collections_path attrs can be 'unset' to None
+    assert config_.collections_path is None
+    assert config_.global_collections_path is None
+
+
 def test_config_as_dict_empty():
     config_ = config.Config()
     config_data = config_.as_dict()

--- a/tests/ansible_galaxy_cli/cli/test_galaxy.py
+++ b/tests/ansible_galaxy_cli/cli/test_galaxy.py
@@ -94,6 +94,18 @@ def test_run_list(mazer_args_for_test):
     log.debug('res: %s', res)
 
 
+def test_version_invalid_config(mazer_args_for_test, mocker):
+
+    mocker.patch('ansible_galaxy_cli.cli.galaxy.config.config_file.load', return_value=None)
+    cli = galaxy.GalaxyCLI(args=mazer_args_for_test + ['version'])
+    cli.parse()
+    res = cli.run()
+
+    log.debug('mat: %s', mazer_args_for_test)
+    log.debug('res: %s', res)
+    assert res == 0
+
+
 def test_publish_no_args(mazer_args_for_test):
     cli = galaxy.GalaxyCLI(args=mazer_args_for_test + ['publish'])
     cli.parse()


### PR DESCRIPTION
##### SUMMARY

Handle mazer.yml with with server null instead of dict #283

Use the default 'server' value (empty dict) if the
the 'server' item from mazer.yml either doesn't exist or
if it is None.

Fixes #283

##### ISSUE TYPE

 - Bugfix Pull Request



##### MAZER VERSION
<!--- Paste verbatim output from "mazer version" between quotes below -->
```
name = mazer
version = 1.0.0
config_file = /home/adrian/.ansible/mazer.yml
uname = Linux, newswoop, 5.1.6-200.fc29.x86_64, #1 SMP Mon Jun 3 17:20:05 UTC 2019, x86_64
executable_location = /home/adrian/venvs/mazer_0.4.0_py36/bin/mazer
python_version = 3.6.8 (default, Jan 27 2019, 09:00:23) [GCC 8.2.1 20181215 (Red Hat 8.2.1-6)]
python_executable = /home/adrian/venvs/mazer_0.4.0_py36/bin/python

```


##### ADDITIONAL INFORMATION

There could be additional validation of the config file contents added here but since the config
file format is likely going away this just handles that particular case.
